### PR TITLE
Prevent supermethods popping up in autocompletion

### DIFF
--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -104,7 +104,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().addContentView__super((View) args[0],
+                        getOriginal().super_addContentView((View) args[0],
                                 (ViewGroup.LayoutParams) args[1]);
                     }
                 }, view, params);
@@ -120,7 +120,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().applyOverrideConfiguration__super((Configuration) args[0]);
+                getOriginal().super_applyOverrideConfiguration((Configuration) args[0]);
             }
         }, overrideConfiguration);
     }
@@ -135,7 +135,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().attachBaseContext__super((Context) args[0]);
+                getOriginal().super_attachBaseContext((Context) args[0]);
             }
         }, newBase);
     }
@@ -156,7 +156,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .bindService__super((Intent) args[0], (ServiceConnection) args[1],
+                                .super_bindService((Intent) args[0], (ServiceConnection) args[1],
                                         (int) args[2]);
                     }
                 }, service, conn, flags);
@@ -175,7 +175,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().checkCallingOrSelfPermission__super((String) args[0]);
+                        return getOriginal().super_checkCallingOrSelfPermission((String) args[0]);
                     }
                 }, permission);
     }
@@ -194,7 +194,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().checkCallingOrSelfUriPermission__super((Uri) args[0],
+                        return getOriginal().super_checkCallingOrSelfUriPermission((Uri) args[0],
                                 (int) args[1]);
                     }
                 }, uri, modeFlags);
@@ -213,7 +213,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().checkCallingPermission__super((String) args[0]);
+                        return getOriginal().super_checkCallingPermission((String) args[0]);
                     }
                 }, permission);
     }
@@ -233,7 +233,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Integer call(final Object... args) {
                         return getOriginal()
-                                .checkCallingUriPermission__super((Uri) args[0], (int) args[1]);
+                                .super_checkCallingUriPermission((Uri) args[0], (int) args[1]);
                     }
                 }, uri, modeFlags);
     }
@@ -252,7 +252,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().checkPermission__super((String) args[0], (int) args[1],
+                        return getOriginal().super_checkPermission((String) args[0], (int) args[1],
                                 (int) args[2]);
                     }
                 }, permission, pid, uid);
@@ -271,7 +271,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().checkSelfPermission__super((String) args[0]);
+                        return getOriginal().super_checkSelfPermission((String) args[0]);
                     }
                 }, permission);
     }
@@ -291,7 +291,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().checkUriPermission__super((Uri) args[0], (int) args[1],
+                        return getOriginal().super_checkUriPermission((Uri) args[0], (int) args[1],
                                 (int) args[2], (int) args[3]);
                     }
                 }, uri, pid, uid, modeFlags);
@@ -313,7 +313,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Integer call(final Object... args) {
                         return getOriginal()
-                                .checkUriPermission__super((Uri) args[0], (String) args[1],
+                                .super_checkUriPermission((Uri) args[0], (String) args[1],
                                         (String) args[2], (int) args[3], (int) args[4],
                                         (int) args[5]);
                     }
@@ -335,7 +335,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             @Override
             public void call(final Object... args) {
                 try {
-                    getOriginal().clearWallpaper__super();
+                    getOriginal().super_clearWallpaper();
                 } catch (IOException e) {
                     throw new SuppressedException(e);
                 }
@@ -353,7 +353,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().closeContextMenu__super();
+                getOriginal().super_closeContextMenu();
             }
         });
     }
@@ -368,7 +368,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().closeOptionsMenu__super();
+                getOriginal().super_closeOptionsMenu();
             }
         });
     }
@@ -388,7 +388,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Context call(final Object... args) {
                         return getOriginal()
-                                .createConfigurationContext__super((Configuration) args[0]);
+                                .super_createConfigurationContext((Configuration) args[0]);
                     }
                 }, overrideConfiguration);
     }
@@ -406,7 +406,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Context>() {
                     @Override
                     public Context call(final Object... args) {
-                        return getOriginal().createDisplayContext__super((Display) args[0]);
+                        return getOriginal().super_createDisplayContext((Display) args[0]);
                     }
                 }, display);
     }
@@ -430,7 +430,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     public Context call(final Object... args) {
                         try {
                             return getOriginal()
-                                    .createPackageContext__super((String) args[0], (int) args[1]);
+                                    .super_createPackageContext((String) args[0], (int) args[1]);
                         } catch (PackageManager.NameNotFoundException e) {
                             throw new SuppressedException(e);
                         }
@@ -455,7 +455,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public PendingIntent call(final Object... args) {
                         return getOriginal()
-                                .createPendingResult__super((int) args[0], (Intent) args[1],
+                                .super_createPendingResult((int) args[0], (Intent) args[1],
                                         (int) args[2]);
                     }
                 }, requestCode, data, flags);
@@ -473,7 +473,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<String[]>() {
             @Override
             public String[] call(final Object... args) {
-                return getOriginal().databaseList__super();
+                return getOriginal().super_databaseList();
             }
         });
     }
@@ -490,7 +490,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().deleteDatabase__super((String) args[0]);
+                return getOriginal().super_deleteDatabase((String) args[0]);
             }
         }, name);
     }
@@ -507,7 +507,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().deleteFile__super((String) args[0]);
+                return getOriginal().super_deleteFile((String) args[0]);
             }
         }, name);
     }
@@ -526,7 +526,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .dispatchGenericMotionEvent__super((MotionEvent) args[0]);
+                                .super_dispatchGenericMotionEvent((MotionEvent) args[0]);
                     }
                 }, ev);
     }
@@ -544,7 +544,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().dispatchKeyEvent__super((KeyEvent) args[0]);
+                        return getOriginal().super_dispatchKeyEvent((KeyEvent) args[0]);
                     }
                 }, event);
     }
@@ -562,7 +562,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().dispatchKeyShortcutEvent__super((KeyEvent) args[0]);
+                        return getOriginal().super_dispatchKeyShortcutEvent((KeyEvent) args[0]);
                     }
                 }, event);
     }
@@ -581,7 +581,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().dispatchPopulateAccessibilityEvent__super(
+                        return getOriginal().super_dispatchPopulateAccessibilityEvent(
                                 (AccessibilityEvent) args[0]);
                     }
                 }, event);
@@ -600,7 +600,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().dispatchTouchEvent__super((MotionEvent) args[0]);
+                        return getOriginal().super_dispatchTouchEvent((MotionEvent) args[0]);
                     }
                 }, ev);
     }
@@ -618,7 +618,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().dispatchTrackballEvent__super((MotionEvent) args[0]);
+                        return getOriginal().super_dispatchTrackballEvent((MotionEvent) args[0]);
                     }
                 }, ev);
     }
@@ -636,7 +636,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().dump__super((String) args[0], (FileDescriptor) args[1],
+                        getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
                                 (PrintWriter) args[2], (String[]) args[3]);
                     }
                 }, prefix, fd, writer, args);
@@ -654,7 +654,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().enforceCallingOrSelfPermission__super((String) args[0],
+                        getOriginal().super_enforceCallingOrSelfPermission((String) args[0],
                                 (String) args[1]);
                     }
                 }, permission, message);
@@ -673,7 +673,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().enforceCallingOrSelfUriPermission__super((Uri) args[0],
+                        getOriginal().super_enforceCallingOrSelfUriPermission((Uri) args[0],
                                 (int) args[1], (String) args[2]);
                     }
                 }, uri, modeFlags, message);
@@ -689,7 +689,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().enforceCallingPermission__super((String) args[0], (String) args[1]);
+                getOriginal().super_enforceCallingPermission((String) args[0], (String) args[1]);
             }
         }, permission, message);
     }
@@ -708,7 +708,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .enforceCallingUriPermission__super((Uri) args[0], (int) args[1],
+                                .super_enforceCallingUriPermission((Uri) args[0], (int) args[1],
                                         (String) args[2]);
                     }
                 }, uri, modeFlags, message);
@@ -727,7 +727,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().enforcePermission__super((String) args[0], (int) args[1],
+                        getOriginal().super_enforcePermission((String) args[0], (int) args[1],
                                 (int) args[2], (String) args[3]);
                     }
                 }, permission, pid, uid, message);
@@ -746,7 +746,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().enforceUriPermission__super((Uri) args[0], (int) args[1],
+                        getOriginal().super_enforceUriPermission((Uri) args[0], (int) args[1],
                                 (int) args[2], (int) args[3], (String) args[4]);
                     }
                 }, uri, pid, uid, modeFlags, message);
@@ -767,7 +767,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().enforceUriPermission__super((Uri) args[0], (String) args[1],
+                        getOriginal().super_enforceUriPermission((Uri) args[0], (String) args[1],
                                 (String) args[2], (int) args[3], (int) args[4], (int) args[5],
                                 (String) args[6]);
                     }
@@ -786,7 +786,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<String[]>() {
             @Override
             public String[] call(final Object... args) {
-                return getOriginal().fileList__super();
+                return getOriginal().super_fileList();
             }
         });
     }
@@ -803,7 +803,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<View>() {
             @Override
             public View call(final Object... args) {
-                return getOriginal().findViewById__super((int) args[0]);
+                return getOriginal().super_findViewById((int) args[0]);
             }
         }, id);
     }
@@ -818,7 +818,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().finish__super();
+                getOriginal().super_finish();
             }
         });
     }
@@ -833,7 +833,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().finishActivity__super((int) args[0]);
+                getOriginal().super_finishActivity((int) args[0]);
             }
         }, requestCode);
     }
@@ -848,7 +848,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().finishActivityFromChild__super((Activity) args[0], (int) args[1]);
+                getOriginal().super_finishActivityFromChild((Activity) args[0], (int) args[1]);
             }
         }, child, requestCode);
     }
@@ -863,7 +863,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().finishAffinity__super();
+                getOriginal().super_finishAffinity();
             }
         });
     }
@@ -878,7 +878,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().finishAfterTransition__super();
+                getOriginal().super_finishAfterTransition();
             }
         });
     }
@@ -893,7 +893,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().finishAndRemoveTask__super();
+                getOriginal().super_finishAndRemoveTask();
             }
         });
     }
@@ -908,7 +908,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().finishFromChild__super((Activity) args[0]);
+                getOriginal().super_finishFromChild((Activity) args[0]);
             }
         }, child);
     }
@@ -927,7 +927,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<android.app.ActionBar>() {
                     @Override
                     public android.app.ActionBar call(final Object... args) {
-                        return getOriginal().getActionBar__super();
+                        return getOriginal().super_getActionBar();
                     }
                 });
     }
@@ -944,7 +944,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Context>() {
             @Override
             public Context call(final Object... args) {
-                return getOriginal().getApplicationContext__super();
+                return getOriginal().super_getApplicationContext();
             }
         });
     }
@@ -962,7 +962,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<ApplicationInfo>() {
                     @Override
                     public ApplicationInfo call(final Object... args) {
-                        return getOriginal().getApplicationInfo__super();
+                        return getOriginal().super_getApplicationInfo();
                     }
                 });
     }
@@ -979,7 +979,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<AssetManager>() {
             @Override
             public AssetManager call(final Object... args) {
-                return getOriginal().getAssets__super();
+                return getOriginal().super_getAssets();
             }
         });
     }
@@ -996,7 +996,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Context>() {
             @Override
             public Context call(final Object... args) {
-                return getOriginal().getBaseContext__super();
+                return getOriginal().super_getBaseContext();
             }
         });
     }
@@ -1013,7 +1013,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getCacheDir__super();
+                return getOriginal().super_getCacheDir();
             }
         });
     }
@@ -1031,7 +1031,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<ComponentName>() {
                     @Override
                     public ComponentName call(final Object... args) {
-                        return getOriginal().getCallingActivity__super();
+                        return getOriginal().super_getCallingActivity();
                     }
                 });
     }
@@ -1048,7 +1048,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<String>() {
             @Override
             public String call(final Object... args) {
-                return getOriginal().getCallingPackage__super();
+                return getOriginal().super_getCallingPackage();
             }
         });
     }
@@ -1066,7 +1066,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().getChangingConfigurations__super();
+                        return getOriginal().super_getChangingConfigurations();
                     }
                 });
     }
@@ -1083,7 +1083,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<ClassLoader>() {
             @Override
             public ClassLoader call(final Object... args) {
-                return getOriginal().getClassLoader__super();
+                return getOriginal().super_getClassLoader();
             }
         });
     }
@@ -1100,7 +1100,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getCodeCacheDir__super();
+                return getOriginal().super_getCodeCacheDir();
             }
         });
     }
@@ -1117,7 +1117,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<ComponentName>() {
             @Override
             public ComponentName call(final Object... args) {
-                return getOriginal().getComponentName__super();
+                return getOriginal().super_getComponentName();
             }
         });
     }
@@ -1135,7 +1135,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<ContentResolver>() {
                     @Override
                     public ContentResolver call(final Object... args) {
-                        return getOriginal().getContentResolver__super();
+                        return getOriginal().super_getContentResolver();
                     }
                 });
     }
@@ -1152,7 +1152,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Scene>() {
             @Override
             public Scene call(final Object... args) {
-                return getOriginal().getContentScene__super();
+                return getOriginal().super_getContentScene();
             }
         });
     }
@@ -1170,7 +1170,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<TransitionManager>() {
                     @Override
                     public TransitionManager call(final Object... args) {
-                        return getOriginal().getContentTransitionManager__super();
+                        return getOriginal().super_getContentTransitionManager();
                     }
                 });
     }
@@ -1187,7 +1187,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<View>() {
             @Override
             public View call(final Object... args) {
-                return getOriginal().getCurrentFocus__super();
+                return getOriginal().super_getCurrentFocus();
             }
         });
     }
@@ -1204,7 +1204,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getDatabasePath__super((String) args[0]);
+                return getOriginal().super_getDatabasePath((String) args[0]);
             }
         }, name);
     }
@@ -1221,7 +1221,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<AppCompatDelegate>() {
             @Override
             public AppCompatDelegate call(final Object... args) {
-                return getOriginal().getDelegate__super();
+                return getOriginal().super_getDelegate();
             }
         });
     }
@@ -1238,7 +1238,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getDir__super((String) args[0], (int) args[1]);
+                return getOriginal().super_getDir((String) args[0], (int) args[1]);
             }
         }, name, mode);
     }
@@ -1257,7 +1257,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<ActionBarDrawerToggle.Delegate>() {
                     @Override
                     public ActionBarDrawerToggle.Delegate call(final Object... args) {
-                        return getOriginal().getDrawerToggleDelegate__super();
+                        return getOriginal().super_getDrawerToggleDelegate();
                     }
                 });
     }
@@ -1274,7 +1274,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getExternalCacheDir__super();
+                return getOriginal().super_getExternalCacheDir();
             }
         });
     }
@@ -1291,7 +1291,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File[]>() {
             @Override
             public File[] call(final Object... args) {
-                return getOriginal().getExternalCacheDirs__super();
+                return getOriginal().super_getExternalCacheDirs();
             }
         });
     }
@@ -1308,7 +1308,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getExternalFilesDir__super((String) args[0]);
+                return getOriginal().super_getExternalFilesDir((String) args[0]);
             }
         }, type);
     }
@@ -1326,7 +1326,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<File[]>() {
                     @Override
                     public File[] call(final Object... args) {
-                        return getOriginal().getExternalFilesDirs__super((String) args[0]);
+                        return getOriginal().super_getExternalFilesDirs((String) args[0]);
                     }
                 }, type);
     }
@@ -1343,7 +1343,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File[]>() {
             @Override
             public File[] call(final Object... args) {
-                return getOriginal().getExternalMediaDirs__super();
+                return getOriginal().super_getExternalMediaDirs();
             }
         });
     }
@@ -1360,7 +1360,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getFileStreamPath__super((String) args[0]);
+                return getOriginal().super_getFileStreamPath((String) args[0]);
             }
         }, name);
     }
@@ -1377,7 +1377,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getFilesDir__super();
+                return getOriginal().super_getFilesDir();
             }
         });
     }
@@ -1396,7 +1396,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<android.app.FragmentManager>() {
                     @Override
                     public android.app.FragmentManager call(final Object... args) {
-                        return getOriginal().getFragmentManager__super();
+                        return getOriginal().super_getFragmentManager();
                     }
                 });
     }
@@ -1413,7 +1413,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Intent>() {
             @Override
             public Intent call(final Object... args) {
-                return getOriginal().getIntent__super();
+                return getOriginal().super_getIntent();
             }
         });
     }
@@ -1449,7 +1449,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<LayoutInflater>() {
                     @Override
                     public LayoutInflater call(final Object... args) {
-                        return getOriginal().getLayoutInflater__super();
+                        return getOriginal().super_getLayoutInflater();
                     }
                 });
     }
@@ -1468,7 +1468,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<android.app.LoaderManager>() {
                     @Override
                     public android.app.LoaderManager call(final Object... args) {
-                        return getOriginal().getLoaderManager__super();
+                        return getOriginal().super_getLoaderManager();
                     }
                 });
     }
@@ -1485,7 +1485,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<String>() {
             @Override
             public String call(final Object... args) {
-                return getOriginal().getLocalClassName__super();
+                return getOriginal().super_getLocalClassName();
             }
         });
     }
@@ -1502,7 +1502,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Looper>() {
             @Override
             public Looper call(final Object... args) {
-                return getOriginal().getMainLooper__super();
+                return getOriginal().super_getMainLooper();
             }
         });
     }
@@ -1519,7 +1519,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<MenuInflater>() {
             @Override
             public MenuInflater call(final Object... args) {
-                return getOriginal().getMenuInflater__super();
+                return getOriginal().super_getMenuInflater();
             }
         });
     }
@@ -1536,7 +1536,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getNoBackupFilesDir__super();
+                return getOriginal().super_getNoBackupFilesDir();
             }
         });
     }
@@ -1553,7 +1553,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File>() {
             @Override
             public File call(final Object... args) {
-                return getOriginal().getObbDir__super();
+                return getOriginal().super_getObbDir();
             }
         });
     }
@@ -1570,7 +1570,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<File[]>() {
             @Override
             public File[] call(final Object... args) {
-                return getOriginal().getObbDirs__super();
+                return getOriginal().super_getObbDirs();
             }
         });
     }
@@ -1587,7 +1587,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<String>() {
             @Override
             public String call(final Object... args) {
-                return getOriginal().getPackageCodePath__super();
+                return getOriginal().super_getPackageCodePath();
             }
         });
     }
@@ -1605,7 +1605,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<PackageManager>() {
                     @Override
                     public PackageManager call(final Object... args) {
-                        return getOriginal().getPackageManager__super();
+                        return getOriginal().super_getPackageManager();
                     }
                 });
     }
@@ -1622,7 +1622,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<String>() {
             @Override
             public String call(final Object... args) {
-                return getOriginal().getPackageName__super();
+                return getOriginal().super_getPackageName();
             }
         });
     }
@@ -1639,7 +1639,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<String>() {
             @Override
             public String call(final Object... args) {
-                return getOriginal().getPackageResourcePath__super();
+                return getOriginal().super_getPackageResourcePath();
             }
         });
     }
@@ -1656,7 +1656,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Intent>() {
             @Override
             public Intent call(final Object... args) {
-                return getOriginal().getParentActivityIntent__super();
+                return getOriginal().super_getParentActivityIntent();
             }
         });
     }
@@ -1674,7 +1674,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<SharedPreferences>() {
                     @Override
                     public SharedPreferences call(final Object... args) {
-                        return getOriginal().getPreferences__super((int) args[0]);
+                        return getOriginal().super_getPreferences((int) args[0]);
                     }
                 }, mode);
     }
@@ -1691,7 +1691,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Uri>() {
             @Override
             public Uri call(final Object... args) {
-                return getOriginal().getReferrer__super();
+                return getOriginal().super_getReferrer();
             }
         });
     }
@@ -1708,7 +1708,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Integer>() {
             @Override
             public Integer call(final Object... args) {
-                return getOriginal().getRequestedOrientation__super();
+                return getOriginal().super_getRequestedOrientation();
             }
         });
     }
@@ -1725,7 +1725,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Resources>() {
             @Override
             public Resources call(final Object... args) {
-                return getOriginal().getResources__super();
+                return getOriginal().super_getResources();
             }
         });
     }
@@ -1745,7 +1745,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public SharedPreferences call(final Object... args) {
                         return getOriginal()
-                                .getSharedPreferences__super((String) args[0], (int) args[1]);
+                                .super_getSharedPreferences((String) args[0], (int) args[1]);
                     }
                 }, name, mode);
     }
@@ -1762,7 +1762,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<ActionBar>() {
             @Override
             public ActionBar call(final Object... args) {
-                return getOriginal().getSupportActionBar__super();
+                return getOriginal().super_getSupportActionBar();
             }
         });
     }
@@ -1780,7 +1780,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<FragmentManager>() {
                     @Override
                     public FragmentManager call(final Object... args) {
-                        return getOriginal().getSupportFragmentManager__super();
+                        return getOriginal().super_getSupportFragmentManager();
                     }
                 });
     }
@@ -1798,7 +1798,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<LoaderManager>() {
                     @Override
                     public LoaderManager call(final Object... args) {
-                        return getOriginal().getSupportLoaderManager__super();
+                        return getOriginal().super_getSupportLoaderManager();
                     }
                 });
     }
@@ -1816,7 +1816,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Intent>() {
                     @Override
                     public Intent call(final Object... args) {
-                        return getOriginal().getSupportParentActivityIntent__super();
+                        return getOriginal().super_getSupportParentActivityIntent();
                     }
                 });
     }
@@ -1833,7 +1833,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Object>() {
             @Override
             public Object call(final Object... args) {
-                return getOriginal().getSystemService__super((String) args[0]);
+                return getOriginal().super_getSystemService((String) args[0]);
             }
         }, name);
     }
@@ -1851,7 +1851,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<String>() {
                     @Override
                     public String call(final Object... args) {
-                        return getOriginal().getSystemServiceName__super((Class<?>) args[0]);
+                        return getOriginal().super_getSystemServiceName((Class<?>) args[0]);
                     }
                 }, serviceClass);
     }
@@ -1868,7 +1868,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Integer>() {
             @Override
             public Integer call(final Object... args) {
-                return getOriginal().getTaskId__super();
+                return getOriginal().super_getTaskId();
             }
         });
     }
@@ -1885,7 +1885,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Resources.Theme>() {
             @Override
             public Resources.Theme call(final Object... args) {
-                return getOriginal().getTheme__super();
+                return getOriginal().super_getTheme();
             }
         });
     }
@@ -1903,7 +1903,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<VoiceInteractor>() {
                     @Override
                     public VoiceInteractor call(final Object... args) {
-                        return getOriginal().getVoiceInteractor__super();
+                        return getOriginal().super_getVoiceInteractor();
                     }
                 });
     }
@@ -1920,7 +1920,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Drawable>() {
             @Override
             public Drawable call(final Object... args) {
-                return getOriginal().getWallpaper__super();
+                return getOriginal().super_getWallpaper();
             }
         });
     }
@@ -1938,7 +1938,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().getWallpaperDesiredMinimumHeight__super();
+                        return getOriginal().super_getWallpaperDesiredMinimumHeight();
                     }
                 });
     }
@@ -1956,7 +1956,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Integer>() {
                     @Override
                     public Integer call(final Object... args) {
-                        return getOriginal().getWallpaperDesiredMinimumWidth__super();
+                        return getOriginal().super_getWallpaperDesiredMinimumWidth();
                     }
                 });
     }
@@ -1973,7 +1973,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Window>() {
             @Override
             public Window call(final Object... args) {
-                return getOriginal().getWindow__super();
+                return getOriginal().super_getWindow();
             }
         });
     }
@@ -1990,7 +1990,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<WindowManager>() {
             @Override
             public WindowManager call(final Object... args) {
-                return getOriginal().getWindowManager__super();
+                return getOriginal().super_getWindowManager();
             }
         });
     }
@@ -2007,7 +2007,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             @Override
             public void call(final Object... args) {
                 getOriginal()
-                        .grantUriPermission__super((String) args[0], (Uri) args[1], (int) args[2]);
+                        .super_grantUriPermission((String) args[0], (Uri) args[1], (int) args[2]);
             }
         }, toPackage, uri, modeFlags);
     }
@@ -2024,7 +2024,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().hasWindowFocus__super();
+                return getOriginal().super_hasWindowFocus();
             }
         });
     }
@@ -2039,7 +2039,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().invalidateOptionsMenu__super();
+                getOriginal().super_invalidateOptionsMenu();
             }
         });
     }
@@ -2057,7 +2057,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().isChangingConfigurations__super();
+                        return getOriginal().super_isChangingConfigurations();
                     }
                 });
     }
@@ -2074,7 +2074,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isDestroyed__super();
+                return getOriginal().super_isDestroyed();
             }
         });
     }
@@ -2091,7 +2091,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isFinishing__super();
+                return getOriginal().super_isFinishing();
             }
         });
     }
@@ -2108,7 +2108,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isImmersive__super();
+                return getOriginal().super_isImmersive();
             }
         });
     }
@@ -2125,7 +2125,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isRestricted__super();
+                return getOriginal().super_isRestricted();
             }
         });
     }
@@ -2142,7 +2142,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isTaskRoot__super();
+                return getOriginal().super_isTaskRoot();
             }
         });
     }
@@ -2159,7 +2159,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isVoiceInteraction__super();
+                return getOriginal().super_isVoiceInteraction();
             }
         });
     }
@@ -2176,7 +2176,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isVoiceInteractionRoot__super();
+                return getOriginal().super_isVoiceInteractionRoot();
             }
         });
     }
@@ -2193,7 +2193,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().moveTaskToBack__super((boolean) args[0]);
+                return getOriginal().super_moveTaskToBack((boolean) args[0]);
             }
         }, nonRoot);
     }
@@ -2210,7 +2210,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().navigateUpTo__super((Intent) args[0]);
+                return getOriginal().super_navigateUpTo((Intent) args[0]);
             }
         }, upIntent);
     }
@@ -2230,7 +2230,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .navigateUpToFromChild__super((Activity) args[0], (Intent) args[1]);
+                                .super_navigateUpToFromChild((Activity) args[0], (Intent) args[1]);
                     }
                 }, child, upIntent);
     }
@@ -2246,8 +2246,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal()
-                                .onActionModeFinished__super((android.view.ActionMode) args[0]);
+                        getOriginal().super_onActionModeFinished((android.view.ActionMode) args[0]);
                     }
                 }, mode);
     }
@@ -2263,7 +2262,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onActionModeStarted__super((android.view.ActionMode) args[0]);
+                        getOriginal().super_onActionModeStarted((android.view.ActionMode) args[0]);
                     }
                 }, mode);
     }
@@ -2278,7 +2277,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onActivityReenter__super((int) args[0], (Intent) args[1]);
+                getOriginal().super_onActivityReenter((int) args[0], (Intent) args[1]);
             }
         }, resultCode, data);
     }
@@ -2294,7 +2293,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             @Override
             public void call(final Object... args) {
                 getOriginal()
-                        .onActivityResult__super((int) args[0], (int) args[1], (Intent) args[2]);
+                        .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
             }
         }, requestCode, resultCode, data);
     }
@@ -2312,7 +2311,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onApplyThemeResource__super((Resources.Theme) args[0],
+                        getOriginal().super_onApplyThemeResource((Resources.Theme) args[0],
                                 (int) args[1], (boolean) args[2]);
                     }
                 }, theme, resid, first);
@@ -2328,7 +2327,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onAttachFragment__super((Fragment) args[0]);
+                getOriginal().super_onAttachFragment((Fragment) args[0]);
             }
         }, fragment);
     }
@@ -2343,7 +2342,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onAttachFragment__super((android.app.Fragment) args[0]);
+                getOriginal().super_onAttachFragment((android.app.Fragment) args[0]);
             }
         }, fragment);
     }
@@ -2358,7 +2357,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onAttachedToWindow__super();
+                getOriginal().super_onAttachedToWindow();
             }
         });
     }
@@ -2373,7 +2372,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onBackPressed__super();
+                getOriginal().super_onBackPressed();
             }
         });
     }
@@ -2390,7 +2389,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onChildTitleChanged__super((Activity) args[0],
+                        getOriginal().super_onChildTitleChanged((Activity) args[0],
                                 (CharSequence) args[1]);
                     }
                 }, childActivity, title);
@@ -2406,7 +2405,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onConfigurationChanged__super((Configuration) args[0]);
+                getOriginal().super_onConfigurationChanged((Configuration) args[0]);
             }
         }, newConfig);
     }
@@ -2421,7 +2420,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onContentChanged__super();
+                getOriginal().super_onContentChanged();
             }
         });
     }
@@ -2439,7 +2438,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onContextItemSelected__super((MenuItem) args[0]);
+                        return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
                     }
                 }, item);
     }
@@ -2454,7 +2453,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onContextMenuClosed__super((Menu) args[0]);
+                getOriginal().super_onContextMenuClosed((Menu) args[0]);
             }
         }, menu);
     }
@@ -2469,7 +2468,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onCreate__super((Bundle) args[0], (PersistableBundle) args[1]);
+                getOriginal().super_onCreate((Bundle) args[0], (PersistableBundle) args[1]);
             }
         }, savedInstanceState, persistentState);
     }
@@ -2484,7 +2483,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onCreate__super((Bundle) args[0]);
+                getOriginal().super_onCreate((Bundle) args[0]);
             }
         }, savedInstanceState);
     }
@@ -2503,7 +2502,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .onCreateContextMenu__super((ContextMenu) args[0], (View) args[1],
+                                .super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
                                         (ContextMenu.ContextMenuInfo) args[2]);
                     }
                 }, menu, v, menuInfo);
@@ -2522,7 +2521,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<CharSequence>() {
                     @Override
                     public CharSequence call(final Object... args) {
-                        return getOriginal().onCreateDescription__super();
+                        return getOriginal().super_onCreateDescription();
                     }
                 });
     }
@@ -2539,7 +2538,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Dialog>() {
             @Override
             public Dialog call(final Object... args) {
-                return getOriginal().onCreateDialog__super((int) args[0]);
+                return getOriginal().super_onCreateDialog((int) args[0]);
             }
         }, id);
     }
@@ -2557,7 +2556,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Dialog>() {
                     @Override
                     public Dialog call(final Object... args) {
-                        return getOriginal().onCreateDialog__super((int) args[0], (Bundle) args[1]);
+                        return getOriginal().super_onCreateDialog((int) args[0], (Bundle) args[1]);
                     }
                 }, id, args);
     }
@@ -2573,8 +2572,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal()
-                                .onCreateNavigateUpTaskStack__super((TaskStackBuilder) args[0]);
+                        getOriginal().super_onCreateNavigateUpTaskStack((TaskStackBuilder) args[0]);
                     }
                 }, builder);
     }
@@ -2591,7 +2589,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onCreateOptionsMenu__super((Menu) args[0]);
+                return getOriginal().super_onCreateOptionsMenu((Menu) args[0]);
             }
         }, menu);
     }
@@ -2609,8 +2607,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .onCreatePanelMenu__super((int) args[0], (Menu) args[1]);
+                        return getOriginal().super_onCreatePanelMenu((int) args[0], (Menu) args[1]);
                     }
                 }, featureId, menu);
     }
@@ -2627,7 +2624,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<View>() {
             @Override
             public View call(final Object... args) {
-                return getOriginal().onCreatePanelView__super((int) args[0]);
+                return getOriginal().super_onCreatePanelView((int) args[0]);
             }
         }, featureId);
     }
@@ -2645,7 +2642,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onCreateSupportNavigateUpTaskStack__super(
+                        getOriginal().super_onCreateSupportNavigateUpTaskStack(
                                 (android.support.v4.app.TaskStackBuilder) args[0]);
                     }
                 }, builder);
@@ -2666,7 +2663,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .onCreateThumbnail__super((Bitmap) args[0], (Canvas) args[1]);
+                                .super_onCreateThumbnail((Bitmap) args[0], (Canvas) args[1]);
                     }
                 }, outBitmap, canvas);
     }
@@ -2686,7 +2683,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<View>() {
                     @Override
                     public View call(final Object... args) {
-                        return getOriginal().onCreateView__super((View) args[0], (String) args[1],
+                        return getOriginal().super_onCreateView((View) args[0], (String) args[1],
                                 (Context) args[2], (AttributeSet) args[3]);
                     }
                 }, parent, name, context, attrs);
@@ -2706,9 +2703,8 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<View>() {
                     @Override
                     public View call(final Object... args) {
-                        return getOriginal()
-                                .onCreateView__super((String) args[0], (Context) args[1],
-                                        (AttributeSet) args[2]);
+                        return getOriginal().super_onCreateView((String) args[0], (Context) args[1],
+                                (AttributeSet) args[2]);
                     }
                 }, name, context, attrs);
     }
@@ -2723,7 +2719,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onDestroy__super();
+                getOriginal().super_onDestroy();
             }
         });
     }
@@ -2738,7 +2734,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onDetachedFromWindow__super();
+                getOriginal().super_onDetachedFromWindow();
             }
         });
     }
@@ -2753,7 +2749,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onEnterAnimationComplete__super();
+                getOriginal().super_onEnterAnimationComplete();
             }
         });
     }
@@ -2771,7 +2767,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onGenericMotionEvent__super((MotionEvent) args[0]);
+                        return getOriginal().super_onGenericMotionEvent((MotionEvent) args[0]);
                     }
                 }, event);
     }
@@ -2788,7 +2784,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onKeyDown__super((int) args[0], (KeyEvent) args[1]);
+                return getOriginal().super_onKeyDown((int) args[0], (KeyEvent) args[1]);
             }
         }, keyCode, event);
     }
@@ -2807,7 +2803,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .onKeyLongPress__super((int) args[0], (KeyEvent) args[1]);
+                                .super_onKeyLongPress((int) args[0], (KeyEvent) args[1]);
                     }
                 }, keyCode, event);
     }
@@ -2826,7 +2822,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onKeyMultiple__super((int) args[0], (int) args[1],
+                        return getOriginal().super_onKeyMultiple((int) args[0], (int) args[1],
                                 (KeyEvent) args[2]);
                     }
                 }, keyCode, repeatCount, event);
@@ -2845,8 +2841,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .onKeyShortcut__super((int) args[0], (KeyEvent) args[1]);
+                        return getOriginal().super_onKeyShortcut((int) args[0], (KeyEvent) args[1]);
                     }
                 }, keyCode, event);
     }
@@ -2863,7 +2858,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onKeyUp__super((int) args[0], (KeyEvent) args[1]);
+                return getOriginal().super_onKeyUp((int) args[0], (KeyEvent) args[1]);
             }
         }, keyCode, event);
     }
@@ -2878,7 +2873,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onLowMemory__super();
+                getOriginal().super_onLowMemory();
             }
         });
     }
@@ -2895,7 +2890,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onMenuOpened__super((int) args[0], (Menu) args[1]);
+                return getOriginal().super_onMenuOpened((int) args[0], (Menu) args[1]);
             }
         }, featureId, menu);
     }
@@ -2912,7 +2907,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onNavigateUp__super();
+                return getOriginal().super_onNavigateUp();
             }
         });
     }
@@ -2930,7 +2925,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onNavigateUpFromChild__super((Activity) args[0]);
+                        return getOriginal().super_onNavigateUpFromChild((Activity) args[0]);
                     }
                 }, child);
     }
@@ -2945,7 +2940,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onNewIntent__super((Intent) args[0]);
+                getOriginal().super_onNewIntent((Intent) args[0]);
             }
         }, intent);
     }
@@ -2963,7 +2958,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onOptionsItemSelected__super((MenuItem) args[0]);
+                        return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
                     }
                 }, item);
     }
@@ -2978,7 +2973,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onOptionsMenuClosed__super((Menu) args[0]);
+                getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
             }
         }, menu);
     }
@@ -2993,7 +2988,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPanelClosed__super((int) args[0], (Menu) args[1]);
+                getOriginal().super_onPanelClosed((int) args[0], (Menu) args[1]);
             }
         }, featureId, menu);
     }
@@ -3008,7 +3003,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPause__super();
+                getOriginal().super_onPause();
             }
         });
     }
@@ -3024,7 +3019,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPostCreate__super((Bundle) args[0], (PersistableBundle) args[1]);
+                getOriginal().super_onPostCreate((Bundle) args[0], (PersistableBundle) args[1]);
             }
         }, savedInstanceState, persistentState);
     }
@@ -3039,7 +3034,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPostCreate__super((Bundle) args[0]);
+                getOriginal().super_onPostCreate((Bundle) args[0]);
             }
         }, savedInstanceState);
     }
@@ -3054,7 +3049,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPostResume__super();
+                getOriginal().super_onPostResume();
             }
         });
     }
@@ -3069,7 +3064,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPrepareDialog__super((int) args[0], (Dialog) args[1]);
+                getOriginal().super_onPrepareDialog((int) args[0], (Dialog) args[1]);
             }
         }, id, dialog);
     }
@@ -3086,7 +3081,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             @Override
             public void call(final Object... args) {
                 getOriginal()
-                        .onPrepareDialog__super((int) args[0], (Dialog) args[1], (Bundle) args[2]);
+                        .super_onPrepareDialog((int) args[0], (Dialog) args[1], (Bundle) args[2]);
             }
         }, id, dialog, args);
     }
@@ -3103,7 +3098,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .onPrepareNavigateUpTaskStack__super((TaskStackBuilder) args[0]);
+                                .super_onPrepareNavigateUpTaskStack((TaskStackBuilder) args[0]);
                     }
                 }, builder);
     }
@@ -3121,7 +3116,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onPrepareOptionsMenu__super((Menu) args[0]);
+                        return getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
                     }
                 }, menu);
     }
@@ -3141,7 +3136,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .onPrepareOptionsPanel__super((View) args[0], (Menu) args[1]);
+                                .super_onPrepareOptionsPanel((View) args[0], (Menu) args[1]);
                     }
                 }, view, menu);
     }
@@ -3160,7 +3155,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onPreparePanel__super((int) args[0], (View) args[1],
+                        return getOriginal().super_onPreparePanel((int) args[0], (View) args[1],
                                 (Menu) args[2]);
                     }
                 }, featureId, view, menu);
@@ -3179,7 +3174,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onPrepareSupportNavigateUpTaskStack__super(
+                        getOriginal().super_onPrepareSupportNavigateUpTaskStack(
                                 (android.support.v4.app.TaskStackBuilder) args[0]);
                     }
                 }, builder);
@@ -3195,7 +3190,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onProvideAssistContent__super((AssistContent) args[0]);
+                getOriginal().super_onProvideAssistContent((AssistContent) args[0]);
             }
         }, outContent);
     }
@@ -3210,7 +3205,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onProvideAssistData__super((Bundle) args[0]);
+                getOriginal().super_onProvideAssistData((Bundle) args[0]);
             }
         }, data);
     }
@@ -3227,7 +3222,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Uri>() {
             @Override
             public Uri call(final Object... args) {
-                return getOriginal().onProvideReferrer__super();
+                return getOriginal().super_onProvideReferrer();
             }
         });
     }
@@ -3245,8 +3240,9 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onRequestPermissionsResult__super((int) args[0],
-                                (String[]) args[1], (int[]) args[2]);
+                        getOriginal()
+                                .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
+                                        (int[]) args[2]);
                     }
                 }, requestCode, permissions, grantResults);
     }
@@ -3261,7 +3257,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onRestart__super();
+                getOriginal().super_onRestart();
             }
         });
     }
@@ -3279,7 +3275,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onRestoreInstanceState__super((Bundle) args[0],
+                        getOriginal().super_onRestoreInstanceState((Bundle) args[0],
                                 (PersistableBundle) args[1]);
                     }
                 }, savedInstanceState, persistentState);
@@ -3295,7 +3291,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onRestoreInstanceState__super((Bundle) args[0]);
+                getOriginal().super_onRestoreInstanceState((Bundle) args[0]);
             }
         }, savedInstanceState);
     }
@@ -3310,7 +3306,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onResume__super();
+                getOriginal().super_onResume();
             }
         });
     }
@@ -3325,7 +3321,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onResumeFragments__super();
+                getOriginal().super_onResumeFragments();
             }
         });
     }
@@ -3356,7 +3352,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onSaveInstanceState__super((Bundle) args[0],
+                        getOriginal().super_onSaveInstanceState((Bundle) args[0],
                                 (PersistableBundle) args[1]);
                     }
                 }, outState, outPersistentState);
@@ -3372,7 +3368,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onSaveInstanceState__super((Bundle) args[0]);
+                getOriginal().super_onSaveInstanceState((Bundle) args[0]);
             }
         }, outState);
     }
@@ -3390,7 +3386,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onSearchRequested__super((SearchEvent) args[0]);
+                        return getOriginal().super_onSearchRequested((SearchEvent) args[0]);
                     }
                 }, searchEvent);
     }
@@ -3407,7 +3403,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onSearchRequested__super();
+                return getOriginal().super_onSearchRequested();
             }
         });
     }
@@ -3422,7 +3418,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onStart__super();
+                getOriginal().super_onStart();
             }
         });
     }
@@ -3437,7 +3433,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onStateNotSaved__super();
+                getOriginal().super_onStateNotSaved();
             }
         });
     }
@@ -3452,7 +3448,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onStop__super();
+                getOriginal().super_onStop();
             }
         });
     }
@@ -3467,7 +3463,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onSupportActionModeFinished__super((ActionMode) args[0]);
+                getOriginal().super_onSupportActionModeFinished((ActionMode) args[0]);
             }
         }, mode);
     }
@@ -3482,7 +3478,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onSupportActionModeStarted__super((ActionMode) args[0]);
+                getOriginal().super_onSupportActionModeStarted((ActionMode) args[0]);
             }
         }, mode);
     }
@@ -3497,7 +3493,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onSupportContentChanged__super();
+                getOriginal().super_onSupportContentChanged();
             }
         });
     }
@@ -3514,7 +3510,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onSupportNavigateUp__super();
+                return getOriginal().super_onSupportNavigateUp();
             }
         });
     }
@@ -3529,7 +3525,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onTitleChanged__super((CharSequence) args[0], (int) args[1]);
+                getOriginal().super_onTitleChanged((CharSequence) args[0], (int) args[1]);
             }
         }, title, color);
     }
@@ -3546,7 +3542,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().onTouchEvent__super((MotionEvent) args[0]);
+                return getOriginal().super_onTouchEvent((MotionEvent) args[0]);
             }
         }, event);
     }
@@ -3564,7 +3560,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onTrackballEvent__super((MotionEvent) args[0]);
+                        return getOriginal().super_onTrackballEvent((MotionEvent) args[0]);
                     }
                 }, event);
     }
@@ -3579,7 +3575,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onTrimMemory__super((int) args[0]);
+                getOriginal().super_onTrimMemory((int) args[0]);
             }
         }, level);
     }
@@ -3594,7 +3590,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onUserInteraction__super();
+                getOriginal().super_onUserInteraction();
             }
         });
     }
@@ -3609,7 +3605,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onUserLeaveHint__super();
+                getOriginal().super_onUserLeaveHint();
             }
         });
     }
@@ -3624,7 +3620,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onVisibleBehindCanceled__super();
+                getOriginal().super_onVisibleBehindCanceled();
             }
         });
     }
@@ -3641,7 +3637,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onWindowAttributesChanged__super(
+                        getOriginal().super_onWindowAttributesChanged(
                                 (WindowManager.LayoutParams) args[0]);
                     }
                 }, params);
@@ -3657,7 +3653,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onWindowFocusChanged__super((boolean) args[0]);
+                getOriginal().super_onWindowFocusChanged((boolean) args[0]);
             }
         }, hasFocus);
     }
@@ -3678,7 +3674,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<android.view.ActionMode>() {
                     @Override
                     public android.view.ActionMode call(final Object... args) {
-                        return getOriginal().onWindowStartingActionMode__super(
+                        return getOriginal().super_onWindowStartingActionMode(
                                 (android.view.ActionMode.Callback) args[0]);
                     }
                 }, callback);
@@ -3700,7 +3696,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<android.view.ActionMode>() {
                     @Override
                     public android.view.ActionMode call(final Object... args) {
-                        return getOriginal().onWindowStartingActionMode__super(
+                        return getOriginal().super_onWindowStartingActionMode(
                                 (android.view.ActionMode.Callback) args[0], (int) args[1]);
                     }
                 }, callback, type);
@@ -3721,7 +3717,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<ActionMode>() {
                     @Override
                     public ActionMode call(final Object... args) {
-                        return getOriginal().onWindowStartingSupportActionMode__super(
+                        return getOriginal().super_onWindowStartingSupportActionMode(
                                 (ActionMode.Callback) args[0]);
                     }
                 }, callback);
@@ -3737,7 +3733,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().openContextMenu__super((View) args[0]);
+                getOriginal().super_openContextMenu((View) args[0]);
             }
         }, view);
     }
@@ -3759,7 +3755,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public FileInputStream call(final Object... args) {
                         try {
-                            return getOriginal().openFileInput__super((String) args[0]);
+                            return getOriginal().super_openFileInput((String) args[0]);
                         } catch (FileNotFoundException e) {
                             throw new SuppressedException(e);
                         }
@@ -3786,7 +3782,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     public FileOutputStream call(final Object... args) {
                         try {
                             return getOriginal()
-                                    .openFileOutput__super((String) args[0], (int) args[1]);
+                                    .super_openFileOutput((String) args[0], (int) args[1]);
                         } catch (FileNotFoundException e) {
                             throw new SuppressedException(e);
                         }
@@ -3804,7 +3800,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().openOptionsMenu__super();
+                getOriginal().super_openOptionsMenu();
             }
         });
     }
@@ -3826,7 +3822,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public SQLiteDatabase call(final Object... args) {
                         return getOriginal()
-                                .openOrCreateDatabase__super((String) args[0], (int) args[1],
+                                .super_openOrCreateDatabase((String) args[0], (int) args[1],
                                         (SQLiteDatabase.CursorFactory) args[2]);
                     }
                 }, name, mode, factory);
@@ -3851,7 +3847,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public SQLiteDatabase call(final Object... args) {
                         return getOriginal()
-                                .openOrCreateDatabase__super((String) args[0], (int) args[1],
+                                .super_openOrCreateDatabase((String) args[0], (int) args[1],
                                         (SQLiteDatabase.CursorFactory) args[2],
                                         (DatabaseErrorHandler) args[3]);
                     }
@@ -3868,7 +3864,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().overridePendingTransition__super((int) args[0], (int) args[1]);
+                getOriginal().super_overridePendingTransition((int) args[0], (int) args[1]);
             }
         }, enterAnim, exitAnim);
     }
@@ -3885,7 +3881,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Drawable>() {
             @Override
             public Drawable call(final Object... args) {
-                return getOriginal().peekWallpaper__super();
+                return getOriginal().super_peekWallpaper();
             }
         });
     }
@@ -3900,7 +3896,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().postponeEnterTransition__super();
+                getOriginal().super_postponeEnterTransition();
             }
         });
     }
@@ -3915,7 +3911,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().recreate__super();
+                getOriginal().super_recreate();
             }
         });
     }
@@ -3932,7 +3928,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .registerComponentCallbacks__super((ComponentCallbacks) args[0]);
+                                .super_registerComponentCallbacks((ComponentCallbacks) args[0]);
                     }
                 }, callback);
     }
@@ -3947,7 +3943,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().registerForContextMenu__super((View) args[0]);
+                getOriginal().super_registerForContextMenu((View) args[0]);
             }
         }, view);
     }
@@ -3966,7 +3962,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Intent>() {
                     @Override
                     public Intent call(final Object... args) {
-                        return getOriginal().registerReceiver__super((BroadcastReceiver) args[0],
+                        return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
                                 (IntentFilter) args[1]);
                     }
                 }, receiver, filter);
@@ -3987,7 +3983,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Intent>() {
                     @Override
                     public Intent call(final Object... args) {
-                        return getOriginal().registerReceiver__super((BroadcastReceiver) args[0],
+                        return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
                                 (IntentFilter) args[1], (String) args[2], (Handler) args[3]);
                     }
                 }, receiver, filter, broadcastPermission, scheduler);
@@ -4005,7 +4001,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().releaseInstance__super();
+                return getOriginal().super_releaseInstance();
             }
         });
     }
@@ -4020,7 +4016,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().removeStickyBroadcast__super((Intent) args[0]);
+                getOriginal().super_removeStickyBroadcast((Intent) args[0]);
             }
         }, intent);
     }
@@ -4037,7 +4033,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().removeStickyBroadcastAsUser__super((Intent) args[0],
+                        getOriginal().super_removeStickyBroadcastAsUser((Intent) args[0],
                                 (UserHandle) args[1]);
                     }
                 }, intent, user);
@@ -4053,7 +4049,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().reportFullyDrawn__super();
+                getOriginal().super_reportFullyDrawn();
             }
         });
     }
@@ -4071,7 +4067,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().requestVisibleBehind__super((boolean) args[0]);
+                        return getOriginal().super_requestVisibleBehind((boolean) args[0]);
                     }
                 }, visible);
     }
@@ -4086,7 +4082,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().revokeUriPermission__super((Uri) args[0], (int) args[1]);
+                getOriginal().super_revokeUriPermission((Uri) args[0], (int) args[1]);
             }
         }, uri, modeFlags);
     }
@@ -4101,7 +4097,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().sendBroadcast__super((Intent) args[0]);
+                getOriginal().super_sendBroadcast((Intent) args[0]);
             }
         }, intent);
     }
@@ -4116,7 +4112,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().sendBroadcast__super((Intent) args[0], (String) args[1]);
+                getOriginal().super_sendBroadcast((Intent) args[0], (String) args[1]);
             }
         }, intent, receiverPermission);
     }
@@ -4131,7 +4127,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().sendBroadcastAsUser__super((Intent) args[0], (UserHandle) args[1]);
+                getOriginal().super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1]);
             }
         }, intent, user);
     }
@@ -4150,7 +4146,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .sendBroadcastAsUser__super((Intent) args[0], (UserHandle) args[1],
+                                .super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1],
                                         (String) args[2]);
                     }
                 }, intent, user, receiverPermission);
@@ -4166,7 +4162,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().sendOrderedBroadcast__super((Intent) args[0], (String) args[1]);
+                getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1]);
             }
         }, intent, receiverPermission);
     }
@@ -4187,10 +4183,9 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal()
-                                .sendOrderedBroadcast__super((Intent) args[0], (String) args[1],
-                                        (BroadcastReceiver) args[2], (Handler) args[3],
-                                        (int) args[4], (String) args[5], (Bundle) args[6]);
+                        getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1],
+                                (BroadcastReceiver) args[2], (Handler) args[3], (int) args[4],
+                                (String) args[5], (Bundle) args[6]);
                     }
                 }, intent, receiverPermission, resultReceiver, scheduler, initialCode, initialData,
                 initialExtras);
@@ -4214,7 +4209,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().sendOrderedBroadcastAsUser__super((Intent) args[0],
+                        getOriginal().super_sendOrderedBroadcastAsUser((Intent) args[0],
                                 (UserHandle) args[1], (String) args[2], (BroadcastReceiver) args[3],
                                 (Handler) args[4], (int) args[5], (String) args[6],
                                 (Bundle) args[7]);
@@ -4233,7 +4228,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().sendStickyBroadcast__super((Intent) args[0]);
+                getOriginal().super_sendStickyBroadcast((Intent) args[0]);
             }
         }, intent);
     }
@@ -4250,7 +4245,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().sendStickyBroadcastAsUser__super((Intent) args[0],
+                        getOriginal().super_sendStickyBroadcastAsUser((Intent) args[0],
                                 (UserHandle) args[1]);
                     }
                 }, intent, user);
@@ -4272,7 +4267,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().sendStickyOrderedBroadcast__super((Intent) args[0],
+                        getOriginal().super_sendStickyOrderedBroadcast((Intent) args[0],
                                 (BroadcastReceiver) args[1], (Handler) args[2], (int) args[3],
                                 (String) args[4], (Bundle) args[5]);
                     }
@@ -4296,7 +4291,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().sendStickyOrderedBroadcastAsUser__super((Intent) args[0],
+                        getOriginal().super_sendStickyOrderedBroadcastAsUser((Intent) args[0],
                                 (UserHandle) args[1], (BroadcastReceiver) args[2],
                                 (Handler) args[3], (int) args[4], (String) args[5],
                                 (Bundle) args[6]);
@@ -4315,7 +4310,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setActionBar__super((Toolbar) args[0]);
+                getOriginal().super_setActionBar((Toolbar) args[0]);
             }
         }, toolbar);
     }
@@ -4332,7 +4327,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .setContentTransitionManager__super((TransitionManager) args[0]);
+                                .super_setContentTransitionManager((TransitionManager) args[0]);
                     }
                 }, tm);
     }
@@ -4347,7 +4342,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setContentView__super((int) args[0]);
+                getOriginal().super_setContentView((int) args[0]);
             }
         }, layoutResID);
     }
@@ -4362,7 +4357,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setContentView__super((View) args[0]);
+                getOriginal().super_setContentView((View) args[0]);
             }
         }, view);
     }
@@ -4379,7 +4374,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setContentView__super((View) args[0],
+                        getOriginal().super_setContentView((View) args[0],
                                 (ViewGroup.LayoutParams) args[1]);
                     }
                 }, view, params);
@@ -4397,7 +4392,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setEnterSharedElementCallback__super(
+                        getOriginal().super_setEnterSharedElementCallback(
                                 (SharedElementCallback) args[0]);
                     }
                 }, callback);
@@ -4415,7 +4410,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setEnterSharedElementCallback__super(
+                        getOriginal().super_setEnterSharedElementCallback(
                                 (android.app.SharedElementCallback) args[0]);
                     }
                 }, callback);
@@ -4433,7 +4428,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setExitSharedElementCallback__super(
+                        getOriginal().super_setExitSharedElementCallback(
                                 (SharedElementCallback) args[0]);
                     }
                 }, listener);
@@ -4451,7 +4446,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setExitSharedElementCallback__super(
+                        getOriginal().super_setExitSharedElementCallback(
                                 (android.app.SharedElementCallback) args[0]);
                     }
                 }, callback);
@@ -4467,7 +4462,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setFinishOnTouchOutside__super((boolean) args[0]);
+                getOriginal().super_setFinishOnTouchOutside((boolean) args[0]);
             }
         }, finish);
     }
@@ -4482,7 +4477,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setImmersive__super((boolean) args[0]);
+                getOriginal().super_setImmersive((boolean) args[0]);
             }
         }, i);
     }
@@ -4497,7 +4492,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setIntent__super((Intent) args[0]);
+                getOriginal().super_setIntent((Intent) args[0]);
             }
         }, newIntent);
     }
@@ -4512,7 +4507,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setRequestedOrientation__super((int) args[0]);
+                getOriginal().super_setRequestedOrientation((int) args[0]);
             }
         }, requestedOrientation);
     }
@@ -4529,7 +4524,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setSupportActionBar__super(
+                        getOriginal().super_setSupportActionBar(
                                 (android.support.v7.widget.Toolbar) args[0]);
                     }
                 }, toolbar);
@@ -4545,7 +4540,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setSupportProgress__super((int) args[0]);
+                getOriginal().super_setSupportProgress((int) args[0]);
             }
         }, progress);
     }
@@ -4561,7 +4556,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setSupportProgressBarIndeterminate__super((boolean) args[0]);
+                        getOriginal().super_setSupportProgressBarIndeterminate((boolean) args[0]);
                     }
                 }, indeterminate);
     }
@@ -4578,7 +4573,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setSupportProgressBarIndeterminateVisibility__super(
+                        getOriginal().super_setSupportProgressBarIndeterminateVisibility(
                                 (boolean) args[0]);
                     }
                 }, visible);
@@ -4594,7 +4589,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setSupportProgressBarVisibility__super((boolean) args[0]);
+                getOriginal().super_setSupportProgressBarVisibility((boolean) args[0]);
             }
         }, visible);
     }
@@ -4611,7 +4606,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setTaskDescription__super(
+                        getOriginal().super_setTaskDescription(
                                 (ActivityManager.TaskDescription) args[0]);
                     }
                 }, taskDescription);
@@ -4627,7 +4622,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setTheme__super((int) args[0]);
+                getOriginal().super_setTheme((int) args[0]);
             }
         }, resid);
     }
@@ -4642,7 +4637,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setTitle__super((CharSequence) args[0]);
+                getOriginal().super_setTitle((CharSequence) args[0]);
             }
         }, title);
     }
@@ -4657,7 +4652,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setTitle__super((int) args[0]);
+                getOriginal().super_setTitle((int) args[0]);
             }
         }, titleId);
     }
@@ -4672,7 +4667,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setTitleColor__super((int) args[0]);
+                getOriginal().super_setTitleColor((int) args[0]);
             }
         }, textColor);
     }
@@ -4687,7 +4682,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setVisible__super((boolean) args[0]);
+                getOriginal().super_setVisible((boolean) args[0]);
             }
         }, visible);
     }
@@ -4707,7 +4702,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             @Override
             public void call(final Object... args) {
                 try {
-                    getOriginal().setWallpaper__super((Bitmap) args[0]);
+                    getOriginal().super_setWallpaper((Bitmap) args[0]);
                 } catch (IOException e) {
                     throw new SuppressedException(e);
                 }
@@ -4730,7 +4725,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             @Override
             public void call(final Object... args) {
                 try {
-                    getOriginal().setWallpaper__super((InputStream) args[0]);
+                    getOriginal().super_setWallpaper((InputStream) args[0]);
                 } catch (IOException e) {
                     throw new SuppressedException(e);
                 }
@@ -4753,7 +4748,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .shouldShowRequestPermissionRationale__super((String) args[0]);
+                                .super_shouldShowRequestPermissionRationale((String) args[0]);
                     }
                 }, permission);
     }
@@ -4771,7 +4766,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().shouldUpRecreateTask__super((Intent) args[0]);
+                        return getOriginal().super_shouldUpRecreateTask((Intent) args[0]);
                     }
                 }, targetIntent);
     }
@@ -4788,7 +4783,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().showAssist__super((Bundle) args[0]);
+                return getOriginal().super_showAssist((Bundle) args[0]);
             }
         }, args);
     }
@@ -4803,7 +4798,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().showLockTaskEscapeMessage__super();
+                getOriginal().super_showLockTaskEscapeMessage();
             }
         });
     }
@@ -4825,7 +4820,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public android.view.ActionMode call(final Object... args) {
                         return getOriginal()
-                                .startActionMode__super((android.view.ActionMode.Callback) args[0]);
+                                .super_startActionMode((android.view.ActionMode.Callback) args[0]);
                     }
                 }, callback);
     }
@@ -4847,7 +4842,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public android.view.ActionMode call(final Object... args) {
                         return getOriginal()
-                                .startActionMode__super((android.view.ActionMode.Callback) args[0],
+                                .super_startActionMode((android.view.ActionMode.Callback) args[0],
                                         (int) args[1]);
                     }
                 }, callback, type);
@@ -4863,7 +4858,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivities__super((Intent[]) args[0]);
+                getOriginal().super_startActivities((Intent[]) args[0]);
             }
         }, new Object[]{intents});
     }
@@ -4878,7 +4873,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivities__super((Intent[]) args[0], (Bundle) args[1]);
+                getOriginal().super_startActivities((Intent[]) args[0], (Bundle) args[1]);
             }
         }, intents, options);
     }
@@ -4893,7 +4888,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivity__super((Intent) args[0]);
+                getOriginal().super_startActivity((Intent) args[0]);
             }
         }, intent);
     }
@@ -4908,7 +4903,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivity__super((Intent) args[0], (Bundle) args[1]);
+                getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
             }
         }, intent, options);
     }
@@ -4923,7 +4918,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivityForResult__super((Intent) args[0], (int) args[1]);
+                getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
             }
         }, intent, requestCode);
     }
@@ -4941,7 +4936,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().startActivityForResult__super((Intent) args[0], (int) args[1],
+                        getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
                                 (Bundle) args[2]);
                     }
                 }, intent, requestCode, options);
@@ -4961,7 +4956,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .startActivityFromChild__super((Activity) args[0], (Intent) args[1],
+                                .super_startActivityFromChild((Activity) args[0], (Intent) args[1],
                                         (int) args[2]);
                     }
                 }, child, intent, requestCode);
@@ -4981,7 +4976,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .startActivityFromChild__super((Activity) args[0], (Intent) args[1],
+                                .super_startActivityFromChild((Activity) args[0], (Intent) args[1],
                                         (int) args[2], (Bundle) args[3]);
                     }
                 }, child, intent, requestCode, options);
@@ -5000,7 +4995,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().startActivityFromFragment__super((Fragment) args[0],
+                        getOriginal().super_startActivityFromFragment((Fragment) args[0],
                                 (Intent) args[1], (int) args[2]);
                     }
                 }, fragment, intent, requestCode);
@@ -5019,7 +5014,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().startActivityFromFragment__super((Fragment) args[0],
+                        getOriginal().super_startActivityFromFragment((Fragment) args[0],
                                 (Intent) args[1], (int) args[2], (Bundle) args[3]);
                     }
                 }, fragment, intent, requestCode, options);
@@ -5039,7 +5034,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .startActivityFromFragment__super((android.app.Fragment) args[0],
+                                .super_startActivityFromFragment((android.app.Fragment) args[0],
                                         (Intent) args[1], (int) args[2]);
                     }
                 }, fragment, intent, requestCode);
@@ -5059,7 +5054,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .startActivityFromFragment__super((android.app.Fragment) args[0],
+                                .super_startActivityFromFragment((android.app.Fragment) args[0],
                                         (Intent) args[1], (int) args[2], (Bundle) args[3]);
                     }
                 }, fragment, intent, requestCode, options);
@@ -5080,7 +5075,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .startActivityIfNeeded__super((Intent) args[0], (int) args[1]);
+                                .super_startActivityIfNeeded((Intent) args[0], (int) args[1]);
                     }
                 }, intent, requestCode);
     }
@@ -5102,7 +5097,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .startActivityIfNeeded__super((Intent) args[0], (int) args[1],
+                                .super_startActivityIfNeeded((Intent) args[0], (int) args[1],
                                         (Bundle) args[2]);
                     }
                 }, intent, requestCode, options);
@@ -5123,7 +5118,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().startInstrumentation__super((ComponentName) args[0],
+                        return getOriginal().super_startInstrumentation((ComponentName) args[0],
                                 (String) args[1], (Bundle) args[2]);
                     }
                 }, className, profileFile, arguments);
@@ -5148,7 +5143,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         try {
-                            getOriginal().startIntentSender__super((IntentSender) args[0],
+                            getOriginal().super_startIntentSender((IntentSender) args[0],
                                     (Intent) args[1], (int) args[2], (int) args[3], (int) args[4]);
                         } catch (IntentSender.SendIntentException e) {
                             throw new SuppressedException(e);
@@ -5177,7 +5172,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         try {
-                            getOriginal().startIntentSender__super((IntentSender) args[0],
+                            getOriginal().super_startIntentSender((IntentSender) args[0],
                                     (Intent) args[1], (int) args[2], (int) args[3], (int) args[4],
                                     (Bundle) args[5]);
                         } catch (IntentSender.SendIntentException e) {
@@ -5207,7 +5202,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         try {
-                            getOriginal().startIntentSenderForResult__super((IntentSender) args[0],
+                            getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
                                     (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
                                     (int) args[5]);
                         } catch (IntentSender.SendIntentException e) {
@@ -5237,7 +5232,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         try {
-                            getOriginal().startIntentSenderForResult__super((IntentSender) args[0],
+                            getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
                                     (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
                                     (int) args[5], (Bundle) args[6]);
                         } catch (IntentSender.SendIntentException e) {
@@ -5267,7 +5262,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         try {
-                            getOriginal().startIntentSenderFromChild__super((Activity) args[0],
+                            getOriginal().super_startIntentSenderFromChild((Activity) args[0],
                                     (IntentSender) args[1], (int) args[2], (Intent) args[3],
                                     (int) args[4], (int) args[5], (int) args[6]);
                         } catch (IntentSender.SendIntentException e) {
@@ -5299,7 +5294,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         try {
-                            getOriginal().startIntentSenderFromChild__super((Activity) args[0],
+                            getOriginal().super_startIntentSenderFromChild((Activity) args[0],
                                     (IntentSender) args[1], (int) args[2], (Intent) args[3],
                                     (int) args[4], (int) args[5], (int) args[6], (Bundle) args[7]);
                         } catch (IntentSender.SendIntentException e) {
@@ -5320,7 +5315,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startLockTask__super();
+                getOriginal().super_startLockTask();
             }
         });
     }
@@ -5335,7 +5330,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startManagingCursor__super((Cursor) args[0]);
+                getOriginal().super_startManagingCursor((Cursor) args[0]);
             }
         }, c);
     }
@@ -5353,7 +5348,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().startNextMatchingActivity__super((Intent) args[0]);
+                        return getOriginal().super_startNextMatchingActivity((Intent) args[0]);
                     }
                 }, intent);
     }
@@ -5372,7 +5367,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().startNextMatchingActivity__super((Intent) args[0],
+                        return getOriginal().super_startNextMatchingActivity((Intent) args[0],
                                 (Bundle) args[1]);
                     }
                 }, intent, options);
@@ -5388,7 +5383,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startPostponedEnterTransition__super();
+                getOriginal().super_startPostponedEnterTransition();
             }
         });
     }
@@ -5406,7 +5401,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().startSearch__super((String) args[0], (boolean) args[1],
+                        getOriginal().super_startSearch((String) args[0], (boolean) args[1],
                                 (Bundle) args[2], (boolean) args[3]);
                     }
                 }, initialQuery, selectInitialQuery, appSearchData, globalSearch);
@@ -5425,7 +5420,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<ComponentName>() {
                     @Override
                     public ComponentName call(final Object... args) {
-                        return getOriginal().startService__super((Intent) args[0]);
+                        return getOriginal().super_startService((Intent) args[0]);
                     }
                 }, service);
     }
@@ -5445,7 +5440,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public ActionMode call(final Object... args) {
                         return getOriginal()
-                                .startSupportActionMode__super((ActionMode.Callback) args[0]);
+                                .super_startSupportActionMode((ActionMode.Callback) args[0]);
                     }
                 }, callback);
     }
@@ -5460,7 +5455,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().stopLockTask__super();
+                getOriginal().super_stopLockTask();
             }
         });
     }
@@ -5475,7 +5470,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().stopManagingCursor__super((Cursor) args[0]);
+                getOriginal().super_stopManagingCursor((Cursor) args[0]);
             }
         }, c);
     }
@@ -5492,7 +5487,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().stopService__super((Intent) args[0]);
+                return getOriginal().super_stopService((Intent) args[0]);
             }
         }, name);
     }
@@ -5507,7 +5502,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().supportFinishAfterTransition__super();
+                getOriginal().super_supportFinishAfterTransition();
             }
         });
     }
@@ -5522,7 +5517,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().supportInvalidateOptionsMenu__super();
+                getOriginal().super_supportInvalidateOptionsMenu();
             }
         });
     }
@@ -5537,7 +5532,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().supportNavigateUpTo__super((Intent) args[0]);
+                getOriginal().super_supportNavigateUpTo((Intent) args[0]);
             }
         }, upIntent);
     }
@@ -5552,7 +5547,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().supportPostponeEnterTransition__super();
+                getOriginal().super_supportPostponeEnterTransition();
             }
         });
     }
@@ -5570,7 +5565,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().supportRequestWindowFeature__super((int) args[0]);
+                        return getOriginal().super_supportRequestWindowFeature((int) args[0]);
                     }
                 }, featureId);
     }
@@ -5588,7 +5583,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().supportShouldUpRecreateTask__super((Intent) args[0]);
+                        return getOriginal().super_supportShouldUpRecreateTask((Intent) args[0]);
                     }
                 }, targetIntent);
     }
@@ -5603,7 +5598,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().supportStartPostponedEnterTransition__super();
+                getOriginal().super_supportStartPostponedEnterTransition();
             }
         });
     }
@@ -5618,7 +5613,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().takeKeyEvents__super((boolean) args[0]);
+                getOriginal().super_takeKeyEvents((boolean) args[0]);
             }
         }, get);
     }
@@ -5633,7 +5628,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().triggerSearch__super((String) args[0], (Bundle) args[1]);
+                getOriginal().super_triggerSearch((String) args[0], (Bundle) args[1]);
             }
         }, query, appSearchData);
     }
@@ -5648,7 +5643,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().unbindService__super((ServiceConnection) args[0]);
+                getOriginal().super_unbindService((ServiceConnection) args[0]);
             }
         }, conn);
     }
@@ -5666,7 +5661,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .unregisterComponentCallbacks__super((ComponentCallbacks) args[0]);
+                                .super_unregisterComponentCallbacks((ComponentCallbacks) args[0]);
                     }
                 }, callback);
     }
@@ -5681,7 +5676,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().unregisterForContextMenu__super((View) args[0]);
+                getOriginal().super_unregisterForContextMenu((View) args[0]);
             }
         }, view);
     }
@@ -5696,7 +5691,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().unregisterReceiver__super((BroadcastReceiver) args[0]);
+                getOriginal().super_unregisterReceiver((BroadcastReceiver) args[0]);
             }
         }, receiver);
     }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/CompositeActivity.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/CompositeActivity.java
@@ -104,10 +104,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.addContentView(view, params);
     }
 
-    public void addContentView__super(final View view, final ViewGroup.LayoutParams params) {
-        super.addContentView(view, params);
-    }
-
     public Removable addPlugin(final ActivityPlugin plugin) {
         return delegate.addPlugin(plugin);
     }
@@ -127,17 +123,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.applyOverrideConfiguration(overrideConfiguration);
     }
 
-    public void applyOverrideConfiguration__super(final Configuration overrideConfiguration) {
-        super.applyOverrideConfiguration(overrideConfiguration);
-    }
-
     @Override
     public void attachBaseContext(final Context newBase) {
         delegate.attachBaseContext(newBase);
-    }
-
-    public void attachBaseContext__super(final Context newBase) {
-        super.attachBaseContext(newBase);
     }
 
     @Override
@@ -146,18 +134,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.bindService(service, conn, flags);
     }
 
-    public boolean bindService__super(final Intent service, final ServiceConnection conn,
-            final int flags) {
-        return super.bindService(service, conn, flags);
-    }
-
     @Override
     public int checkCallingOrSelfPermission(final String permission) {
         return delegate.checkCallingOrSelfPermission(permission);
-    }
-
-    public int checkCallingOrSelfPermission__super(final String permission) {
-        return super.checkCallingOrSelfPermission(permission);
     }
 
     @Override
@@ -165,17 +144,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.checkCallingOrSelfUriPermission(uri, modeFlags);
     }
 
-    public int checkCallingOrSelfUriPermission__super(final Uri uri, final int modeFlags) {
-        return super.checkCallingOrSelfUriPermission(uri, modeFlags);
-    }
-
     @Override
     public int checkCallingPermission(final String permission) {
         return delegate.checkCallingPermission(permission);
-    }
-
-    public int checkCallingPermission__super(final String permission) {
-        return super.checkCallingPermission(permission);
     }
 
     @Override
@@ -183,26 +154,14 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.checkCallingUriPermission(uri, modeFlags);
     }
 
-    public int checkCallingUriPermission__super(final Uri uri, final int modeFlags) {
-        return super.checkCallingUriPermission(uri, modeFlags);
-    }
-
     @Override
     public int checkPermission(final String permission, final int pid, final int uid) {
         return delegate.checkPermission(permission, pid, uid);
     }
 
-    public int checkPermission__super(final String permission, final int pid, final int uid) {
-        return super.checkPermission(permission, pid, uid);
-    }
-
     @Override
     public int checkSelfPermission(final String permission) {
         return delegate.checkSelfPermission(permission);
-    }
-
-    public int checkSelfPermission__super(final String permission) {
-        return super.checkSelfPermission(permission);
     }
 
     @Override
@@ -218,16 +177,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
                 .checkUriPermission(uri, readPermission, writePermission, pid, uid, modeFlags);
     }
 
-    public int checkUriPermission__super(final Uri uri, final int pid, final int uid,
-            final int modeFlags) {
-        return super.checkUriPermission(uri, pid, uid, modeFlags);
-    }
-
-    public int checkUriPermission__super(final Uri uri, final String readPermission,
-            final String writePermission, final int pid, final int uid, final int modeFlags) {
-        return super.checkUriPermission(uri, readPermission, writePermission, pid, uid, modeFlags);
-    }
-
     @Override
     public void clearWallpaper() throws IOException {
         try {
@@ -237,20 +186,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         }
     }
 
-    public void clearWallpaper__super() throws IOException {
-        super.clearWallpaper();
-    }
-
     /**
      * Programmatically closes the most recently opened context menu, if showing.
      */
     @Override
     public void closeContextMenu() {
         delegate.closeContextMenu();
-    }
-
-    public void closeContextMenu__super() {
-        super.closeContextMenu();
     }
 
     /**
@@ -262,26 +203,14 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.closeOptionsMenu();
     }
 
-    public void closeOptionsMenu__super() {
-        super.closeOptionsMenu();
-    }
-
     @Override
     public Context createConfigurationContext(final Configuration overrideConfiguration) {
         return delegate.createConfigurationContext(overrideConfiguration);
     }
 
-    public Context createConfigurationContext__super(final Configuration overrideConfiguration) {
-        return super.createConfigurationContext(overrideConfiguration);
-    }
-
     @Override
     public Context createDisplayContext(final Display display) {
         return delegate.createDisplayContext(display);
-    }
-
-    public Context createDisplayContext__super(final Display display) {
-        return super.createDisplayContext(display);
     }
 
     @Override
@@ -292,11 +221,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         } catch (SuppressedException e) {
             throw (PackageManager.NameNotFoundException) e.getCause();
         }
-    }
-
-    public Context createPackageContext__super(final String packageName, final int flags)
-            throws PackageManager.NameNotFoundException {
-        return super.createPackageContext(packageName, flags);
     }
 
     /**
@@ -330,18 +254,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.createPendingResult(requestCode, data, flags);
     }
 
-    public PendingIntent createPendingResult__super(final int requestCode, final Intent data,
-            final int flags) {
-        return super.createPendingResult(requestCode, data, flags);
-    }
-
     @Override
     public String[] databaseList() {
         return delegate.databaseList();
-    }
-
-    public String[] databaseList__super() {
-        return super.databaseList();
     }
 
     @Override
@@ -349,17 +264,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.deleteDatabase(name);
     }
 
-    public boolean deleteDatabase__super(final String name) {
-        return super.deleteDatabase(name);
-    }
-
     @Override
     public boolean deleteFile(final String name) {
         return delegate.deleteFile(name);
-    }
-
-    public boolean deleteFile__super(final String name) {
-        return super.deleteFile(name);
     }
 
     /**
@@ -376,17 +283,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.dispatchGenericMotionEvent(ev);
     }
 
-    public boolean dispatchGenericMotionEvent__super(final MotionEvent ev) {
-        return super.dispatchGenericMotionEvent(ev);
-    }
-
     @Override
     public boolean dispatchKeyEvent(final KeyEvent event) {
         return delegate.dispatchKeyEvent(event);
-    }
-
-    public boolean dispatchKeyEvent__super(final KeyEvent event) {
-        return super.dispatchKeyEvent(event);
     }
 
     /**
@@ -403,17 +302,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.dispatchKeyShortcutEvent(event);
     }
 
-    public boolean dispatchKeyShortcutEvent__super(final KeyEvent event) {
-        return super.dispatchKeyShortcutEvent(event);
-    }
-
     @Override
     public boolean dispatchPopulateAccessibilityEvent(final AccessibilityEvent event) {
         return delegate.dispatchPopulateAccessibilityEvent(event);
-    }
-
-    public boolean dispatchPopulateAccessibilityEvent__super(final AccessibilityEvent event) {
-        return super.dispatchPopulateAccessibilityEvent(event);
     }
 
     /**
@@ -430,10 +321,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.dispatchTouchEvent(ev);
     }
 
-    public boolean dispatchTouchEvent__super(final MotionEvent ev) {
-        return super.dispatchTouchEvent(ev);
-    }
-
     /**
      * Called to process trackball events.  You can override this to
      * intercept all trackball events before they are dispatched to the
@@ -446,10 +333,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean dispatchTrackballEvent(final MotionEvent ev) {
         return delegate.dispatchTrackballEvent(ev);
-    }
-
-    public boolean dispatchTrackballEvent__super(final MotionEvent ev) {
-        return super.dispatchTrackballEvent(ev);
     }
 
     /**
@@ -468,19 +351,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.dump(prefix, fd, writer, args);
     }
 
-    public void dump__super(final String prefix, final FileDescriptor fd, final PrintWriter writer,
-            final String[] args) {
-        super.dump(prefix, fd, writer, args);
-    }
-
     @Override
     public void enforceCallingOrSelfPermission(final String permission, final String message) {
         delegate.enforceCallingOrSelfPermission(permission, message);
-    }
-
-    public void enforceCallingOrSelfPermission__super(final String permission,
-            final String message) {
-        super.enforceCallingOrSelfPermission(permission, message);
     }
 
     @Override
@@ -489,18 +362,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.enforceCallingOrSelfUriPermission(uri, modeFlags, message);
     }
 
-    public void enforceCallingOrSelfUriPermission__super(final Uri uri, final int modeFlags,
-            final String message) {
-        super.enforceCallingOrSelfUriPermission(uri, modeFlags, message);
-    }
-
     @Override
     public void enforceCallingPermission(final String permission, final String message) {
         delegate.enforceCallingPermission(permission, message);
-    }
-
-    public void enforceCallingPermission__super(final String permission, final String message) {
-        super.enforceCallingPermission(permission, message);
     }
 
     @Override
@@ -509,20 +373,10 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.enforceCallingUriPermission(uri, modeFlags, message);
     }
 
-    public void enforceCallingUriPermission__super(final Uri uri, final int modeFlags,
-            final String message) {
-        super.enforceCallingUriPermission(uri, modeFlags, message);
-    }
-
     @Override
     public void enforcePermission(final String permission, final int pid, final int uid,
             final String message) {
         delegate.enforcePermission(permission, pid, uid, message);
-    }
-
-    public void enforcePermission__super(final String permission, final int pid, final int uid,
-            final String message) {
-        super.enforcePermission(permission, pid, uid, message);
     }
 
     @Override
@@ -539,36 +393,15 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
                 message);
     }
 
-    public void enforceUriPermission__super(final Uri uri, final int pid, final int uid,
-            final int modeFlags, final String message) {
-        super.enforceUriPermission(uri, pid, uid, modeFlags, message);
-    }
-
-    public void enforceUriPermission__super(final Uri uri, final String readPermission,
-            final String writePermission, final int pid, final int uid, final int modeFlags,
-            final String message) {
-        super.enforceUriPermission(uri, readPermission, writePermission, pid, uid, modeFlags,
-                message);
-    }
-
     @Override
     public String[] fileList() {
         return delegate.fileList();
-    }
-
-    public String[] fileList__super() {
-        return super.fileList();
     }
 
     @Nullable
     @Override
     public View findViewById(@IdRes final int id) {
         return delegate.findViewById(id);
-    }
-
-    @Nullable
-    public View findViewById__super(@IdRes final int id) {
-        return super.findViewById(id);
     }
 
     /**
@@ -607,14 +440,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.finishActivityFromChild(child, requestCode);
     }
 
-    public void finishActivityFromChild__super(final Activity child, final int requestCode) {
-        super.finishActivityFromChild(child, requestCode);
-    }
-
-    public void finishActivity__super(final int requestCode) {
-        super.finishActivity(requestCode);
-    }
-
     /**
      * Finish this activity as well as all activities immediately below it
      * in the current task that have the same affinity.  This is typically
@@ -634,10 +459,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.finishAffinity();
     }
 
-    public void finishAffinity__super() {
-        super.finishAffinity();
-    }
-
     /**
      * Reverses the Activity Scene entry Transition and triggers the calling Activity
      * to reverse its exit Transition. When the exit Transition completes,
@@ -651,10 +472,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.finishAfterTransition();
     }
 
-    public void finishAfterTransition__super() {
-        super.finishAfterTransition();
-    }
-
     /**
      * Call this when your activity is done and should be closed and the task should be completely
      * removed as a part of finishing the Activity.
@@ -662,10 +479,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void finishAndRemoveTask() {
         delegate.finishAndRemoveTask();
-    }
-
-    public void finishAndRemoveTask__super() {
-        super.finishAndRemoveTask();
     }
 
     /**
@@ -681,14 +494,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.finishFromChild(child);
     }
 
-    public void finishFromChild__super(final Activity child) {
-        super.finishFromChild(child);
-    }
-
-    public void finish__super() {
-        super.finish();
-    }
-
     /**
      * Retrieve a reference to this activity's ActionBar.
      *
@@ -700,18 +505,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getActionBar();
     }
 
-    @Nullable
-    public android.app.ActionBar getActionBar__super() {
-        return super.getActionBar();
-    }
-
     @Override
     public Context getApplicationContext() {
         return delegate.getApplicationContext();
-    }
-
-    public Context getApplicationContext__super() {
-        return super.getApplicationContext();
     }
 
     @Override
@@ -719,17 +515,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getApplicationInfo();
     }
 
-    public ApplicationInfo getApplicationInfo__super() {
-        return super.getApplicationInfo();
-    }
-
     @Override
     public AssetManager getAssets() {
         return delegate.getAssets();
-    }
-
-    public AssetManager getAssets__super() {
-        return super.getAssets();
     }
 
     /**
@@ -740,17 +528,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getBaseContext();
     }
 
-    public Context getBaseContext__super() {
-        return super.getBaseContext();
-    }
-
     @Override
     public File getCacheDir() {
         return delegate.getCacheDir();
-    }
-
-    public File getCacheDir__super() {
-        return super.getCacheDir();
     }
 
     /**
@@ -771,11 +551,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public ComponentName getCallingActivity() {
         return delegate.getCallingActivity();
-    }
-
-    @Nullable
-    public ComponentName getCallingActivity__super() {
-        return super.getCallingActivity();
     }
 
     /**
@@ -804,11 +579,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getCallingPackage();
     }
 
-    @Nullable
-    public String getCallingPackage__super() {
-        return super.getCallingPackage();
-    }
-
     /**
      * If this activity is being destroyed because it can not handle a
      * configuration parameter being changed (and thus its
@@ -828,26 +598,14 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getChangingConfigurations();
     }
 
-    public int getChangingConfigurations__super() {
-        return super.getChangingConfigurations();
-    }
-
     @Override
     public ClassLoader getClassLoader() {
         return delegate.getClassLoader();
     }
 
-    public ClassLoader getClassLoader__super() {
-        return super.getClassLoader();
-    }
-
     @Override
     public File getCodeCacheDir() {
         return delegate.getCodeCacheDir();
-    }
-
-    public File getCodeCacheDir__super() {
-        return super.getCodeCacheDir();
     }
 
     /**
@@ -860,17 +618,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getComponentName();
     }
 
-    public ComponentName getComponentName__super() {
-        return super.getComponentName();
-    }
-
     @Override
     public ContentResolver getContentResolver() {
         return delegate.getContentResolver();
-    }
-
-    public ContentResolver getContentResolver__super() {
-        return super.getContentResolver();
     }
 
     /**
@@ -884,10 +634,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public Scene getContentScene() {
         return delegate.getContentScene();
-    }
-
-    public Scene getContentScene__super() {
-        return super.getContentScene();
     }
 
     /**
@@ -904,10 +650,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getContentTransitionManager();
     }
 
-    public TransitionManager getContentTransitionManager__super() {
-        return super.getContentTransitionManager();
-    }
-
     /**
      * Calls {@link Window#getCurrentFocus} on the
      * Window of this Activity to return the currently focused view.
@@ -922,18 +664,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getCurrentFocus();
     }
 
-    @Nullable
-    public View getCurrentFocus__super() {
-        return super.getCurrentFocus();
-    }
-
     @Override
     public File getDatabasePath(final String name) {
         return delegate.getDatabasePath(name);
-    }
-
-    public File getDatabasePath__super(final String name) {
-        return super.getDatabasePath(name);
     }
 
     /**
@@ -945,18 +678,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getDelegate();
     }
 
-    @NonNull
-    public AppCompatDelegate getDelegate__super() {
-        return super.getDelegate();
-    }
-
     @Override
     public File getDir(final String name, final int mode) {
         return delegate.getDir(name, mode);
-    }
-
-    public File getDir__super(final String name, final int mode) {
-        return super.getDir(name, mode);
     }
 
     @Nullable
@@ -965,18 +689,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getDrawerToggleDelegate();
     }
 
-    @Nullable
-    public ActionBarDrawerToggle.Delegate getDrawerToggleDelegate__super() {
-        return super.getDrawerToggleDelegate();
-    }
-
     @Override
     public File getExternalCacheDir() {
         return delegate.getExternalCacheDir();
-    }
-
-    public File getExternalCacheDir__super() {
-        return super.getExternalCacheDir();
     }
 
     @Override
@@ -984,17 +699,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getExternalCacheDirs();
     }
 
-    public File[] getExternalCacheDirs__super() {
-        return super.getExternalCacheDirs();
-    }
-
     @Override
     public File getExternalFilesDir(final String type) {
         return delegate.getExternalFilesDir(type);
-    }
-
-    public File getExternalFilesDir__super(final String type) {
-        return super.getExternalFilesDir(type);
     }
 
     @Override
@@ -1002,17 +709,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getExternalFilesDirs(type);
     }
 
-    public File[] getExternalFilesDirs__super(final String type) {
-        return super.getExternalFilesDirs(type);
-    }
-
     @Override
     public File[] getExternalMediaDirs() {
         return delegate.getExternalMediaDirs();
-    }
-
-    public File[] getExternalMediaDirs__super() {
-        return super.getExternalMediaDirs();
     }
 
     @Override
@@ -1020,17 +719,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getFileStreamPath(name);
     }
 
-    public File getFileStreamPath__super(final String name) {
-        return super.getFileStreamPath(name);
-    }
-
     @Override
     public File getFilesDir() {
         return delegate.getFilesDir();
-    }
-
-    public File getFilesDir__super() {
-        return super.getFilesDir();
     }
 
     /**
@@ -1042,20 +733,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getFragmentManager();
     }
 
-    public android.app.FragmentManager getFragmentManager__super() {
-        return super.getFragmentManager();
-    }
-
     /**
      * Return the intent that started this activity.
      */
     @Override
     public Intent getIntent() {
         return delegate.getIntent();
-    }
-
-    public Intent getIntent__super() {
-        return super.getIntent();
     }
 
     /**
@@ -1098,21 +781,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getLayoutInflater();
     }
 
-    @NonNull
-    public LayoutInflater getLayoutInflater__super() {
-        return super.getLayoutInflater();
-    }
-
     /**
      * Return the LoaderManager for this activity, creating it if needed.
      */
     @Override
     public android.app.LoaderManager getLoaderManager() {
         return delegate.getLoaderManager();
-    }
-
-    public android.app.LoaderManager getLoaderManager__super() {
-        return super.getLoaderManager();
     }
 
     /**
@@ -1127,18 +801,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getLocalClassName();
     }
 
-    @NonNull
-    public String getLocalClassName__super() {
-        return super.getLocalClassName();
-    }
-
     @Override
     public Looper getMainLooper() {
         return delegate.getMainLooper();
-    }
-
-    public Looper getMainLooper__super() {
-        return super.getMainLooper();
     }
 
     @Override
@@ -1146,17 +811,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getMenuInflater();
     }
 
-    public MenuInflater getMenuInflater__super() {
-        return super.getMenuInflater();
-    }
-
     @Override
     public File getNoBackupFilesDir() {
         return delegate.getNoBackupFilesDir();
-    }
-
-    public File getNoBackupFilesDir__super() {
-        return super.getNoBackupFilesDir();
     }
 
     @Override
@@ -1164,17 +821,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getObbDir();
     }
 
-    public File getObbDir__super() {
-        return super.getObbDir();
-    }
-
     @Override
     public File[] getObbDirs() {
         return delegate.getObbDirs();
-    }
-
-    public File[] getObbDirs__super() {
-        return super.getObbDirs();
     }
 
     @Override
@@ -1182,17 +831,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getPackageCodePath();
     }
 
-    public String getPackageCodePath__super() {
-        return super.getPackageCodePath();
-    }
-
     @Override
     public PackageManager getPackageManager() {
         return delegate.getPackageManager();
-    }
-
-    public PackageManager getPackageManager__super() {
-        return super.getPackageManager();
     }
 
     @Override
@@ -1200,17 +841,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getPackageName();
     }
 
-    public String getPackageName__super() {
-        return super.getPackageName();
-    }
-
     @Override
     public String getPackageResourcePath() {
         return delegate.getPackageResourcePath();
-    }
-
-    public String getPackageResourcePath__super() {
-        return super.getPackageResourcePath();
     }
 
     /**
@@ -1230,11 +863,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getParentActivityIntent();
     }
 
-    @Nullable
-    public Intent getParentActivityIntent__super() {
-        return super.getParentActivityIntent();
-    }
-
     /**
      * Retrieve a {@link SharedPreferences} object for accessing preferences
      * that are private to this activity.  This simply calls the underlying
@@ -1250,10 +878,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public SharedPreferences getPreferences(final int mode) {
         return delegate.getPreferences(mode);
-    }
-
-    public SharedPreferences getPreferences__super(final int mode) {
-        return super.getPreferences(mode);
     }
 
     /**
@@ -1278,11 +902,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getReferrer();
     }
 
-    @Nullable
-    public Uri getReferrer__super() {
-        return super.getReferrer();
-    }
-
     /**
      * Return the current requested orientation of the activity.  This will
      * either be the orientation requested in its component's manifest, or
@@ -1297,26 +916,14 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getRequestedOrientation();
     }
 
-    public int getRequestedOrientation__super() {
-        return super.getRequestedOrientation();
-    }
-
     @Override
     public Resources getResources() {
         return delegate.getResources();
     }
 
-    public Resources getResources__super() {
-        return super.getResources();
-    }
-
     @Override
     public SharedPreferences getSharedPreferences(final String name, final int mode) {
         return delegate.getSharedPreferences(name, mode);
-    }
-
-    public SharedPreferences getSharedPreferences__super(final String name, final int mode) {
-        return super.getSharedPreferences(name, mode);
     }
 
     /**
@@ -1332,11 +939,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getSupportActionBar();
     }
 
-    @Nullable
-    public ActionBar getSupportActionBar__super() {
-        return super.getSupportActionBar();
-    }
-
     /**
      * Return the FragmentManager for interacting with fragments associated
      * with this activity.
@@ -1346,17 +948,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getSupportFragmentManager();
     }
 
-    public FragmentManager getSupportFragmentManager__super() {
-        return super.getSupportFragmentManager();
-    }
-
     @Override
     public LoaderManager getSupportLoaderManager() {
         return delegate.getSupportLoaderManager();
-    }
-
-    public LoaderManager getSupportLoaderManager__super() {
-        return super.getSupportLoaderManager();
     }
 
     /**
@@ -1374,11 +968,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getSupportParentActivityIntent();
     }
 
-    @Nullable
-    public Intent getSupportParentActivityIntent__super() {
-        return super.getSupportParentActivityIntent();
-    }
-
     @Override
     public Object getSystemService(final String name) {
         return delegate.getSystemService(name);
@@ -1387,14 +976,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public String getSystemServiceName(final Class<?> serviceClass) {
         return delegate.getSystemServiceName(serviceClass);
-    }
-
-    public String getSystemServiceName__super(final Class<?> serviceClass) {
-        return super.getSystemServiceName(serviceClass);
-    }
-
-    public Object getSystemService__super(final String name) {
-        return super.getSystemService(name);
     }
 
     /**
@@ -1408,17 +989,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getTaskId();
     }
 
-    public int getTaskId__super() {
-        return super.getTaskId();
-    }
-
     @Override
     public Resources.Theme getTheme() {
         return delegate.getTheme();
-    }
-
-    public Resources.Theme getTheme__super() {
-        return super.getTheme();
     }
 
     /**
@@ -1428,10 +1001,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public VoiceInteractor getVoiceInteractor() {
         return delegate.getVoiceInteractor();
-    }
-
-    public VoiceInteractor getVoiceInteractor__super() {
-        return super.getVoiceInteractor();
     }
 
     @Override
@@ -1444,21 +1013,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getWallpaperDesiredMinimumHeight();
     }
 
-    public int getWallpaperDesiredMinimumHeight__super() {
-        return super.getWallpaperDesiredMinimumHeight();
-    }
-
     @Override
     public int getWallpaperDesiredMinimumWidth() {
         return delegate.getWallpaperDesiredMinimumWidth();
-    }
-
-    public int getWallpaperDesiredMinimumWidth__super() {
-        return super.getWallpaperDesiredMinimumWidth();
-    }
-
-    public Drawable getWallpaper__super() {
-        return super.getWallpaper();
     }
 
     /**
@@ -1482,22 +1039,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.getWindowManager();
     }
 
-    public WindowManager getWindowManager__super() {
-        return super.getWindowManager();
-    }
-
-    public Window getWindow__super() {
-        return super.getWindow();
-    }
-
     @Override
     public void grantUriPermission(final String toPackage, final Uri uri, final int modeFlags) {
         delegate.grantUriPermission(toPackage, uri, modeFlags);
-    }
-
-    public void grantUriPermission__super(final String toPackage, final Uri uri,
-            final int modeFlags) {
-        super.grantUriPermission(toPackage, uri, modeFlags);
     }
 
     /**
@@ -1512,20 +1056,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.hasWindowFocus();
     }
 
-    public boolean hasWindowFocus__super() {
-        return super.hasWindowFocus();
-    }
-
     /**
      * @hide
      */
     @Override
     public void invalidateOptionsMenu() {
         delegate.invalidateOptionsMenu();
-    }
-
-    public void invalidateOptionsMenu__super() {
-        super.invalidateOptionsMenu();
     }
 
     /**
@@ -1542,10 +1078,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.isChangingConfigurations();
     }
 
-    public boolean isChangingConfigurations__super() {
-        return super.isChangingConfigurations();
-    }
-
     /**
      * Returns true if the final {@link #onDestroy()} call has been made
      * on the Activity, so this instance is now dead.
@@ -1553,10 +1085,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean isDestroyed() {
         return delegate.isDestroyed();
-    }
-
-    public boolean isDestroyed__super() {
-        return super.isDestroyed();
     }
 
     /**
@@ -1572,10 +1100,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean isFinishing() {
         return delegate.isFinishing();
-    }
-
-    public boolean isFinishing__super() {
-        return super.isFinishing();
     }
 
     /**
@@ -1594,17 +1118,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.isImmersive();
     }
 
-    public boolean isImmersive__super() {
-        return super.isImmersive();
-    }
-
     @Override
     public boolean isRestricted() {
         return delegate.isRestricted();
-    }
-
-    public boolean isRestricted__super() {
-        return super.isRestricted();
     }
 
     /**
@@ -1616,10 +1132,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean isTaskRoot() {
         return delegate.isTaskRoot();
-    }
-
-    public boolean isTaskRoot__super() {
-        return super.isTaskRoot();
     }
 
     /**
@@ -1644,14 +1156,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.isVoiceInteractionRoot();
     }
 
-    public boolean isVoiceInteractionRoot__super() {
-        return super.isVoiceInteractionRoot();
-    }
-
-    public boolean isVoiceInteraction__super() {
-        return super.isVoiceInteraction();
-    }
-
     /**
      * Move the task containing this activity to the back of the activity
      * stack.  The activity's order within the task is unchanged.
@@ -1665,10 +1169,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean moveTaskToBack(final boolean nonRoot) {
         return delegate.moveTaskToBack(nonRoot);
-    }
-
-    public boolean moveTaskToBack__super(final boolean nonRoot) {
-        return super.moveTaskToBack(nonRoot);
     }
 
     /**
@@ -1713,14 +1213,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.navigateUpToFromChild(child, upIntent);
     }
 
-    public boolean navigateUpToFromChild__super(final Activity child, final Intent upIntent) {
-        return super.navigateUpToFromChild(child, upIntent);
-    }
-
-    public boolean navigateUpTo__super(final Intent upIntent) {
-        return super.navigateUpTo(upIntent);
-    }
-
     /**
      * Notifies the activity that an action mode has finished.
      * Activity subclasses overriding this method should call the superclass implementation.
@@ -1732,10 +1224,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onActionModeFinished(mode);
     }
 
-    public void onActionModeFinished__super(final android.view.ActionMode mode) {
-        super.onActionModeFinished(mode);
-    }
-
     /**
      * Notifies the Activity that an action mode has been started.
      * Activity subclasses overriding this method should call the superclass implementation.
@@ -1745,10 +1233,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onActionModeStarted(final android.view.ActionMode mode) {
         delegate.onActionModeStarted(mode);
-    }
-
-    public void onActionModeStarted__super(final android.view.ActionMode mode) {
-        super.onActionModeStarted(mode);
     }
 
     /**
@@ -1773,10 +1257,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onActivityReenter(resultCode, data);
     }
 
-    public void onActivityReenter__super(final int resultCode, final Intent data) {
-        super.onActivityReenter(resultCode, data);
-    }
-
     /**
      * Dispatch incoming result to the correct fragment.
      */
@@ -1785,20 +1265,10 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onActivityResult(requestCode, resultCode, data);
     }
 
-    public void onActivityResult__super(final int requestCode, final int resultCode,
-            final Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-    }
-
     @Override
     public void onApplyThemeResource(final Resources.Theme theme, final int resid,
             final boolean first) {
         delegate.onApplyThemeResource(theme, resid, first);
-    }
-
-    public void onApplyThemeResource__super(final Resources.Theme theme, final int resid,
-            final boolean first) {
-        super.onApplyThemeResource(theme, resid, first);
     }
 
     /**
@@ -1819,14 +1289,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onAttachFragment(fragment);
     }
 
-    public void onAttachFragment__super(final Fragment fragment) {
-        super.onAttachFragment(fragment);
-    }
-
-    public void onAttachFragment__super(final android.app.Fragment fragment) {
-        super.onAttachFragment(fragment);
-    }
-
     /**
      * Called when the main window associated with the activity has been
      * attached to the window manager.
@@ -1840,10 +1302,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onAttachedToWindow();
     }
 
-    public void onAttachedToWindow__super() {
-        super.onAttachedToWindow();
-    }
-
     /**
      * Take care of popping the fragment back stack or finishing the activity
      * as appropriate.
@@ -1853,17 +1311,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onBackPressed();
     }
 
-    public void onBackPressed__super() {
-        super.onBackPressed();
-    }
-
     @Override
     public void onChildTitleChanged(final Activity childActivity, final CharSequence title) {
         delegate.onChildTitleChanged(childActivity, title);
-    }
-
-    public void onChildTitleChanged__super(final Activity childActivity, final CharSequence title) {
-        super.onChildTitleChanged(childActivity, title);
     }
 
     @Override
@@ -1871,17 +1321,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onConfigurationChanged(newConfig);
     }
 
-    public void onConfigurationChanged__super(final Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-    }
-
     @Override
     public void onContentChanged() {
         delegate.onContentChanged();
-    }
-
-    public void onContentChanged__super() {
-        super.onContentChanged();
     }
 
     /**
@@ -1906,10 +1348,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onContextItemSelected(item);
     }
 
-    public boolean onContextItemSelected__super(final MenuItem item) {
-        return super.onContextItemSelected(item);
-    }
-
     /**
      * This hook is called whenever the context menu is being closed (either by
      * the user canceling the menu with the back/menu button, or when an item is
@@ -1920,10 +1358,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onContextMenuClosed(final Menu menu) {
         delegate.onContextMenuClosed(menu);
-    }
-
-    public void onContextMenuClosed__super(final Menu menu) {
-        super.onContextMenuClosed(menu);
     }
 
     /**
@@ -1977,11 +1411,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onCreateContextMenu(menu, v, menuInfo);
     }
 
-    public void onCreateContextMenu__super(final ContextMenu menu, final View v,
-            final ContextMenu.ContextMenuInfo menuInfo) {
-        super.onCreateContextMenu(menu, v, menuInfo);
-    }
-
     /**
      * Generate a new description for this activity.  This method is called
      * before pausing the activity and can, if desired, return some textual
@@ -2002,11 +1431,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public CharSequence onCreateDescription() {
         return delegate.onCreateDescription();
-    }
-
-    @Nullable
-    public CharSequence onCreateDescription__super() {
-        return super.onCreateDescription();
     }
 
     /**
@@ -2054,15 +1478,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onCreateDialog(id, args);
     }
 
-    public Dialog onCreateDialog__super(final int id) {
-        return super.onCreateDialog(id);
-    }
-
-    @Nullable
-    public Dialog onCreateDialog__super(final int id, final Bundle args) {
-        return super.onCreateDialog(id, args);
-    }
-
     /**
      * Define the synthetic task stack that will be generated during Up navigation from
      * a different task.
@@ -2085,10 +1500,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onCreateNavigateUpTaskStack(final TaskStackBuilder builder) {
         delegate.onCreateNavigateUpTaskStack(builder);
-    }
-
-    public void onCreateNavigateUpTaskStack__super(final TaskStackBuilder builder) {
-        super.onCreateNavigateUpTaskStack(builder);
     }
 
     /**
@@ -2122,20 +1533,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onCreateOptionsMenu(menu);
     }
 
-    public boolean onCreateOptionsMenu__super(final Menu menu) {
-        return super.onCreateOptionsMenu(menu);
-    }
-
     /**
      * Dispatch to Fragment.onCreateOptionsMenu().
      */
     @Override
     public boolean onCreatePanelMenu(final int featureId, final Menu menu) {
         return delegate.onCreatePanelMenu(featureId, menu);
-    }
-
-    public boolean onCreatePanelMenu__super(final int featureId, final Menu menu) {
-        return super.onCreatePanelMenu(featureId, menu);
     }
 
     /**
@@ -2149,11 +1552,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public View onCreatePanelView(final int featureId) {
         return delegate.onCreatePanelView(featureId);
-    }
-
-    @Nullable
-    public View onCreatePanelView__super(final int featureId) {
-        return super.onCreatePanelView(featureId);
     }
 
     /**
@@ -2186,11 +1584,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onCreateSupportNavigateUpTaskStack(builder);
     }
 
-    public void onCreateSupportNavigateUpTaskStack__super(
-            @NonNull final android.support.v4.app.TaskStackBuilder builder) {
-        super.onCreateSupportNavigateUpTaskStack(builder);
-    }
-
     /**
      * Generate a new thumbnail for this activity.  This method is called before
      * pausing the activity, and should draw into <var>outBitmap</var> the
@@ -2214,10 +1607,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onCreateThumbnail(outBitmap, canvas);
     }
 
-    public boolean onCreateThumbnail__super(final Bitmap outBitmap, final Canvas canvas) {
-        return super.onCreateThumbnail(outBitmap, canvas);
-    }
-
     @Override
     public View onCreateView(final View parent, final String name, final Context context,
             final AttributeSet attrs) {
@@ -2229,32 +1618,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onCreateView(name, context, attrs);
     }
 
-    public View onCreateView__super(final View parent, final String name, final Context context,
-            final AttributeSet attrs) {
-        return super.onCreateView(parent, name, context, attrs);
-    }
-
-    public View onCreateView__super(final String name, final Context context,
-            final AttributeSet attrs) {
-        return super.onCreateView(name, context, attrs);
-    }
-
-    public void onCreate__super(final Bundle savedInstanceState,
-            final PersistableBundle persistentState) {
-        super.onCreate(savedInstanceState, persistentState);
-    }
-
-    public void onCreate__super(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
     @Override
     public void onDestroy() {
         delegate.onDestroy();
-    }
-
-    public void onDestroy__super() {
-        super.onDestroy();
     }
 
     /**
@@ -2270,10 +1636,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onDetachedFromWindow();
     }
 
-    public void onDetachedFromWindow__super() {
-        super.onDetachedFromWindow();
-    }
-
     /**
      * Activities cannot draw during the period that their windows are animating in. In order
      * to know when it is safe to begin drawing they can override this method which will be
@@ -2282,10 +1644,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onEnterAnimationComplete() {
         delegate.onEnterAnimationComplete();
-    }
-
-    public void onEnterAnimationComplete__super() {
-        super.onEnterAnimationComplete();
     }
 
     /**
@@ -2317,20 +1675,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onGenericMotionEvent(event);
     }
 
-    public boolean onGenericMotionEvent__super(final MotionEvent event) {
-        return super.onGenericMotionEvent(event);
-    }
-
     /**
      * Take care of calling onBackPressed() for pre-Eclair platforms.
      */
     @Override
     public boolean onKeyDown(final int keyCode, final KeyEvent event) {
         return delegate.onKeyDown(keyCode, event);
-    }
-
-    public boolean onKeyDown__super(final int keyCode, final KeyEvent event) {
-        return super.onKeyDown(keyCode, event);
     }
 
     /**
@@ -2343,10 +1693,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onKeyLongPress(keyCode, event);
     }
 
-    public boolean onKeyLongPress__super(final int keyCode, final KeyEvent event) {
-        return super.onKeyLongPress(keyCode, event);
-    }
-
     /**
      * Default implementation of {@link KeyEvent.Callback#onKeyMultiple(int, int, KeyEvent)
      * KeyEvent.Callback.onKeyMultiple()}: always returns false (doesn't handle
@@ -2355,11 +1701,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean onKeyMultiple(final int keyCode, final int repeatCount, final KeyEvent event) {
         return delegate.onKeyMultiple(keyCode, repeatCount, event);
-    }
-
-    public boolean onKeyMultiple__super(final int keyCode, final int repeatCount,
-            final KeyEvent event) {
-        return super.onKeyMultiple(keyCode, repeatCount, event);
     }
 
     /**
@@ -2375,10 +1716,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean onKeyShortcut(final int keyCode, final KeyEvent event) {
         return delegate.onKeyShortcut(keyCode, event);
-    }
-
-    public boolean onKeyShortcut__super(final int keyCode, final KeyEvent event) {
-        return super.onKeyShortcut(keyCode, event);
     }
 
     /**
@@ -2401,20 +1738,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onKeyUp(keyCode, event);
     }
 
-    public boolean onKeyUp__super(final int keyCode, final KeyEvent event) {
-        return super.onKeyUp(keyCode, event);
-    }
-
     /**
      * Dispatch onLowMemory() to all fragments.
      */
     @Override
     public void onLowMemory() {
         delegate.onLowMemory();
-    }
-
-    public void onLowMemory__super() {
-        super.onLowMemory();
     }
 
     /**
@@ -2426,10 +1755,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean onMenuOpened(final int featureId, final Menu menu) {
         return delegate.onMenuOpened(featureId, menu);
-    }
-
-    public boolean onMenuOpened__super(final int featureId, final Menu menu) {
-        return super.onMenuOpened(featureId, menu);
     }
 
     /**
@@ -2473,14 +1798,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onNavigateUpFromChild(child);
     }
 
-    public boolean onNavigateUpFromChild__super(final Activity child) {
-        return super.onNavigateUpFromChild(child);
-    }
-
-    public boolean onNavigateUp__super() {
-        return super.onNavigateUp();
-    }
-
     /**
      * Handle onNewIntent() to inform the fragment manager that the
      * state is not saved.  If you are handling new intents and may be
@@ -2494,10 +1811,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onNewIntent(final Intent intent) {
         delegate.onNewIntent(intent);
-    }
-
-    public void onNewIntent__super(final Intent intent) {
-        super.onNewIntent(intent);
     }
 
     /**
@@ -2521,10 +1834,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onOptionsItemSelected(item);
     }
 
-    public boolean onOptionsItemSelected__super(final MenuItem item) {
-        return super.onOptionsItemSelected(item);
-    }
-
     /**
      * This hook is called whenever the options menu is being closed (either by the user canceling
      * the menu with the back/menu button, or when an item is selected).
@@ -2535,10 +1844,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onOptionsMenuClosed(final Menu menu) {
         delegate.onOptionsMenuClosed(menu);
-    }
-
-    public void onOptionsMenuClosed__super(final Menu menu) {
-        super.onOptionsMenuClosed(menu);
     }
 
     /**
@@ -2552,20 +1857,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onPanelClosed(featureId, menu);
     }
 
-    public void onPanelClosed__super(final int featureId, final Menu menu) {
-        super.onPanelClosed(featureId, menu);
-    }
-
     /**
      * Dispatch onPause() to fragments.
      */
     @Override
     public void onPause() {
         delegate.onPause();
-    }
-
-    public void onPause__super() {
-        super.onPause();
     }
 
     /**
@@ -2589,22 +1886,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onPostCreate(savedInstanceState);
     }
 
-    public void onPostCreate__super(final Bundle savedInstanceState,
-            final PersistableBundle persistentState) {
-        super.onPostCreate(savedInstanceState, persistentState);
-    }
-
-    public void onPostCreate__super(@Nullable final Bundle savedInstanceState) {
-        super.onPostCreate(savedInstanceState);
-    }
-
     @Override
     public void onPostResume() {
         delegate.onPostResume();
-    }
-
-    public void onPostResume__super() {
-        super.onPostResume();
     }
 
     /**
@@ -2644,14 +1928,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onPrepareDialog(id, dialog, args);
     }
 
-    public void onPrepareDialog__super(final int id, final Dialog dialog) {
-        super.onPrepareDialog(id, dialog);
-    }
-
-    public void onPrepareDialog__super(final int id, final Dialog dialog, final Bundle args) {
-        super.onPrepareDialog(id, dialog, args);
-    }
-
     /**
      * Prepare the synthetic task stack that will be generated during Up navigation
      * from a different task.
@@ -2667,10 +1943,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onPrepareNavigateUpTaskStack(final TaskStackBuilder builder) {
         delegate.onPrepareNavigateUpTaskStack(builder);
-    }
-
-    public void onPrepareNavigateUpTaskStack__super(final TaskStackBuilder builder) {
-        super.onPrepareNavigateUpTaskStack(builder);
     }
 
     /**
@@ -2694,10 +1966,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onPrepareOptionsMenu(menu);
     }
 
-    public boolean onPrepareOptionsMenu__super(final Menu menu) {
-        return super.onPrepareOptionsMenu(menu);
-    }
-
     /**
      * @hide
      */
@@ -2706,20 +1974,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onPrepareOptionsPanel(view, menu);
     }
 
-    public boolean onPrepareOptionsPanel__super(final View view, final Menu menu) {
-        return super.onPrepareOptionsPanel(view, menu);
-    }
-
     /**
      * Dispatch onPrepareOptionsMenu() to fragments.
      */
     @Override
     public boolean onPreparePanel(final int featureId, final View view, final Menu menu) {
         return delegate.onPreparePanel(featureId, view, menu);
-    }
-
-    public boolean onPreparePanel__super(final int featureId, final View view, final Menu menu) {
-        return super.onPreparePanel(featureId, view, menu);
     }
 
     /**
@@ -2742,11 +2002,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     public void onPrepareSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
         delegate.onPrepareSupportNavigateUpTaskStack(builder);
-    }
-
-    public void onPrepareSupportNavigateUpTaskStack__super(
-            @NonNull final android.support.v4.app.TaskStackBuilder builder) {
-        super.onPrepareSupportNavigateUpTaskStack(builder);
     }
 
     /**
@@ -2773,10 +2028,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onProvideAssistContent(outContent);
     }
 
-    public void onProvideAssistContent__super(final AssistContent outContent) {
-        super.onProvideAssistContent(outContent);
-    }
-
     /**
      * This is called when the user is requesting an assist, to build a full
      * {@link Intent#ACTION_ASSIST} Intent with all of the context of the current
@@ -2793,10 +2044,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onProvideAssistData(data);
     }
 
-    public void onProvideAssistData__super(final Bundle data) {
-        super.onProvideAssistData(data);
-    }
-
     /**
      * Override to generate the desired referrer for the content currently being shown
      * by the app.  The default implementation returns null, meaning the referrer will simply
@@ -2806,10 +2053,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public Uri onProvideReferrer() {
         return delegate.onProvideReferrer();
-    }
-
-    public Uri onProvideReferrer__super() {
-        return super.onProvideReferrer();
     }
 
     /**
@@ -2832,11 +2075,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     public void onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
         delegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
-
-    public void onRequestPermissionsResult__super(final int requestCode,
-            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     /**
@@ -2862,10 +2100,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onRestart() {
         delegate.onRestart();
-    }
-
-    public void onRestart__super() {
-        super.onRestart();
     }
 
     /**
@@ -2918,15 +2152,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onRestoreInstanceState(savedInstanceState);
     }
 
-    public void onRestoreInstanceState__super(final Bundle savedInstanceState,
-            final PersistableBundle persistentState) {
-        super.onRestoreInstanceState(savedInstanceState, persistentState);
-    }
-
-    public void onRestoreInstanceState__super(final Bundle savedInstanceState) {
-        super.onRestoreInstanceState(savedInstanceState);
-    }
-
     /**
      * Dispatch onResume() to fragments.  Note that for better inter-operation
      * with older versions of the platform, at the point of this call the
@@ -2950,14 +2175,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onResumeFragments() {
         delegate.onResumeFragments();
-    }
-
-    public void onResumeFragments__super() {
-        super.onResumeFragments();
-    }
-
-    public void onResume__super() {
-        super.onResume();
     }
 
     /**
@@ -3001,15 +2218,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onSaveInstanceState(outState);
     }
 
-    public void onSaveInstanceState__super(final Bundle outState,
-            final PersistableBundle outPersistentState) {
-        super.onSaveInstanceState(outState, outPersistentState);
-    }
-
-    public void onSaveInstanceState__super(final Bundle outState) {
-        super.onSaveInstanceState(outState);
-    }
-
     /**
      * This hook is called when the user signals the desire to start a search.
      *
@@ -3045,14 +2253,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onSearchRequested();
     }
 
-    public boolean onSearchRequested__super(final SearchEvent searchEvent) {
-        return super.onSearchRequested(searchEvent);
-    }
-
-    public boolean onSearchRequested__super() {
-        return super.onSearchRequested();
-    }
-
     /**
      * Dispatch onStart() to all fragments.  Ensure any created loaders are
      * now started.
@@ -3060,10 +2260,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onStart() {
         delegate.onStart();
-    }
-
-    public void onStart__super() {
-        super.onStart();
     }
 
     /**
@@ -3074,17 +2270,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onStateNotSaved();
     }
 
-    public void onStateNotSaved__super() {
-        super.onStateNotSaved();
-    }
-
     @Override
     public void onStop() {
         delegate.onStop();
-    }
-
-    public void onStop__super() {
-        super.onStop();
     }
 
     /**
@@ -3098,10 +2286,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onSupportActionModeFinished(mode);
     }
 
-    public void onSupportActionModeFinished__super(@NonNull final ActionMode mode) {
-        super.onSupportActionModeFinished(mode);
-    }
-
     /**
      * Notifies the Activity that a support action mode has been started.
      * Activity subclasses overriding this method should call the superclass implementation.
@@ -3113,20 +2297,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onSupportActionModeStarted(mode);
     }
 
-    public void onSupportActionModeStarted__super(@NonNull final ActionMode mode) {
-        super.onSupportActionModeStarted(mode);
-    }
-
     /**
      * @deprecated Use {@link #onContentChanged()} instead.
      */
     @Override
     public void onSupportContentChanged() {
         delegate.onSupportContentChanged();
-    }
-
-    public void onSupportContentChanged__super() {
-        super.onSupportContentChanged();
     }
 
     /**
@@ -3157,17 +2333,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onSupportNavigateUp();
     }
 
-    public boolean onSupportNavigateUp__super() {
-        return super.onSupportNavigateUp();
-    }
-
     @Override
     public void onTitleChanged(final CharSequence title, final int color) {
         delegate.onTitleChanged(title, color);
-    }
-
-    public void onTitleChanged__super(final CharSequence title, final int color) {
-        super.onTitleChanged(title, color);
     }
 
     /**
@@ -3182,10 +2350,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean onTouchEvent(final MotionEvent event) {
         return delegate.onTouchEvent(event);
-    }
-
-    public boolean onTouchEvent__super(final MotionEvent event) {
-        return super.onTouchEvent(event);
     }
 
     /**
@@ -3206,17 +2370,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onTrackballEvent(event);
     }
 
-    public boolean onTrackballEvent__super(final MotionEvent event) {
-        return super.onTrackballEvent(event);
-    }
-
     @Override
     public void onTrimMemory(final int level) {
         delegate.onTrimMemory(level);
-    }
-
-    public void onTrimMemory__super(final int level) {
-        super.onTrimMemory(level);
     }
 
     /**
@@ -3243,10 +2399,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onUserInteraction();
     }
 
-    public void onUserInteraction__super() {
-        super.onUserInteraction();
-    }
-
     /**
      * Called as part of the activity lifecycle when an activity is about to go
      * into the background as the result of user choice.  For example, when the
@@ -3265,10 +2417,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void onUserLeaveHint() {
         delegate.onUserLeaveHint();
-    }
-
-    public void onUserLeaveHint__super() {
-        super.onUserLeaveHint();
     }
 
     /**
@@ -3290,17 +2438,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onVisibleBehindCanceled();
     }
 
-    public void onVisibleBehindCanceled__super() {
-        super.onVisibleBehindCanceled();
-    }
-
     @Override
     public void onWindowAttributesChanged(final WindowManager.LayoutParams params) {
         delegate.onWindowAttributesChanged(params);
-    }
-
-    public void onWindowAttributesChanged__super(final WindowManager.LayoutParams params) {
-        super.onWindowAttributesChanged(params);
     }
 
     /**
@@ -3334,10 +2474,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.onWindowFocusChanged(hasFocus);
     }
 
-    public void onWindowFocusChanged__super(final boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
-    }
-
     /**
      * Give the Activity a chance to control the UI for an action mode requested
      * by the system.
@@ -3366,18 +2502,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onWindowStartingActionMode(callback, type);
     }
 
-    @Nullable
-    public android.view.ActionMode onWindowStartingActionMode__super(
-            final android.view.ActionMode.Callback callback) {
-        return super.onWindowStartingActionMode(callback);
-    }
-
-    @Nullable
-    public android.view.ActionMode onWindowStartingActionMode__super(
-            final android.view.ActionMode.Callback callback, final int type) {
-        return super.onWindowStartingActionMode(callback, type);
-    }
-
     /**
      * Called when a support action mode is being started for this window. Gives the
      * callback an opportunity to handle the action mode in its own unique and
@@ -3394,12 +2518,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.onWindowStartingSupportActionMode(callback);
     }
 
-    @Nullable
-    public ActionMode onWindowStartingSupportActionMode__super(
-            @NonNull final ActionMode.Callback callback) {
-        return super.onWindowStartingSupportActionMode(callback);
-    }
-
     /**
      * Programmatically opens the context menu for a particular {@code view}.
      * The {@code view} should have been added via
@@ -3412,10 +2530,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.openContextMenu(view);
     }
 
-    public void openContextMenu__super(final View view) {
-        super.openContextMenu(view);
-    }
-
     @Override
     public FileInputStream openFileInput(final String name) throws FileNotFoundException {
         try {
@@ -3423,10 +2537,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         } catch (SuppressedException e) {
             throw (FileNotFoundException) e.getCause();
         }
-    }
-
-    public FileInputStream openFileInput__super(final String name) throws FileNotFoundException {
-        return super.openFileInput(name);
     }
 
     @Override
@@ -3439,11 +2549,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         }
     }
 
-    public FileOutputStream openFileOutput__super(final String name, final int mode)
-            throws FileNotFoundException {
-        return super.openFileOutput(name, mode);
-    }
-
     /**
      * Programmatically opens the options menu. If the options menu is already
      * open, this method does nothing.
@@ -3451,10 +2556,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void openOptionsMenu() {
         delegate.openOptionsMenu();
-    }
-
-    public void openOptionsMenu__super() {
-        super.openOptionsMenu();
     }
 
     @Override
@@ -3467,16 +2568,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     public SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler) {
         return delegate.openOrCreateDatabase(name, mode, factory, errorHandler);
-    }
-
-    public SQLiteDatabase openOrCreateDatabase__super(final String name, final int mode,
-            final SQLiteDatabase.CursorFactory factory) {
-        return super.openOrCreateDatabase(name, mode, factory);
-    }
-
-    public SQLiteDatabase openOrCreateDatabase__super(final String name, final int mode,
-            final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler) {
-        return super.openOrCreateDatabase(name, mode, factory, errorHandler);
     }
 
     /**
@@ -3501,17 +2592,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.overridePendingTransition(enterAnim, exitAnim);
     }
 
-    public void overridePendingTransition__super(final int enterAnim, final int exitAnim) {
-        super.overridePendingTransition(enterAnim, exitAnim);
-    }
-
     @Override
     public Drawable peekWallpaper() {
         return delegate.peekWallpaper();
-    }
-
-    public Drawable peekWallpaper__super() {
-        return super.peekWallpaper();
     }
 
     /**
@@ -3534,10 +2617,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.postponeEnterTransition();
     }
 
-    public void postponeEnterTransition__super() {
-        super.postponeEnterTransition();
-    }
-
     /**
      * Cause this Activity to be recreated with a new instance.  This results
      * in essentially the same flow as when the Activity is created due to
@@ -3547,10 +2626,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void recreate() {
         delegate.recreate();
-    }
-
-    public void recreate__super() {
-        super.recreate();
     }
 
     /**
@@ -3568,10 +2643,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.registerComponentCallbacks(callback);
     }
 
-    public void registerComponentCallbacks__super(final ComponentCallbacks callback) {
-        super.registerComponentCallbacks(callback);
-    }
-
     /**
      * Registers a context menu to be shown for the given view (multiple views
      * can show the context menu). This method will set the
@@ -3587,10 +2658,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.registerForContextMenu(view);
     }
 
-    public void registerForContextMenu__super(final View view) {
-        super.registerForContextMenu(view);
-    }
-
     @Override
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter) {
         return delegate.registerReceiver(receiver, filter);
@@ -3600,16 +2667,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter,
             final String broadcastPermission, final Handler scheduler) {
         return delegate.registerReceiver(receiver, filter, broadcastPermission, scheduler);
-    }
-
-    public Intent registerReceiver__super(final BroadcastReceiver receiver,
-            final IntentFilter filter) {
-        return super.registerReceiver(receiver, filter);
-    }
-
-    public Intent registerReceiver__super(final BroadcastReceiver receiver,
-            final IntentFilter filter, final String broadcastPermission, final Handler scheduler) {
-        return super.registerReceiver(receiver, filter, broadcastPermission, scheduler);
     }
 
     /**
@@ -3628,10 +2685,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.releaseInstance();
     }
 
-    public boolean releaseInstance__super() {
-        return super.releaseInstance();
-    }
-
     @Override
     public void removeStickyBroadcast(final Intent intent) {
         delegate.removeStickyBroadcast(intent);
@@ -3640,14 +2693,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void removeStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
         delegate.removeStickyBroadcastAsUser(intent, user);
-    }
-
-    public void removeStickyBroadcastAsUser__super(final Intent intent, final UserHandle user) {
-        super.removeStickyBroadcastAsUser(intent, user);
-    }
-
-    public void removeStickyBroadcast__super(final Intent intent) {
-        super.removeStickyBroadcast(intent);
     }
 
     /**
@@ -3666,10 +2711,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void reportFullyDrawn() {
         delegate.reportFullyDrawn();
-    }
-
-    public void reportFullyDrawn__super() {
-        super.reportFullyDrawn();
     }
 
     /**
@@ -3709,17 +2750,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.requestVisibleBehind(visible);
     }
 
-    public boolean requestVisibleBehind__super(final boolean visible) {
-        return super.requestVisibleBehind(visible);
-    }
-
     @Override
     public void revokeUriPermission(final Uri uri, final int modeFlags) {
         delegate.revokeUriPermission(uri, modeFlags);
-    }
-
-    public void revokeUriPermission__super(final Uri uri, final int modeFlags) {
-        super.revokeUriPermission(uri, modeFlags);
     }
 
     @Override
@@ -3741,23 +2774,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     public void sendBroadcastAsUser(final Intent intent, final UserHandle user,
             final String receiverPermission) {
         delegate.sendBroadcastAsUser(intent, user, receiverPermission);
-    }
-
-    public void sendBroadcastAsUser__super(final Intent intent, final UserHandle user) {
-        super.sendBroadcastAsUser(intent, user);
-    }
-
-    public void sendBroadcastAsUser__super(final Intent intent, final UserHandle user,
-            final String receiverPermission) {
-        super.sendBroadcastAsUser(intent, user, receiverPermission);
-    }
-
-    public void sendBroadcast__super(final Intent intent) {
-        super.sendBroadcast(intent);
-    }
-
-    public void sendBroadcast__super(final Intent intent, final String receiverPermission) {
-        super.sendBroadcast(intent, receiverPermission);
     }
 
     @Override
@@ -3782,25 +2798,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
                 scheduler, initialCode, initialData, initialExtras);
     }
 
-    public void sendOrderedBroadcastAsUser__super(final Intent intent, final UserHandle user,
-            final String receiverPermission, final BroadcastReceiver resultReceiver,
-            final Handler scheduler, final int initialCode, final String initialData,
-            final Bundle initialExtras) {
-        super.sendOrderedBroadcastAsUser(intent, user, receiverPermission, resultReceiver,
-                scheduler, initialCode, initialData, initialExtras);
-    }
-
-    public void sendOrderedBroadcast__super(final Intent intent, final String receiverPermission) {
-        super.sendOrderedBroadcast(intent, receiverPermission);
-    }
-
-    public void sendOrderedBroadcast__super(final Intent intent, final String receiverPermission,
-            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
-            final String initialData, final Bundle initialExtras) {
-        super.sendOrderedBroadcast(intent, receiverPermission, resultReceiver, scheduler,
-                initialCode, initialData, initialExtras);
-    }
-
     @Override
     public void sendStickyBroadcast(final Intent intent) {
         delegate.sendStickyBroadcast(intent);
@@ -3809,14 +2806,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void sendStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
         delegate.sendStickyBroadcastAsUser(intent, user);
-    }
-
-    public void sendStickyBroadcastAsUser__super(final Intent intent, final UserHandle user) {
-        super.sendStickyBroadcastAsUser(intent, user);
-    }
-
-    public void sendStickyBroadcast__super(final Intent intent) {
-        super.sendStickyBroadcast(intent);
     }
 
     @Override
@@ -3833,20 +2822,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
             final String initialData, final Bundle initialExtras) {
         delegate.sendStickyOrderedBroadcastAsUser(intent, user, resultReceiver, scheduler,
                 initialCode, initialData, initialExtras);
-    }
-
-    public void sendStickyOrderedBroadcastAsUser__super(final Intent intent, final UserHandle user,
-            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
-            final String initialData, final Bundle initialExtras) {
-        super.sendStickyOrderedBroadcastAsUser(intent, user, resultReceiver, scheduler, initialCode,
-                initialData, initialExtras);
-    }
-
-    public void sendStickyOrderedBroadcast__super(final Intent intent,
-            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
-            final String initialData, final Bundle initialExtras) {
-        super.sendStickyOrderedBroadcast(intent, resultReceiver, scheduler, initialCode,
-                initialData, initialExtras);
     }
 
     /**
@@ -3870,10 +2845,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.setActionBar(toolbar);
     }
 
-    public void setActionBar__super(final Toolbar toolbar) {
-        super.setActionBar(toolbar);
-    }
-
     /**
      * Set the {@link TransitionManager} to use for default transitions in this window.
      * Requires {@link Window#FEATURE_CONTENT_TRANSITIONS}.
@@ -3883,10 +2854,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setContentTransitionManager(final TransitionManager tm) {
         delegate.setContentTransitionManager(tm);
-    }
-
-    public void setContentTransitionManager__super(final TransitionManager tm) {
-        super.setContentTransitionManager(tm);
     }
 
     @Override
@@ -3902,18 +2869,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setContentView(final View view, final ViewGroup.LayoutParams params) {
         delegate.setContentView(view, params);
-    }
-
-    public void setContentView__super(@LayoutRes final int layoutResID) {
-        super.setContentView(layoutResID);
-    }
-
-    public void setContentView__super(final View view) {
-        super.setContentView(view);
-    }
-
-    public void setContentView__super(final View view, final ViewGroup.LayoutParams params) {
-        super.setContentView(view, params);
     }
 
     /**
@@ -3940,15 +2895,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setEnterSharedElementCallback(final android.app.SharedElementCallback callback) {
         delegate.setEnterSharedElementCallback(callback);
-    }
-
-    public void setEnterSharedElementCallback__super(final SharedElementCallback callback) {
-        super.setEnterSharedElementCallback(callback);
-    }
-
-    public void setEnterSharedElementCallback__super(
-            final android.app.SharedElementCallback callback) {
-        super.setEnterSharedElementCallback(callback);
     }
 
     /**
@@ -3979,15 +2925,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.setExitSharedElementCallback(callback);
     }
 
-    public void setExitSharedElementCallback__super(final SharedElementCallback listener) {
-        super.setExitSharedElementCallback(listener);
-    }
-
-    public void setExitSharedElementCallback__super(
-            final android.app.SharedElementCallback callback) {
-        super.setExitSharedElementCallback(callback);
-    }
-
     /**
      * Sets whether this activity is finished when touched outside its window's
      * bounds.
@@ -3995,10 +2932,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setFinishOnTouchOutside(final boolean finish) {
         delegate.setFinishOnTouchOutside(finish);
-    }
-
-    public void setFinishOnTouchOutside__super(final boolean finish) {
-        super.setFinishOnTouchOutside(finish);
     }
 
     /**
@@ -4020,10 +2953,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.setImmersive(i);
     }
 
-    public void setImmersive__super(final boolean i) {
-        super.setImmersive(i);
-    }
-
     /**
      * Change the intent returned by {@link #getIntent}.  This holds a
      * reference to the given intent; it does not copy it.  Often used in
@@ -4036,10 +2965,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setIntent(final Intent newIntent) {
         delegate.setIntent(newIntent);
-    }
-
-    public void setIntent__super(final Intent newIntent) {
-        super.setIntent(newIntent);
     }
 
     /**
@@ -4055,10 +2980,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setRequestedOrientation(final int requestedOrientation) {
         delegate.setRequestedOrientation(requestedOrientation);
-    }
-
-    public void setRequestedOrientation__super(final int requestedOrientation) {
-        super.setRequestedOrientation(requestedOrientation);
     }
 
     /**
@@ -4080,11 +3001,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setSupportActionBar(@Nullable final android.support.v7.widget.Toolbar toolbar) {
         delegate.setSupportActionBar(toolbar);
-    }
-
-    public void setSupportActionBar__super(
-            @Nullable final android.support.v7.widget.Toolbar toolbar) {
-        super.setSupportActionBar(toolbar);
     }
 
     /**
@@ -4111,28 +3027,12 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.setSupportProgressBarIndeterminateVisibility(visible);
     }
 
-    public void setSupportProgressBarIndeterminateVisibility__super(final boolean visible) {
-        super.setSupportProgressBarIndeterminateVisibility(visible);
-    }
-
-    public void setSupportProgressBarIndeterminate__super(final boolean indeterminate) {
-        super.setSupportProgressBarIndeterminate(indeterminate);
-    }
-
     /**
      * @deprecated Progress bars are no longer provided in AppCompat.
      */
     @Override
     public void setSupportProgressBarVisibility(final boolean visible) {
         delegate.setSupportProgressBarVisibility(visible);
-    }
-
-    public void setSupportProgressBarVisibility__super(final boolean visible) {
-        super.setSupportProgressBarVisibility(visible);
-    }
-
-    public void setSupportProgress__super(final int progress) {
-        super.setSupportProgress(progress);
     }
 
     /**
@@ -4153,17 +3053,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.setTaskDescription(taskDescription);
     }
 
-    public void setTaskDescription__super(final ActivityManager.TaskDescription taskDescription) {
-        super.setTaskDescription(taskDescription);
-    }
-
     @Override
     public void setTheme(@StyleRes final int resid) {
         delegate.setTheme(resid);
-    }
-
-    public void setTheme__super(@StyleRes final int resid) {
-        super.setTheme(resid);
     }
 
     /**
@@ -4203,18 +3095,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.setTitleColor(textColor);
     }
 
-    public void setTitleColor__super(final int textColor) {
-        super.setTitleColor(textColor);
-    }
-
-    public void setTitle__super(final CharSequence title) {
-        super.setTitle(title);
-    }
-
-    public void setTitle__super(final int titleId) {
-        super.setTitle(titleId);
-    }
-
     /**
      * Control whether this activity's main window is visible.  This is intended
      * only for the special case of an activity that is not going to show a
@@ -4228,10 +3108,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void setVisible(final boolean visible) {
         delegate.setVisible(visible);
-    }
-
-    public void setVisible__super(final boolean visible) {
-        super.setVisible(visible);
     }
 
     @Override
@@ -4250,14 +3126,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         } catch (SuppressedException e) {
             throw (IOException) e.getCause();
         }
-    }
-
-    public void setWallpaper__super(final Bitmap bitmap) throws IOException {
-        super.setWallpaper(bitmap);
-    }
-
-    public void setWallpaper__super(final InputStream data) throws IOException {
-        super.setWallpaper(data);
     }
 
     /**
@@ -4284,10 +3152,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.shouldShowRequestPermissionRationale(permission);
     }
 
-    public boolean shouldShowRequestPermissionRationale__super(final String permission) {
-        return super.shouldShowRequestPermissionRationale(permission);
-    }
-
     /**
      * Returns true if the app should recreate the task when navigating 'up' from this activity
      * by using targetIntent.
@@ -4306,10 +3170,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.shouldUpRecreateTask(targetIntent);
     }
 
-    public boolean shouldUpRecreateTask__super(final Intent targetIntent) {
-        return super.shouldUpRecreateTask(targetIntent);
-    }
-
     /**
      * Ask to have the current assistant shown to the user.  This only works if the calling
      * activity is the current foreground activity.  It is the same as calling
@@ -4326,10 +3186,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.showAssist(args);
     }
 
-    public boolean showAssist__super(final Bundle args) {
-        return super.showAssist(args);
-    }
-
     /**
      * Shows the user the system defined message for telling the user how to exit
      * lock task mode. The task containing this activity must be in lock task mode at the time
@@ -4338,10 +3194,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void showLockTaskEscapeMessage() {
         delegate.showLockTaskEscapeMessage();
-    }
-
-    public void showLockTaskEscapeMessage__super() {
-        super.showLockTaskEscapeMessage();
     }
 
     /**
@@ -4372,18 +3224,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     public android.view.ActionMode startActionMode(final android.view.ActionMode.Callback callback,
             final int type) {
         return delegate.startActionMode(callback, type);
-    }
-
-    @Nullable
-    public android.view.ActionMode startActionMode__super(
-            final android.view.ActionMode.Callback callback) {
-        return super.startActionMode(callback);
-    }
-
-    @Nullable
-    public android.view.ActionMode startActionMode__super(
-            final android.view.ActionMode.Callback callback, final int type) {
-        return super.startActionMode(callback, type);
     }
 
     /**
@@ -4421,14 +3261,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void startActivities(final Intent[] intents, final Bundle options) {
         delegate.startActivities(intents, options);
-    }
-
-    public void startActivities__super(final Intent[] intents) {
-        super.startActivities(intents);
-    }
-
-    public void startActivities__super(final Intent[] intents, final Bundle options) {
-        super.startActivities(intents, options);
     }
 
     /**
@@ -4514,15 +3346,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.startActivityForResult(intent, requestCode, options);
     }
 
-    public void startActivityForResult__super(final Intent intent, final int requestCode) {
-        super.startActivityForResult(intent, requestCode);
-    }
-
-    public void startActivityForResult__super(final Intent intent, final int requestCode,
-            final Bundle options) {
-        super.startActivityForResult(intent, requestCode, options);
-    }
-
     /**
      * Same as calling {@link #startActivityFromChild(Activity, Intent, int, Bundle)}
      * with no options.
@@ -4559,16 +3382,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     public void startActivityFromChild(final Activity child, final Intent intent,
             final int requestCode, final Bundle options) {
         delegate.startActivityFromChild(child, intent, requestCode, options);
-    }
-
-    public void startActivityFromChild__super(final Activity child, final Intent intent,
-            final int requestCode) {
-        super.startActivityFromChild(child, intent, requestCode);
-    }
-
-    public void startActivityFromChild__super(final Activity child, final Intent intent,
-            final int requestCode, final Bundle options) {
-        super.startActivityFromChild(child, intent, requestCode, options);
     }
 
     /**
@@ -4629,26 +3442,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.startActivityFromFragment(fragment, intent, requestCode, options);
     }
 
-    public void startActivityFromFragment__super(final Fragment fragment, final Intent intent,
-            final int requestCode) {
-        super.startActivityFromFragment(fragment, intent, requestCode);
-    }
-
-    public void startActivityFromFragment__super(final Fragment fragment, final Intent intent,
-            final int requestCode, @Nullable final Bundle options) {
-        super.startActivityFromFragment(fragment, intent, requestCode, options);
-    }
-
-    public void startActivityFromFragment__super(final android.app.Fragment fragment,
-            final Intent intent, final int requestCode) {
-        super.startActivityFromFragment(fragment, intent, requestCode);
-    }
-
-    public void startActivityFromFragment__super(final android.app.Fragment fragment,
-            final Intent intent, final int requestCode, final Bundle options) {
-        super.startActivityFromFragment(fragment, intent, requestCode, options);
-    }
-
     /**
      * Same as calling {@link #startActivityIfNeeded(Intent, int, Bundle)}
      * with no options.
@@ -4701,32 +3494,10 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.startActivityIfNeeded(intent, requestCode, options);
     }
 
-    public boolean startActivityIfNeeded__super(final Intent intent, final int requestCode) {
-        return super.startActivityIfNeeded(intent, requestCode);
-    }
-
-    public boolean startActivityIfNeeded__super(final Intent intent, final int requestCode,
-            final Bundle options) {
-        return super.startActivityIfNeeded(intent, requestCode, options);
-    }
-
-    public void startActivity__super(final Intent intent) {
-        super.startActivity(intent);
-    }
-
-    public void startActivity__super(final Intent intent, final Bundle options) {
-        super.startActivity(intent, options);
-    }
-
     @Override
     public boolean startInstrumentation(final ComponentName className, final String profileFile,
             final Bundle arguments) {
         return delegate.startInstrumentation(className, profileFile, arguments);
-    }
-
-    public boolean startInstrumentation__super(final ComponentName className,
-            final String profileFile, final Bundle arguments) {
-        return super.startInstrumentation(className, profileFile, arguments);
     }
 
     /**
@@ -4847,20 +3618,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         }
     }
 
-    public void startIntentSenderForResult__super(final IntentSender intent, final int requestCode,
-            final Intent fillInIntent, final int flagsMask, final int flagsValues,
-            final int extraFlags) throws IntentSender.SendIntentException {
-        super.startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask, flagsValues,
-                extraFlags);
-    }
-
-    public void startIntentSenderForResult__super(final IntentSender intent, final int requestCode,
-            final Intent fillInIntent, final int flagsMask, final int flagsValues,
-            final int extraFlags, final Bundle options) throws IntentSender.SendIntentException {
-        super.startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask, flagsValues,
-                extraFlags, options);
-    }
-
     /**
      * Same as calling {@link #startIntentSenderFromChild(Activity, IntentSender,
      * int, Intent, int, int, int, Bundle)} with no options.
@@ -4896,33 +3653,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         }
     }
 
-    public void startIntentSenderFromChild__super(final Activity child, final IntentSender intent,
-            final int requestCode, final Intent fillInIntent, final int flagsMask,
-            final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException {
-        super.startIntentSenderFromChild(child, intent, requestCode, fillInIntent, flagsMask,
-                flagsValues, extraFlags);
-    }
-
-    public void startIntentSenderFromChild__super(final Activity child, final IntentSender intent,
-            final int requestCode, final Intent fillInIntent, final int flagsMask,
-            final int flagsValues, final int extraFlags, final Bundle options)
-            throws IntentSender.SendIntentException {
-        super.startIntentSenderFromChild(child, intent, requestCode, fillInIntent, flagsMask,
-                flagsValues, extraFlags, options);
-    }
-
-    public void startIntentSender__super(final IntentSender intent, final Intent fillInIntent,
-            final int flagsMask, final int flagsValues, final int extraFlags)
-            throws IntentSender.SendIntentException {
-        super.startIntentSender(intent, fillInIntent, flagsMask, flagsValues, extraFlags);
-    }
-
-    public void startIntentSender__super(final IntentSender intent, final Intent fillInIntent,
-            final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
-            throws IntentSender.SendIntentException {
-        super.startIntentSender(intent, fillInIntent, flagsMask, flagsValues, extraFlags, options);
-    }
-
     /**
      * Request to put this Activity in a mode where the user is locked to the
      * current task.
@@ -4947,10 +3677,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void startLockTask() {
         delegate.startLockTask();
-    }
-
-    public void startLockTask__super() {
-        super.startLockTask();
     }
 
     /**
@@ -4982,10 +3708,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void startManagingCursor(final Cursor c) {
         delegate.startManagingCursor(c);
-    }
-
-    public void startManagingCursor__super(final Cursor c) {
-        super.startManagingCursor(c);
     }
 
     /**
@@ -5029,14 +3751,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.startNextMatchingActivity(intent, options);
     }
 
-    public boolean startNextMatchingActivity__super(final Intent intent) {
-        return super.startNextMatchingActivity(intent);
-    }
-
-    public boolean startNextMatchingActivity__super(final Intent intent, final Bundle options) {
-        return super.startNextMatchingActivity(intent, options);
-    }
-
     /**
      * Begin postponed transitions after {@link #postponeEnterTransition()} was called.
      * If postponeEnterTransition() was called, you must call startPostponedEnterTransition()
@@ -5045,10 +3759,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void startPostponedEnterTransition() {
         delegate.startPostponedEnterTransition();
-    }
-
-    public void startPostponedEnterTransition__super() {
-        super.startPostponedEnterTransition();
     }
 
     /**
@@ -5099,18 +3809,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.startSearch(initialQuery, selectInitialQuery, appSearchData, globalSearch);
     }
 
-    public void startSearch__super(final String initialQuery, final boolean selectInitialQuery,
-            final Bundle appSearchData, final boolean globalSearch) {
-        super.startSearch(initialQuery, selectInitialQuery, appSearchData, globalSearch);
-    }
-
     @Override
     public ComponentName startService(final Intent service) {
         return delegate.startService(service);
-    }
-
-    public ComponentName startService__super(final Intent service) {
-        return super.startService(service);
     }
 
     /**
@@ -5123,11 +3824,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public ActionMode startSupportActionMode(@NonNull final ActionMode.Callback callback) {
         return delegate.startSupportActionMode(callback);
-    }
-
-    @Nullable
-    public ActionMode startSupportActionMode__super(@NonNull final ActionMode.Callback callback) {
-        return super.startSupportActionMode(callback);
     }
 
     /**
@@ -5152,10 +3848,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.stopLockTask();
     }
 
-    public void stopLockTask__super() {
-        super.stopLockTask();
-    }
-
     /**
      * Given a Cursor that was previously given to
      * {@link #startManagingCursor}, stop the activity's management of that
@@ -5176,17 +3868,1693 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.stopManagingCursor(c);
     }
 
-    public void stopManagingCursor__super(final Cursor c) {
-        super.stopManagingCursor(c);
-    }
-
     @Override
     public boolean stopService(final Intent name) {
         return delegate.stopService(name);
     }
 
-    public boolean stopService__super(final Intent name) {
+    @Override
+    public void super_addContentView(final View view, final ViewGroup.LayoutParams params) {
+        super.addContentView(view, params);
+    }
+
+    @Override
+    public void super_applyOverrideConfiguration(final Configuration overrideConfiguration) {
+        super.applyOverrideConfiguration(overrideConfiguration);
+    }
+
+    @Override
+    public void super_attachBaseContext(final Context newBase) {
+        super.attachBaseContext(newBase);
+    }
+
+    @Override
+    public boolean super_bindService(final Intent service, final ServiceConnection conn,
+            final int flags) {
+        return super.bindService(service, conn, flags);
+    }
+
+    @Override
+    public int super_checkCallingOrSelfPermission(final String permission) {
+        return super.checkCallingOrSelfPermission(permission);
+    }
+
+    @Override
+    public int super_checkCallingOrSelfUriPermission(final Uri uri, final int modeFlags) {
+        return super.checkCallingOrSelfUriPermission(uri, modeFlags);
+    }
+
+    @Override
+    public int super_checkCallingPermission(final String permission) {
+        return super.checkCallingPermission(permission);
+    }
+
+    @Override
+    public int super_checkCallingUriPermission(final Uri uri, final int modeFlags) {
+        return super.checkCallingUriPermission(uri, modeFlags);
+    }
+
+    @Override
+    public int super_checkPermission(final String permission, final int pid, final int uid) {
+        return super.checkPermission(permission, pid, uid);
+    }
+
+    @Override
+    public int super_checkSelfPermission(final String permission) {
+        return super.checkSelfPermission(permission);
+    }
+
+    @Override
+    public int super_checkUriPermission(final Uri uri, final int pid, final int uid,
+            final int modeFlags) {
+        return super.checkUriPermission(uri, pid, uid, modeFlags);
+    }
+
+    @Override
+    public int super_checkUriPermission(final Uri uri, final String readPermission,
+            final String writePermission, final int pid, final int uid, final int modeFlags) {
+        return super.checkUriPermission(uri, readPermission, writePermission, pid, uid, modeFlags);
+    }
+
+    @Override
+    public void super_clearWallpaper() throws IOException {
+        super.clearWallpaper();
+    }
+
+    @Override
+    public void super_closeContextMenu() {
+        super.closeContextMenu();
+    }
+
+    @Override
+    public void super_closeOptionsMenu() {
+        super.closeOptionsMenu();
+    }
+
+    @Override
+    public Context super_createConfigurationContext(final Configuration overrideConfiguration) {
+        return super.createConfigurationContext(overrideConfiguration);
+    }
+
+    @Override
+    public Context super_createDisplayContext(final Display display) {
+        return super.createDisplayContext(display);
+    }
+
+    @Override
+    public Context super_createPackageContext(final String packageName, final int flags)
+            throws PackageManager.NameNotFoundException {
+        return super.createPackageContext(packageName, flags);
+    }
+
+    @Override
+    public PendingIntent super_createPendingResult(final int requestCode, final Intent data,
+            final int flags) {
+        return super.createPendingResult(requestCode, data, flags);
+    }
+
+    @Override
+    public String[] super_databaseList() {
+        return super.databaseList();
+    }
+
+    @Override
+    public boolean super_deleteDatabase(final String name) {
+        return super.deleteDatabase(name);
+    }
+
+    @Override
+    public boolean super_deleteFile(final String name) {
+        return super.deleteFile(name);
+    }
+
+    @Override
+    public boolean super_dispatchGenericMotionEvent(final MotionEvent ev) {
+        return super.dispatchGenericMotionEvent(ev);
+    }
+
+    @Override
+    public boolean super_dispatchKeyEvent(final KeyEvent event) {
+        return super.dispatchKeyEvent(event);
+    }
+
+    @Override
+    public boolean super_dispatchKeyShortcutEvent(final KeyEvent event) {
+        return super.dispatchKeyShortcutEvent(event);
+    }
+
+    @Override
+    public boolean super_dispatchPopulateAccessibilityEvent(final AccessibilityEvent event) {
+        return super.dispatchPopulateAccessibilityEvent(event);
+    }
+
+    @Override
+    public boolean super_dispatchTouchEvent(final MotionEvent ev) {
+        return super.dispatchTouchEvent(ev);
+    }
+
+    @Override
+    public boolean super_dispatchTrackballEvent(final MotionEvent ev) {
+        return super.dispatchTrackballEvent(ev);
+    }
+
+    @Override
+    public void super_dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
+            final String[] args) {
+        super.dump(prefix, fd, writer, args);
+    }
+
+    @Override
+    public void super_enforceCallingOrSelfPermission(final String permission,
+            final String message) {
+        super.enforceCallingOrSelfPermission(permission, message);
+    }
+
+    @Override
+    public void super_enforceCallingOrSelfUriPermission(final Uri uri, final int modeFlags,
+            final String message) {
+        super.enforceCallingOrSelfUriPermission(uri, modeFlags, message);
+    }
+
+    @Override
+    public void super_enforceCallingPermission(final String permission, final String message) {
+        super.enforceCallingPermission(permission, message);
+    }
+
+    @Override
+    public void super_enforceCallingUriPermission(final Uri uri, final int modeFlags,
+            final String message) {
+        super.enforceCallingUriPermission(uri, modeFlags, message);
+    }
+
+    @Override
+    public void super_enforcePermission(final String permission, final int pid, final int uid,
+            final String message) {
+        super.enforcePermission(permission, pid, uid, message);
+    }
+
+    @Override
+    public void super_enforceUriPermission(final Uri uri, final int pid, final int uid,
+            final int modeFlags, final String message) {
+        super.enforceUriPermission(uri, pid, uid, modeFlags, message);
+    }
+
+    @Override
+    public void super_enforceUriPermission(final Uri uri, final String readPermission,
+            final String writePermission, final int pid, final int uid, final int modeFlags,
+            final String message) {
+        super.enforceUriPermission(uri, readPermission, writePermission, pid, uid, modeFlags,
+                message);
+    }
+
+    @Override
+    public String[] super_fileList() {
+        return super.fileList();
+    }
+
+    @Nullable
+    @Override
+    public View super_findViewById(@IdRes final int id) {
+        return super.findViewById(id);
+    }
+
+    @Override
+    public void super_finish() {
+        super.finish();
+    }
+
+    @Override
+    public void super_finishActivity(final int requestCode) {
+        super.finishActivity(requestCode);
+    }
+
+    @Override
+    public void super_finishActivityFromChild(final Activity child, final int requestCode) {
+        super.finishActivityFromChild(child, requestCode);
+    }
+
+    @Override
+    public void super_finishAffinity() {
+        super.finishAffinity();
+    }
+
+    @Override
+    public void super_finishAfterTransition() {
+        super.finishAfterTransition();
+    }
+
+    @Override
+    public void super_finishAndRemoveTask() {
+        super.finishAndRemoveTask();
+    }
+
+    @Override
+    public void super_finishFromChild(final Activity child) {
+        super.finishFromChild(child);
+    }
+
+    @Nullable
+    @Override
+    public android.app.ActionBar super_getActionBar() {
+        return super.getActionBar();
+    }
+
+    @Override
+    public Context super_getApplicationContext() {
+        return super.getApplicationContext();
+    }
+
+    @Override
+    public ApplicationInfo super_getApplicationInfo() {
+        return super.getApplicationInfo();
+    }
+
+    @Override
+    public AssetManager super_getAssets() {
+        return super.getAssets();
+    }
+
+    @Override
+    public Context super_getBaseContext() {
+        return super.getBaseContext();
+    }
+
+    @Override
+    public File super_getCacheDir() {
+        return super.getCacheDir();
+    }
+
+    @Nullable
+    @Override
+    public ComponentName super_getCallingActivity() {
+        return super.getCallingActivity();
+    }
+
+    @Nullable
+    @Override
+    public String super_getCallingPackage() {
+        return super.getCallingPackage();
+    }
+
+    @Override
+    public int super_getChangingConfigurations() {
+        return super.getChangingConfigurations();
+    }
+
+    @Override
+    public ClassLoader super_getClassLoader() {
+        return super.getClassLoader();
+    }
+
+    @Override
+    public File super_getCodeCacheDir() {
+        return super.getCodeCacheDir();
+    }
+
+    @Override
+    public ComponentName super_getComponentName() {
+        return super.getComponentName();
+    }
+
+    @Override
+    public ContentResolver super_getContentResolver() {
+        return super.getContentResolver();
+    }
+
+    @Override
+    public Scene super_getContentScene() {
+        return super.getContentScene();
+    }
+
+    @Override
+    public TransitionManager super_getContentTransitionManager() {
+        return super.getContentTransitionManager();
+    }
+
+    @Nullable
+    @Override
+    public View super_getCurrentFocus() {
+        return super.getCurrentFocus();
+    }
+
+    @Override
+    public File super_getDatabasePath(final String name) {
+        return super.getDatabasePath(name);
+    }
+
+    @NonNull
+    @Override
+    public AppCompatDelegate super_getDelegate() {
+        return super.getDelegate();
+    }
+
+    @Override
+    public File super_getDir(final String name, final int mode) {
+        return super.getDir(name, mode);
+    }
+
+    @Nullable
+    @Override
+    public ActionBarDrawerToggle.Delegate super_getDrawerToggleDelegate() {
+        return super.getDrawerToggleDelegate();
+    }
+
+    @Override
+    public File super_getExternalCacheDir() {
+        return super.getExternalCacheDir();
+    }
+
+    @Override
+    public File[] super_getExternalCacheDirs() {
+        return super.getExternalCacheDirs();
+    }
+
+    @Override
+    public File super_getExternalFilesDir(final String type) {
+        return super.getExternalFilesDir(type);
+    }
+
+    @Override
+    public File[] super_getExternalFilesDirs(final String type) {
+        return super.getExternalFilesDirs(type);
+    }
+
+    @Override
+    public File[] super_getExternalMediaDirs() {
+        return super.getExternalMediaDirs();
+    }
+
+    @Override
+    public File super_getFileStreamPath(final String name) {
+        return super.getFileStreamPath(name);
+    }
+
+    @Override
+    public File super_getFilesDir() {
+        return super.getFilesDir();
+    }
+
+    @Override
+    public android.app.FragmentManager super_getFragmentManager() {
+        return super.getFragmentManager();
+    }
+
+    @Override
+    public Intent super_getIntent() {
+        return super.getIntent();
+    }
+
+    @NonNull
+    @Override
+    public LayoutInflater super_getLayoutInflater() {
+        return super.getLayoutInflater();
+    }
+
+    @Override
+    public android.app.LoaderManager super_getLoaderManager() {
+        return super.getLoaderManager();
+    }
+
+    @NonNull
+    @Override
+    public String super_getLocalClassName() {
+        return super.getLocalClassName();
+    }
+
+    @Override
+    public Looper super_getMainLooper() {
+        return super.getMainLooper();
+    }
+
+    @Override
+    public MenuInflater super_getMenuInflater() {
+        return super.getMenuInflater();
+    }
+
+    @Override
+    public File super_getNoBackupFilesDir() {
+        return super.getNoBackupFilesDir();
+    }
+
+    @Override
+    public File super_getObbDir() {
+        return super.getObbDir();
+    }
+
+    @Override
+    public File[] super_getObbDirs() {
+        return super.getObbDirs();
+    }
+
+    @Override
+    public String super_getPackageCodePath() {
+        return super.getPackageCodePath();
+    }
+
+    @Override
+    public PackageManager super_getPackageManager() {
+        return super.getPackageManager();
+    }
+
+    @Override
+    public String super_getPackageName() {
+        return super.getPackageName();
+    }
+
+    @Override
+    public String super_getPackageResourcePath() {
+        return super.getPackageResourcePath();
+    }
+
+    @Nullable
+    @Override
+    public Intent super_getParentActivityIntent() {
+        return super.getParentActivityIntent();
+    }
+
+    @Override
+    public SharedPreferences super_getPreferences(final int mode) {
+        return super.getPreferences(mode);
+    }
+
+    @Nullable
+    @Override
+    public Uri super_getReferrer() {
+        return super.getReferrer();
+    }
+
+    @Override
+    public int super_getRequestedOrientation() {
+        return super.getRequestedOrientation();
+    }
+
+    @Override
+    public Resources super_getResources() {
+        return super.getResources();
+    }
+
+    @Override
+    public SharedPreferences super_getSharedPreferences(final String name, final int mode) {
+        return super.getSharedPreferences(name, mode);
+    }
+
+    @Nullable
+    @Override
+    public ActionBar super_getSupportActionBar() {
+        return super.getSupportActionBar();
+    }
+
+    @Override
+    public FragmentManager super_getSupportFragmentManager() {
+        return super.getSupportFragmentManager();
+    }
+
+    @Override
+    public LoaderManager super_getSupportLoaderManager() {
+        return super.getSupportLoaderManager();
+    }
+
+    @Nullable
+    @Override
+    public Intent super_getSupportParentActivityIntent() {
+        return super.getSupportParentActivityIntent();
+    }
+
+    @Override
+    public Object super_getSystemService(final String name) {
+        return super.getSystemService(name);
+    }
+
+    @Override
+    public String super_getSystemServiceName(final Class<?> serviceClass) {
+        return super.getSystemServiceName(serviceClass);
+    }
+
+    @Override
+    public int super_getTaskId() {
+        return super.getTaskId();
+    }
+
+    @Override
+    public Resources.Theme super_getTheme() {
+        return super.getTheme();
+    }
+
+    @Override
+    public VoiceInteractor super_getVoiceInteractor() {
+        return super.getVoiceInteractor();
+    }
+
+    @Override
+    public Drawable super_getWallpaper() {
+        return super.getWallpaper();
+    }
+
+    @Override
+    public int super_getWallpaperDesiredMinimumHeight() {
+        return super.getWallpaperDesiredMinimumHeight();
+    }
+
+    @Override
+    public int super_getWallpaperDesiredMinimumWidth() {
+        return super.getWallpaperDesiredMinimumWidth();
+    }
+
+    @Override
+    public Window super_getWindow() {
+        return super.getWindow();
+    }
+
+    @Override
+    public WindowManager super_getWindowManager() {
+        return super.getWindowManager();
+    }
+
+    @Override
+    public void super_grantUriPermission(final String toPackage, final Uri uri,
+            final int modeFlags) {
+        super.grantUriPermission(toPackage, uri, modeFlags);
+    }
+
+    @Override
+    public boolean super_hasWindowFocus() {
+        return super.hasWindowFocus();
+    }
+
+    @Override
+    public void super_invalidateOptionsMenu() {
+        super.invalidateOptionsMenu();
+    }
+
+    @Override
+    public boolean super_isChangingConfigurations() {
+        return super.isChangingConfigurations();
+    }
+
+    @Override
+    public boolean super_isDestroyed() {
+        return super.isDestroyed();
+    }
+
+    @Override
+    public boolean super_isFinishing() {
+        return super.isFinishing();
+    }
+
+    @Override
+    public boolean super_isImmersive() {
+        return super.isImmersive();
+    }
+
+    @Override
+    public boolean super_isRestricted() {
+        return super.isRestricted();
+    }
+
+    @Override
+    public boolean super_isTaskRoot() {
+        return super.isTaskRoot();
+    }
+
+    @Override
+    public boolean super_isVoiceInteraction() {
+        return super.isVoiceInteraction();
+    }
+
+    @Override
+    public boolean super_isVoiceInteractionRoot() {
+        return super.isVoiceInteractionRoot();
+    }
+
+    @Override
+    public boolean super_moveTaskToBack(final boolean nonRoot) {
+        return super.moveTaskToBack(nonRoot);
+    }
+
+    @Override
+    public boolean super_navigateUpTo(final Intent upIntent) {
+        return super.navigateUpTo(upIntent);
+    }
+
+    @Override
+    public boolean super_navigateUpToFromChild(final Activity child, final Intent upIntent) {
+        return super.navigateUpToFromChild(child, upIntent);
+    }
+
+    @Override
+    public void super_onActionModeFinished(final android.view.ActionMode mode) {
+        super.onActionModeFinished(mode);
+    }
+
+    @Override
+    public void super_onActionModeStarted(final android.view.ActionMode mode) {
+        super.onActionModeStarted(mode);
+    }
+
+    @Override
+    public void super_onActivityReenter(final int resultCode, final Intent data) {
+        super.onActivityReenter(resultCode, data);
+    }
+
+    @Override
+    public void super_onActivityResult(final int requestCode, final int resultCode,
+            final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void super_onApplyThemeResource(final Resources.Theme theme, final int resid,
+            final boolean first) {
+        super.onApplyThemeResource(theme, resid, first);
+    }
+
+    @Override
+    public void super_onAttachFragment(final Fragment fragment) {
+        super.onAttachFragment(fragment);
+    }
+
+    @Override
+    public void super_onAttachFragment(final android.app.Fragment fragment) {
+        super.onAttachFragment(fragment);
+    }
+
+    @Override
+    public void super_onAttachedToWindow() {
+        super.onAttachedToWindow();
+    }
+
+    @Override
+    public void super_onBackPressed() {
+        super.onBackPressed();
+    }
+
+    @Override
+    public void super_onChildTitleChanged(final Activity childActivity, final CharSequence title) {
+        super.onChildTitleChanged(childActivity, title);
+    }
+
+    @Override
+    public void super_onConfigurationChanged(final Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    public void super_onContentChanged() {
+        super.onContentChanged();
+    }
+
+    @Override
+    public boolean super_onContextItemSelected(final MenuItem item) {
+        return super.onContextItemSelected(item);
+    }
+
+    @Override
+    public void super_onContextMenuClosed(final Menu menu) {
+        super.onContextMenuClosed(menu);
+    }
+
+    @Override
+    public void super_onCreate(final Bundle savedInstanceState,
+            final PersistableBundle persistentState) {
+        super.onCreate(savedInstanceState, persistentState);
+    }
+
+    @Override
+    public void super_onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void super_onCreateContextMenu(final ContextMenu menu, final View v,
+            final ContextMenu.ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+    }
+
+    @Nullable
+    @Override
+    public CharSequence super_onCreateDescription() {
+        return super.onCreateDescription();
+    }
+
+    @Override
+    public Dialog super_onCreateDialog(final int id) {
+        return super.onCreateDialog(id);
+    }
+
+    @Nullable
+    @Override
+    public Dialog super_onCreateDialog(final int id, final Bundle args) {
+        return super.onCreateDialog(id, args);
+    }
+
+    @Override
+    public void super_onCreateNavigateUpTaskStack(final TaskStackBuilder builder) {
+        super.onCreateNavigateUpTaskStack(builder);
+    }
+
+    @Override
+    public boolean super_onCreateOptionsMenu(final Menu menu) {
+        return super.onCreateOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean super_onCreatePanelMenu(final int featureId, final Menu menu) {
+        return super.onCreatePanelMenu(featureId, menu);
+    }
+
+    @Nullable
+    @Override
+    public View super_onCreatePanelView(final int featureId) {
+        return super.onCreatePanelView(featureId);
+    }
+
+    @Override
+    public void super_onCreateSupportNavigateUpTaskStack(
+            @NonNull final android.support.v4.app.TaskStackBuilder builder) {
+        super.onCreateSupportNavigateUpTaskStack(builder);
+    }
+
+    @Override
+    public boolean super_onCreateThumbnail(final Bitmap outBitmap, final Canvas canvas) {
+        return super.onCreateThumbnail(outBitmap, canvas);
+    }
+
+    @Override
+    public View super_onCreateView(final View parent, final String name, final Context context,
+            final AttributeSet attrs) {
+        return super.onCreateView(parent, name, context, attrs);
+    }
+
+    @Override
+    public View super_onCreateView(final String name, final Context context,
+            final AttributeSet attrs) {
+        return super.onCreateView(name, context, attrs);
+    }
+
+    @Override
+    public void super_onDestroy() {
+        super.onDestroy();
+    }
+
+    @Override
+    public void super_onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+    }
+
+    @Override
+    public void super_onEnterAnimationComplete() {
+        super.onEnterAnimationComplete();
+    }
+
+    @Override
+    public boolean super_onGenericMotionEvent(final MotionEvent event) {
+        return super.onGenericMotionEvent(event);
+    }
+
+    @Override
+    public boolean super_onKeyDown(final int keyCode, final KeyEvent event) {
+        return super.onKeyDown(keyCode, event);
+    }
+
+    @Override
+    public boolean super_onKeyLongPress(final int keyCode, final KeyEvent event) {
+        return super.onKeyLongPress(keyCode, event);
+    }
+
+    @Override
+    public boolean super_onKeyMultiple(final int keyCode, final int repeatCount,
+            final KeyEvent event) {
+        return super.onKeyMultiple(keyCode, repeatCount, event);
+    }
+
+    @Override
+    public boolean super_onKeyShortcut(final int keyCode, final KeyEvent event) {
+        return super.onKeyShortcut(keyCode, event);
+    }
+
+    @Override
+    public boolean super_onKeyUp(final int keyCode, final KeyEvent event) {
+        return super.onKeyUp(keyCode, event);
+    }
+
+    @Override
+    public void super_onLowMemory() {
+        super.onLowMemory();
+    }
+
+    @Override
+    public boolean super_onMenuOpened(final int featureId, final Menu menu) {
+        return super.onMenuOpened(featureId, menu);
+    }
+
+    @Override
+    public boolean super_onNavigateUp() {
+        return super.onNavigateUp();
+    }
+
+    @Override
+    public boolean super_onNavigateUpFromChild(final Activity child) {
+        return super.onNavigateUpFromChild(child);
+    }
+
+    @Override
+    public void super_onNewIntent(final Intent intent) {
+        super.onNewIntent(intent);
+    }
+
+    @Override
+    public boolean super_onOptionsItemSelected(final MenuItem item) {
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void super_onOptionsMenuClosed(final Menu menu) {
+        super.onOptionsMenuClosed(menu);
+    }
+
+    @Override
+    public void super_onPanelClosed(final int featureId, final Menu menu) {
+        super.onPanelClosed(featureId, menu);
+    }
+
+    @Override
+    public void super_onPause() {
+        super.onPause();
+    }
+
+    @Override
+    public void super_onPostCreate(final Bundle savedInstanceState,
+            final PersistableBundle persistentState) {
+        super.onPostCreate(savedInstanceState, persistentState);
+    }
+
+    @Override
+    public void super_onPostCreate(@Nullable final Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+    }
+
+    @Override
+    public void super_onPostResume() {
+        super.onPostResume();
+    }
+
+    @Override
+    public void super_onPrepareDialog(final int id, final Dialog dialog) {
+        super.onPrepareDialog(id, dialog);
+    }
+
+    @Override
+    public void super_onPrepareDialog(final int id, final Dialog dialog, final Bundle args) {
+        super.onPrepareDialog(id, dialog, args);
+    }
+
+    @Override
+    public void super_onPrepareNavigateUpTaskStack(final TaskStackBuilder builder) {
+        super.onPrepareNavigateUpTaskStack(builder);
+    }
+
+    @Override
+    public boolean super_onPrepareOptionsMenu(final Menu menu) {
+        return super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public boolean super_onPrepareOptionsPanel(final View view, final Menu menu) {
+        return super.onPrepareOptionsPanel(view, menu);
+    }
+
+    @Override
+    public boolean super_onPreparePanel(final int featureId, final View view, final Menu menu) {
+        return super.onPreparePanel(featureId, view, menu);
+    }
+
+    @Override
+    public void super_onPrepareSupportNavigateUpTaskStack(
+            @NonNull final android.support.v4.app.TaskStackBuilder builder) {
+        super.onPrepareSupportNavigateUpTaskStack(builder);
+    }
+
+    @Override
+    public void super_onProvideAssistContent(final AssistContent outContent) {
+        super.onProvideAssistContent(outContent);
+    }
+
+    @Override
+    public void super_onProvideAssistData(final Bundle data) {
+        super.onProvideAssistData(data);
+    }
+
+    @Override
+    public Uri super_onProvideReferrer() {
+        return super.onProvideReferrer();
+    }
+
+    @Override
+    public void super_onRequestPermissionsResult(final int requestCode,
+            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    @Override
+    public void super_onRestart() {
+        super.onRestart();
+    }
+
+    @Override
+    public void super_onRestoreInstanceState(final Bundle savedInstanceState,
+            final PersistableBundle persistentState) {
+        super.onRestoreInstanceState(savedInstanceState, persistentState);
+    }
+
+    @Override
+    public void super_onRestoreInstanceState(final Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+    }
+
+    @Override
+    public void super_onResume() {
+        super.onResume();
+    }
+
+    @Override
+    public void super_onResumeFragments() {
+        super.onResumeFragments();
+    }
+
+    @Override
+    public void super_onSaveInstanceState(final Bundle outState,
+            final PersistableBundle outPersistentState) {
+        super.onSaveInstanceState(outState, outPersistentState);
+    }
+
+    @Override
+    public void super_onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public boolean super_onSearchRequested(final SearchEvent searchEvent) {
+        return super.onSearchRequested(searchEvent);
+    }
+
+    @Override
+    public boolean super_onSearchRequested() {
+        return super.onSearchRequested();
+    }
+
+    @Override
+    public void super_onStart() {
+        super.onStart();
+    }
+
+    @Override
+    public void super_onStateNotSaved() {
+        super.onStateNotSaved();
+    }
+
+    @Override
+    public void super_onStop() {
+        super.onStop();
+    }
+
+    @Override
+    public void super_onSupportActionModeFinished(@NonNull final ActionMode mode) {
+        super.onSupportActionModeFinished(mode);
+    }
+
+    @Override
+    public void super_onSupportActionModeStarted(@NonNull final ActionMode mode) {
+        super.onSupportActionModeStarted(mode);
+    }
+
+    @Override
+    public void super_onSupportContentChanged() {
+        super.onSupportContentChanged();
+    }
+
+    @Override
+    public boolean super_onSupportNavigateUp() {
+        return super.onSupportNavigateUp();
+    }
+
+    @Override
+    public void super_onTitleChanged(final CharSequence title, final int color) {
+        super.onTitleChanged(title, color);
+    }
+
+    @Override
+    public boolean super_onTouchEvent(final MotionEvent event) {
+        return super.onTouchEvent(event);
+    }
+
+    @Override
+    public boolean super_onTrackballEvent(final MotionEvent event) {
+        return super.onTrackballEvent(event);
+    }
+
+    @Override
+    public void super_onTrimMemory(final int level) {
+        super.onTrimMemory(level);
+    }
+
+    @Override
+    public void super_onUserInteraction() {
+        super.onUserInteraction();
+    }
+
+    @Override
+    public void super_onUserLeaveHint() {
+        super.onUserLeaveHint();
+    }
+
+    @Override
+    public void super_onVisibleBehindCanceled() {
+        super.onVisibleBehindCanceled();
+    }
+
+    @Override
+    public void super_onWindowAttributesChanged(final WindowManager.LayoutParams params) {
+        super.onWindowAttributesChanged(params);
+    }
+
+    @Override
+    public void super_onWindowFocusChanged(final boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+    }
+
+    @Nullable
+    @Override
+    public android.view.ActionMode super_onWindowStartingActionMode(
+            final android.view.ActionMode.Callback callback) {
+        return super.onWindowStartingActionMode(callback);
+    }
+
+    @Nullable
+    @Override
+    public android.view.ActionMode super_onWindowStartingActionMode(
+            final android.view.ActionMode.Callback callback, final int type) {
+        return super.onWindowStartingActionMode(callback, type);
+    }
+
+    @Nullable
+    @Override
+    public ActionMode super_onWindowStartingSupportActionMode(
+            @NonNull final ActionMode.Callback callback) {
+        return super.onWindowStartingSupportActionMode(callback);
+    }
+
+    @Override
+    public void super_openContextMenu(final View view) {
+        super.openContextMenu(view);
+    }
+
+    @Override
+    public FileInputStream super_openFileInput(final String name) throws FileNotFoundException {
+        return super.openFileInput(name);
+    }
+
+    @Override
+    public FileOutputStream super_openFileOutput(final String name, final int mode)
+            throws FileNotFoundException {
+        return super.openFileOutput(name, mode);
+    }
+
+    @Override
+    public void super_openOptionsMenu() {
+        super.openOptionsMenu();
+    }
+
+    @Override
+    public SQLiteDatabase super_openOrCreateDatabase(final String name, final int mode,
+            final SQLiteDatabase.CursorFactory factory) {
+        return super.openOrCreateDatabase(name, mode, factory);
+    }
+
+    @Override
+    public SQLiteDatabase super_openOrCreateDatabase(final String name, final int mode,
+            final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler) {
+        return super.openOrCreateDatabase(name, mode, factory, errorHandler);
+    }
+
+    @Override
+    public void super_overridePendingTransition(final int enterAnim, final int exitAnim) {
+        super.overridePendingTransition(enterAnim, exitAnim);
+    }
+
+    @Override
+    public Drawable super_peekWallpaper() {
+        return super.peekWallpaper();
+    }
+
+    @Override
+    public void super_postponeEnterTransition() {
+        super.postponeEnterTransition();
+    }
+
+    @Override
+    public void super_recreate() {
+        super.recreate();
+    }
+
+    @Override
+    public void super_registerComponentCallbacks(final ComponentCallbacks callback) {
+        super.registerComponentCallbacks(callback);
+    }
+
+    @Override
+    public void super_registerForContextMenu(final View view) {
+        super.registerForContextMenu(view);
+    }
+
+    @Override
+    public Intent super_registerReceiver(final BroadcastReceiver receiver,
+            final IntentFilter filter) {
+        return super.registerReceiver(receiver, filter);
+    }
+
+    @Override
+    public Intent super_registerReceiver(final BroadcastReceiver receiver,
+            final IntentFilter filter, final String broadcastPermission, final Handler scheduler) {
+        return super.registerReceiver(receiver, filter, broadcastPermission, scheduler);
+    }
+
+    @Override
+    public boolean super_releaseInstance() {
+        return super.releaseInstance();
+    }
+
+    @Override
+    public void super_removeStickyBroadcast(final Intent intent) {
+        super.removeStickyBroadcast(intent);
+    }
+
+    @Override
+    public void super_removeStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
+        super.removeStickyBroadcastAsUser(intent, user);
+    }
+
+    @Override
+    public void super_reportFullyDrawn() {
+        super.reportFullyDrawn();
+    }
+
+    @Override
+    public boolean super_requestVisibleBehind(final boolean visible) {
+        return super.requestVisibleBehind(visible);
+    }
+
+    @Override
+    public void super_revokeUriPermission(final Uri uri, final int modeFlags) {
+        super.revokeUriPermission(uri, modeFlags);
+    }
+
+    @Override
+    public void super_sendBroadcast(final Intent intent) {
+        super.sendBroadcast(intent);
+    }
+
+    @Override
+    public void super_sendBroadcast(final Intent intent, final String receiverPermission) {
+        super.sendBroadcast(intent, receiverPermission);
+    }
+
+    @Override
+    public void super_sendBroadcastAsUser(final Intent intent, final UserHandle user) {
+        super.sendBroadcastAsUser(intent, user);
+    }
+
+    @Override
+    public void super_sendBroadcastAsUser(final Intent intent, final UserHandle user,
+            final String receiverPermission) {
+        super.sendBroadcastAsUser(intent, user, receiverPermission);
+    }
+
+    @Override
+    public void super_sendOrderedBroadcast(final Intent intent, final String receiverPermission) {
+        super.sendOrderedBroadcast(intent, receiverPermission);
+    }
+
+    @Override
+    public void super_sendOrderedBroadcast(final Intent intent, final String receiverPermission,
+            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
+            final String initialData, final Bundle initialExtras) {
+        super.sendOrderedBroadcast(intent, receiverPermission, resultReceiver, scheduler,
+                initialCode, initialData, initialExtras);
+    }
+
+    @Override
+    public void super_sendOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
+            final String receiverPermission, final BroadcastReceiver resultReceiver,
+            final Handler scheduler, final int initialCode, final String initialData,
+            final Bundle initialExtras) {
+        super.sendOrderedBroadcastAsUser(intent, user, receiverPermission, resultReceiver,
+                scheduler, initialCode, initialData, initialExtras);
+    }
+
+    @Override
+    public void super_sendStickyBroadcast(final Intent intent) {
+        super.sendStickyBroadcast(intent);
+    }
+
+    @Override
+    public void super_sendStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
+        super.sendStickyBroadcastAsUser(intent, user);
+    }
+
+    @Override
+    public void super_sendStickyOrderedBroadcast(final Intent intent,
+            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
+            final String initialData, final Bundle initialExtras) {
+        super.sendStickyOrderedBroadcast(intent, resultReceiver, scheduler, initialCode,
+                initialData, initialExtras);
+    }
+
+    @Override
+    public void super_sendStickyOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
+            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
+            final String initialData, final Bundle initialExtras) {
+        super.sendStickyOrderedBroadcastAsUser(intent, user, resultReceiver, scheduler, initialCode,
+                initialData, initialExtras);
+    }
+
+    @Override
+    public void super_setActionBar(final Toolbar toolbar) {
+        super.setActionBar(toolbar);
+    }
+
+    @Override
+    public void super_setContentTransitionManager(final TransitionManager tm) {
+        super.setContentTransitionManager(tm);
+    }
+
+    @Override
+    public void super_setContentView(@LayoutRes final int layoutResID) {
+        super.setContentView(layoutResID);
+    }
+
+    @Override
+    public void super_setContentView(final View view) {
+        super.setContentView(view);
+    }
+
+    @Override
+    public void super_setContentView(final View view, final ViewGroup.LayoutParams params) {
+        super.setContentView(view, params);
+    }
+
+    @Override
+    public void super_setEnterSharedElementCallback(final SharedElementCallback callback) {
+        super.setEnterSharedElementCallback(callback);
+    }
+
+    @Override
+    public void super_setEnterSharedElementCallback(
+            final android.app.SharedElementCallback callback) {
+        super.setEnterSharedElementCallback(callback);
+    }
+
+    @Override
+    public void super_setExitSharedElementCallback(final SharedElementCallback listener) {
+        super.setExitSharedElementCallback(listener);
+    }
+
+    @Override
+    public void super_setExitSharedElementCallback(
+            final android.app.SharedElementCallback callback) {
+        super.setExitSharedElementCallback(callback);
+    }
+
+    @Override
+    public void super_setFinishOnTouchOutside(final boolean finish) {
+        super.setFinishOnTouchOutside(finish);
+    }
+
+    @Override
+    public void super_setImmersive(final boolean i) {
+        super.setImmersive(i);
+    }
+
+    @Override
+    public void super_setIntent(final Intent newIntent) {
+        super.setIntent(newIntent);
+    }
+
+    @Override
+    public void super_setRequestedOrientation(final int requestedOrientation) {
+        super.setRequestedOrientation(requestedOrientation);
+    }
+
+    @Override
+    public void super_setSupportActionBar(
+            @Nullable final android.support.v7.widget.Toolbar toolbar) {
+        super.setSupportActionBar(toolbar);
+    }
+
+    @Override
+    public void super_setSupportProgress(final int progress) {
+        super.setSupportProgress(progress);
+    }
+
+    @Override
+    public void super_setSupportProgressBarIndeterminate(final boolean indeterminate) {
+        super.setSupportProgressBarIndeterminate(indeterminate);
+    }
+
+    @Override
+    public void super_setSupportProgressBarIndeterminateVisibility(final boolean visible) {
+        super.setSupportProgressBarIndeterminateVisibility(visible);
+    }
+
+    @Override
+    public void super_setSupportProgressBarVisibility(final boolean visible) {
+        super.setSupportProgressBarVisibility(visible);
+    }
+
+    @Override
+    public void super_setTaskDescription(final ActivityManager.TaskDescription taskDescription) {
+        super.setTaskDescription(taskDescription);
+    }
+
+    @Override
+    public void super_setTheme(@StyleRes final int resid) {
+        super.setTheme(resid);
+    }
+
+    @Override
+    public void super_setTitle(final CharSequence title) {
+        super.setTitle(title);
+    }
+
+    @Override
+    public void super_setTitle(final int titleId) {
+        super.setTitle(titleId);
+    }
+
+    @Override
+    public void super_setTitleColor(final int textColor) {
+        super.setTitleColor(textColor);
+    }
+
+    @Override
+    public void super_setVisible(final boolean visible) {
+        super.setVisible(visible);
+    }
+
+    @Override
+    public void super_setWallpaper(final Bitmap bitmap) throws IOException {
+        super.setWallpaper(bitmap);
+    }
+
+    @Override
+    public void super_setWallpaper(final InputStream data) throws IOException {
+        super.setWallpaper(data);
+    }
+
+    @Override
+    public boolean super_shouldShowRequestPermissionRationale(final String permission) {
+        return super.shouldShowRequestPermissionRationale(permission);
+    }
+
+    @Override
+    public boolean super_shouldUpRecreateTask(final Intent targetIntent) {
+        return super.shouldUpRecreateTask(targetIntent);
+    }
+
+    @Override
+    public boolean super_showAssist(final Bundle args) {
+        return super.showAssist(args);
+    }
+
+    @Override
+    public void super_showLockTaskEscapeMessage() {
+        super.showLockTaskEscapeMessage();
+    }
+
+    @Nullable
+    @Override
+    public android.view.ActionMode super_startActionMode(
+            final android.view.ActionMode.Callback callback) {
+        return super.startActionMode(callback);
+    }
+
+    @Nullable
+    @Override
+    public android.view.ActionMode super_startActionMode(
+            final android.view.ActionMode.Callback callback, final int type) {
+        return super.startActionMode(callback, type);
+    }
+
+    @Override
+    public void super_startActivities(final Intent[] intents) {
+        super.startActivities(intents);
+    }
+
+    @Override
+    public void super_startActivities(final Intent[] intents, final Bundle options) {
+        super.startActivities(intents, options);
+    }
+
+    @Override
+    public void super_startActivity(final Intent intent) {
+        super.startActivity(intent);
+    }
+
+    @Override
+    public void super_startActivity(final Intent intent, final Bundle options) {
+        super.startActivity(intent, options);
+    }
+
+    @Override
+    public void super_startActivityForResult(final Intent intent, final int requestCode) {
+        super.startActivityForResult(intent, requestCode);
+    }
+
+    @Override
+    public void super_startActivityForResult(final Intent intent, final int requestCode,
+            final Bundle options) {
+        super.startActivityForResult(intent, requestCode, options);
+    }
+
+    @Override
+    public void super_startActivityFromChild(final Activity child, final Intent intent,
+            final int requestCode) {
+        super.startActivityFromChild(child, intent, requestCode);
+    }
+
+    @Override
+    public void super_startActivityFromChild(final Activity child, final Intent intent,
+            final int requestCode, final Bundle options) {
+        super.startActivityFromChild(child, intent, requestCode, options);
+    }
+
+    @Override
+    public void super_startActivityFromFragment(final Fragment fragment, final Intent intent,
+            final int requestCode) {
+        super.startActivityFromFragment(fragment, intent, requestCode);
+    }
+
+    @Override
+    public void super_startActivityFromFragment(final Fragment fragment, final Intent intent,
+            final int requestCode, @Nullable final Bundle options) {
+        super.startActivityFromFragment(fragment, intent, requestCode, options);
+    }
+
+    @Override
+    public void super_startActivityFromFragment(final android.app.Fragment fragment,
+            final Intent intent, final int requestCode) {
+        super.startActivityFromFragment(fragment, intent, requestCode);
+    }
+
+    @Override
+    public void super_startActivityFromFragment(final android.app.Fragment fragment,
+            final Intent intent, final int requestCode, final Bundle options) {
+        super.startActivityFromFragment(fragment, intent, requestCode, options);
+    }
+
+    @Override
+    public boolean super_startActivityIfNeeded(final Intent intent, final int requestCode) {
+        return super.startActivityIfNeeded(intent, requestCode);
+    }
+
+    @Override
+    public boolean super_startActivityIfNeeded(final Intent intent, final int requestCode,
+            final Bundle options) {
+        return super.startActivityIfNeeded(intent, requestCode, options);
+    }
+
+    @Override
+    public boolean super_startInstrumentation(final ComponentName className,
+            final String profileFile, final Bundle arguments) {
+        return super.startInstrumentation(className, profileFile, arguments);
+    }
+
+    @Override
+    public void super_startIntentSender(final IntentSender intent, final Intent fillInIntent,
+            final int flagsMask, final int flagsValues, final int extraFlags)
+            throws IntentSender.SendIntentException {
+        super.startIntentSender(intent, fillInIntent, flagsMask, flagsValues, extraFlags);
+    }
+
+    @Override
+    public void super_startIntentSender(final IntentSender intent, final Intent fillInIntent,
+            final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
+            throws IntentSender.SendIntentException {
+        super.startIntentSender(intent, fillInIntent, flagsMask, flagsValues, extraFlags, options);
+    }
+
+    @Override
+    public void super_startIntentSenderForResult(final IntentSender intent, final int requestCode,
+            final Intent fillInIntent, final int flagsMask, final int flagsValues,
+            final int extraFlags) throws IntentSender.SendIntentException {
+        super.startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask, flagsValues,
+                extraFlags);
+    }
+
+    @Override
+    public void super_startIntentSenderForResult(final IntentSender intent, final int requestCode,
+            final Intent fillInIntent, final int flagsMask, final int flagsValues,
+            final int extraFlags, final Bundle options) throws IntentSender.SendIntentException {
+        super.startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask, flagsValues,
+                extraFlags, options);
+    }
+
+    @Override
+    public void super_startIntentSenderFromChild(final Activity child, final IntentSender intent,
+            final int requestCode, final Intent fillInIntent, final int flagsMask,
+            final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException {
+        super.startIntentSenderFromChild(child, intent, requestCode, fillInIntent, flagsMask,
+                flagsValues, extraFlags);
+    }
+
+    @Override
+    public void super_startIntentSenderFromChild(final Activity child, final IntentSender intent,
+            final int requestCode, final Intent fillInIntent, final int flagsMask,
+            final int flagsValues, final int extraFlags, final Bundle options)
+            throws IntentSender.SendIntentException {
+        super.startIntentSenderFromChild(child, intent, requestCode, fillInIntent, flagsMask,
+                flagsValues, extraFlags, options);
+    }
+
+    @Override
+    public void super_startLockTask() {
+        super.startLockTask();
+    }
+
+    @Override
+    public void super_startManagingCursor(final Cursor c) {
+        super.startManagingCursor(c);
+    }
+
+    @Override
+    public boolean super_startNextMatchingActivity(final Intent intent) {
+        return super.startNextMatchingActivity(intent);
+    }
+
+    @Override
+    public boolean super_startNextMatchingActivity(final Intent intent, final Bundle options) {
+        return super.startNextMatchingActivity(intent, options);
+    }
+
+    @Override
+    public void super_startPostponedEnterTransition() {
+        super.startPostponedEnterTransition();
+    }
+
+    @Override
+    public void super_startSearch(final String initialQuery, final boolean selectInitialQuery,
+            final Bundle appSearchData, final boolean globalSearch) {
+        super.startSearch(initialQuery, selectInitialQuery, appSearchData, globalSearch);
+    }
+
+    @Override
+    public ComponentName super_startService(final Intent service) {
+        return super.startService(service);
+    }
+
+    @Nullable
+    @Override
+    public ActionMode super_startSupportActionMode(@NonNull final ActionMode.Callback callback) {
+        return super.startSupportActionMode(callback);
+    }
+
+    @Override
+    public void super_stopLockTask() {
+        super.stopLockTask();
+    }
+
+    @Override
+    public void super_stopManagingCursor(final Cursor c) {
+        super.stopManagingCursor(c);
+    }
+
+    @Override
+    public boolean super_stopService(final Intent name) {
         return super.stopService(name);
+    }
+
+    @Override
+    public void super_supportFinishAfterTransition() {
+        super.supportFinishAfterTransition();
+    }
+
+    @Override
+    public void super_supportInvalidateOptionsMenu() {
+        super.supportInvalidateOptionsMenu();
+    }
+
+    @Override
+    public void super_supportNavigateUpTo(@NonNull final Intent upIntent) {
+        super.supportNavigateUpTo(upIntent);
+    }
+
+    @Override
+    public void super_supportPostponeEnterTransition() {
+        super.supportPostponeEnterTransition();
+    }
+
+    @Override
+    public boolean super_supportRequestWindowFeature(final int featureId) {
+        return super.supportRequestWindowFeature(featureId);
+    }
+
+    @Override
+    public boolean super_supportShouldUpRecreateTask(@NonNull final Intent targetIntent) {
+        return super.supportShouldUpRecreateTask(targetIntent);
+    }
+
+    @Override
+    public void super_supportStartPostponedEnterTransition() {
+        super.supportStartPostponedEnterTransition();
+    }
+
+    @Override
+    public void super_takeKeyEvents(final boolean get) {
+        super.takeKeyEvents(get);
+    }
+
+    @Override
+    public void super_triggerSearch(final String query, final Bundle appSearchData) {
+        super.triggerSearch(query, appSearchData);
+    }
+
+    @Override
+    public void super_unbindService(final ServiceConnection conn) {
+        super.unbindService(conn);
+    }
+
+    @Override
+    public void super_unregisterComponentCallbacks(final ComponentCallbacks callback) {
+        super.unregisterComponentCallbacks(callback);
+    }
+
+    @Override
+    public void super_unregisterForContextMenu(final View view) {
+        super.unregisterForContextMenu(view);
+    }
+
+    @Override
+    public void super_unregisterReceiver(final BroadcastReceiver receiver) {
+        super.unregisterReceiver(receiver);
     }
 
     /**
@@ -5203,17 +5571,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.supportFinishAfterTransition();
     }
 
-    public void supportFinishAfterTransition__super() {
-        super.supportFinishAfterTransition();
-    }
-
     @Override
     public void supportInvalidateOptionsMenu() {
         delegate.supportInvalidateOptionsMenu();
-    }
-
-    public void supportInvalidateOptionsMenu__super() {
-        super.supportInvalidateOptionsMenu();
     }
 
     /**
@@ -5233,10 +5593,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.supportNavigateUpTo(upIntent);
     }
 
-    public void supportNavigateUpTo__super(@NonNull final Intent upIntent) {
-        super.supportNavigateUpTo(upIntent);
-    }
-
     /**
      * Support library version of {@link Activity#postponeEnterTransition()} that works
      * only on API 21 and later.
@@ -5244,10 +5600,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void supportPostponeEnterTransition() {
         delegate.supportPostponeEnterTransition();
-    }
-
-    public void supportPostponeEnterTransition__super() {
-        super.supportPostponeEnterTransition();
     }
 
     /**
@@ -5266,10 +5618,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public boolean supportRequestWindowFeature(final int featureId) {
         return delegate.supportRequestWindowFeature(featureId);
-    }
-
-    public boolean supportRequestWindowFeature__super(final int featureId) {
-        return super.supportRequestWindowFeature(featureId);
     }
 
     /**
@@ -5291,10 +5639,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         return delegate.supportShouldUpRecreateTask(targetIntent);
     }
 
-    public boolean supportShouldUpRecreateTask__super(@NonNull final Intent targetIntent) {
-        return super.supportShouldUpRecreateTask(targetIntent);
-    }
-
     /**
      * Support library version of {@link Activity#startPostponedEnterTransition()}
      * that only works with API 21 and later.
@@ -5302,10 +5646,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void supportStartPostponedEnterTransition() {
         delegate.supportStartPostponedEnterTransition();
-    }
-
-    public void supportStartPostponedEnterTransition__super() {
-        super.supportStartPostponedEnterTransition();
     }
 
     /**
@@ -5318,10 +5658,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void takeKeyEvents(final boolean get) {
         delegate.takeKeyEvents(get);
-    }
-
-    public void takeKeyEvents__super(final boolean get) {
-        super.takeKeyEvents(get);
     }
 
     /**
@@ -5338,17 +5674,9 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.triggerSearch(query, appSearchData);
     }
 
-    public void triggerSearch__super(final String query, final Bundle appSearchData) {
-        super.triggerSearch(query, appSearchData);
-    }
-
     @Override
     public void unbindService(final ServiceConnection conn) {
         delegate.unbindService(conn);
-    }
-
-    public void unbindService__super(final ServiceConnection conn) {
-        super.unbindService(conn);
     }
 
     /**
@@ -5358,10 +5686,6 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     @Override
     public void unregisterComponentCallbacks(final ComponentCallbacks callback) {
         delegate.unregisterComponentCallbacks(callback);
-    }
-
-    public void unregisterComponentCallbacks__super(final ComponentCallbacks callback) {
-        super.unregisterComponentCallbacks(callback);
     }
 
     /**
@@ -5376,16 +5700,8 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
         delegate.unregisterForContextMenu(view);
     }
 
-    public void unregisterForContextMenu__super(final View view) {
-        super.unregisterForContextMenu(view);
-    }
-
     @Override
     public void unregisterReceiver(final BroadcastReceiver receiver) {
         delegate.unregisterReceiver(receiver);
-    }
-
-    public void unregisterReceiver__super(final BroadcastReceiver receiver) {
-        super.unregisterReceiver(receiver);
     }
 }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ICompositeActivity.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ICompositeActivity.java
@@ -87,150 +87,75 @@ public interface ICompositeActivity
 
     void addContentView(final View view, final ViewGroup.LayoutParams params);
 
-    void addContentView__super(final View view, final ViewGroup.LayoutParams params);
-
     void applyOverrideConfiguration(final Configuration overrideConfiguration);
-
-    void applyOverrideConfiguration__super(final Configuration overrideConfiguration);
 
     void attachBaseContext(final Context newBase);
 
-    void attachBaseContext__super(final Context newBase);
-
     boolean bindService(final Intent service, final ServiceConnection conn, final int flags);
-
-    boolean bindService__super(final Intent service, final ServiceConnection conn, final int flags);
 
     int checkCallingOrSelfPermission(final String permission);
 
-    int checkCallingOrSelfPermission__super(final String permission);
-
     int checkCallingOrSelfUriPermission(final Uri uri, final int modeFlags);
-
-    int checkCallingOrSelfUriPermission__super(final Uri uri, final int modeFlags);
 
     int checkCallingPermission(final String permission);
 
-    int checkCallingPermission__super(final String permission);
-
     int checkCallingUriPermission(final Uri uri, final int modeFlags);
-
-    int checkCallingUriPermission__super(final Uri uri, final int modeFlags);
 
     int checkPermission(final String permission, final int pid, final int uid);
 
-    int checkPermission__super(final String permission, final int pid, final int uid);
-
     int checkSelfPermission(final String permission);
-
-    int checkSelfPermission__super(final String permission);
 
     int checkUriPermission(final Uri uri, final int pid, final int uid, final int modeFlags);
 
     int checkUriPermission(final Uri uri, final String readPermission, final String writePermission,
             final int pid, final int uid, final int modeFlags);
 
-    int checkUriPermission__super(final Uri uri, final int pid, final int uid, final int modeFlags);
-
-    int checkUriPermission__super(final Uri uri, final String readPermission,
-            final String writePermission, final int pid, final int uid, final int modeFlags);
-
     void clearWallpaper() throws IOException;
-
-    void clearWallpaper__super() throws IOException;
 
     void closeContextMenu();
 
-    void closeContextMenu__super();
-
     void closeOptionsMenu();
-
-    void closeOptionsMenu__super();
 
     Context createConfigurationContext(final Configuration overrideConfiguration);
 
-    Context createConfigurationContext__super(final Configuration overrideConfiguration);
-
     Context createDisplayContext(final Display display);
-
-    Context createDisplayContext__super(final Display display);
 
     Context createPackageContext(final String packageName, final int flags)
             throws PackageManager.NameNotFoundException;
 
-    Context createPackageContext__super(final String packageName, final int flags)
-            throws PackageManager.NameNotFoundException;
-
     PendingIntent createPendingResult(final int requestCode, final Intent data, final int flags);
-
-    PendingIntent createPendingResult__super(final int requestCode, final Intent data,
-            final int flags);
 
     String[] databaseList();
 
-    String[] databaseList__super();
-
     boolean deleteDatabase(final String name);
-
-    boolean deleteDatabase__super(final String name);
 
     boolean deleteFile(final String name);
 
-    boolean deleteFile__super(final String name);
-
     boolean dispatchGenericMotionEvent(final MotionEvent ev);
-
-    boolean dispatchGenericMotionEvent__super(final MotionEvent ev);
 
     boolean dispatchKeyEvent(final KeyEvent event);
 
-    boolean dispatchKeyEvent__super(final KeyEvent event);
-
     boolean dispatchKeyShortcutEvent(final KeyEvent event);
-
-    boolean dispatchKeyShortcutEvent__super(final KeyEvent event);
 
     boolean dispatchPopulateAccessibilityEvent(final AccessibilityEvent event);
 
-    boolean dispatchPopulateAccessibilityEvent__super(final AccessibilityEvent event);
-
     boolean dispatchTouchEvent(final MotionEvent ev);
 
-    boolean dispatchTouchEvent__super(final MotionEvent ev);
-
     boolean dispatchTrackballEvent(final MotionEvent ev);
-
-    boolean dispatchTrackballEvent__super(final MotionEvent ev);
 
     void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args);
 
-    void dump__super(final String prefix, final FileDescriptor fd, final PrintWriter writer,
-            final String[] args);
-
     void enforceCallingOrSelfPermission(final String permission, final String message);
-
-    void enforceCallingOrSelfPermission__super(final String permission, final String message);
 
     void enforceCallingOrSelfUriPermission(final Uri uri, final int modeFlags,
             final String message);
 
-    void enforceCallingOrSelfUriPermission__super(final Uri uri, final int modeFlags,
-            final String message);
-
     void enforceCallingPermission(final String permission, final String message);
-
-    void enforceCallingPermission__super(final String permission, final String message);
 
     void enforceCallingUriPermission(final Uri uri, final int modeFlags, final String message);
 
-    void enforceCallingUriPermission__super(final Uri uri, final int modeFlags,
-            final String message);
-
     void enforcePermission(final String permission, final int pid, final int uid,
-            final String message);
-
-    void enforcePermission__super(final String permission, final int pid, final int uid,
             final String message);
 
     void enforceUriPermission(final Uri uri, final int pid, final int uid, final int modeFlags,
@@ -240,20 +165,9 @@ public interface ICompositeActivity
             final String writePermission, final int pid, final int uid, final int modeFlags,
             final String message);
 
-    void enforceUriPermission__super(final Uri uri, final int pid, final int uid,
-            final int modeFlags, final String message);
-
-    void enforceUriPermission__super(final Uri uri, final String readPermission,
-            final String writePermission, final int pid, final int uid, final int modeFlags,
-            final String message);
-
     String[] fileList();
 
-    String[] fileList__super();
-
     View findViewById(@IdRes final int id);
-
-    View findViewById__super(@IdRes final int id);
 
     void finish();
 
@@ -261,143 +175,71 @@ public interface ICompositeActivity
 
     void finishActivityFromChild(final Activity child, final int requestCode);
 
-    void finishActivityFromChild__super(final Activity child, final int requestCode);
-
-    void finishActivity__super(final int requestCode);
-
     void finishAffinity();
-
-    void finishAffinity__super();
 
     void finishAfterTransition();
 
-    void finishAfterTransition__super();
-
     void finishAndRemoveTask();
-
-    void finishAndRemoveTask__super();
 
     void finishFromChild(final Activity child);
 
-    void finishFromChild__super(final Activity child);
-
-    void finish__super();
-
     android.app.ActionBar getActionBar();
-
-    android.app.ActionBar getActionBar__super();
 
     Context getApplicationContext();
 
-    Context getApplicationContext__super();
-
     ApplicationInfo getApplicationInfo();
-
-    ApplicationInfo getApplicationInfo__super();
 
     AssetManager getAssets();
 
-    AssetManager getAssets__super();
-
     Context getBaseContext();
-
-    Context getBaseContext__super();
 
     File getCacheDir();
 
-    File getCacheDir__super();
-
     ComponentName getCallingActivity();
-
-    ComponentName getCallingActivity__super();
 
     String getCallingPackage();
 
-    String getCallingPackage__super();
-
     int getChangingConfigurations();
-
-    int getChangingConfigurations__super();
 
     ClassLoader getClassLoader();
 
-    ClassLoader getClassLoader__super();
-
     File getCodeCacheDir();
-
-    File getCodeCacheDir__super();
 
     ComponentName getComponentName();
 
-    ComponentName getComponentName__super();
-
     ContentResolver getContentResolver();
-
-    ContentResolver getContentResolver__super();
 
     Scene getContentScene();
 
-    Scene getContentScene__super();
-
     TransitionManager getContentTransitionManager();
-
-    TransitionManager getContentTransitionManager__super();
 
     View getCurrentFocus();
 
-    View getCurrentFocus__super();
-
     File getDatabasePath(final String name);
-
-    File getDatabasePath__super(final String name);
 
     AppCompatDelegate getDelegate();
 
-    AppCompatDelegate getDelegate__super();
-
     File getDir(final String name, final int mode);
-
-    File getDir__super(final String name, final int mode);
 
     ActionBarDrawerToggle.Delegate getDrawerToggleDelegate();
 
-    ActionBarDrawerToggle.Delegate getDrawerToggleDelegate__super();
-
     File getExternalCacheDir();
-
-    File getExternalCacheDir__super();
 
     File[] getExternalCacheDirs();
 
-    File[] getExternalCacheDirs__super();
-
     File getExternalFilesDir(final String type);
-
-    File getExternalFilesDir__super(final String type);
 
     File[] getExternalFilesDirs(final String type);
 
-    File[] getExternalFilesDirs__super(final String type);
-
     File[] getExternalMediaDirs();
-
-    File[] getExternalMediaDirs__super();
 
     File getFileStreamPath(final String name);
 
-    File getFileStreamPath__super(final String name);
-
     File getFilesDir();
-
-    File getFilesDir__super();
 
     android.app.FragmentManager getFragmentManager();
 
-    android.app.FragmentManager getFragmentManager__super();
-
     Intent getIntent();
-
-    Intent getIntent__super();
 
     Object getLastCompositeCustomNonConfigurationInstance();
 
@@ -407,244 +249,123 @@ public interface ICompositeActivity
 
     LayoutInflater getLayoutInflater();
 
-    LayoutInflater getLayoutInflater__super();
-
     android.app.LoaderManager getLoaderManager();
-
-    android.app.LoaderManager getLoaderManager__super();
 
     String getLocalClassName();
 
-    String getLocalClassName__super();
-
     Looper getMainLooper();
-
-    Looper getMainLooper__super();
 
     MenuInflater getMenuInflater();
 
-    MenuInflater getMenuInflater__super();
-
     File getNoBackupFilesDir();
-
-    File getNoBackupFilesDir__super();
 
     File getObbDir();
 
-    File getObbDir__super();
-
     File[] getObbDirs();
-
-    File[] getObbDirs__super();
 
     String getPackageCodePath();
 
-    String getPackageCodePath__super();
-
     PackageManager getPackageManager();
-
-    PackageManager getPackageManager__super();
 
     String getPackageName();
 
-    String getPackageName__super();
-
     String getPackageResourcePath();
-
-    String getPackageResourcePath__super();
 
     Intent getParentActivityIntent();
 
-    Intent getParentActivityIntent__super();
-
     SharedPreferences getPreferences(final int mode);
-
-    SharedPreferences getPreferences__super(final int mode);
 
     Uri getReferrer();
 
-    Uri getReferrer__super();
-
     int getRequestedOrientation();
-
-    int getRequestedOrientation__super();
 
     Resources getResources();
 
-    Resources getResources__super();
-
     SharedPreferences getSharedPreferences(final String name, final int mode);
-
-    SharedPreferences getSharedPreferences__super(final String name, final int mode);
 
     ActionBar getSupportActionBar();
 
-    ActionBar getSupportActionBar__super();
-
     FragmentManager getSupportFragmentManager();
-
-    FragmentManager getSupportFragmentManager__super();
 
     LoaderManager getSupportLoaderManager();
 
-    LoaderManager getSupportLoaderManager__super();
-
     Intent getSupportParentActivityIntent();
-
-    Intent getSupportParentActivityIntent__super();
 
     Object getSystemService(final String name);
 
     String getSystemServiceName(final Class<?> serviceClass);
 
-    String getSystemServiceName__super(final Class<?> serviceClass);
-
-    Object getSystemService__super(final String name);
-
     int getTaskId();
-
-    int getTaskId__super();
 
     Resources.Theme getTheme();
 
-    Resources.Theme getTheme__super();
-
     VoiceInteractor getVoiceInteractor();
-
-    VoiceInteractor getVoiceInteractor__super();
 
     Drawable getWallpaper();
 
     int getWallpaperDesiredMinimumHeight();
 
-    int getWallpaperDesiredMinimumHeight__super();
-
     int getWallpaperDesiredMinimumWidth();
-
-    int getWallpaperDesiredMinimumWidth__super();
-
-    Drawable getWallpaper__super();
 
     Window getWindow();
 
     WindowManager getWindowManager();
 
-    WindowManager getWindowManager__super();
-
-    Window getWindow__super();
-
     void grantUriPermission(final String toPackage, final Uri uri, final int modeFlags);
-
-    void grantUriPermission__super(final String toPackage, final Uri uri, final int modeFlags);
 
     boolean hasWindowFocus();
 
-    boolean hasWindowFocus__super();
-
     void invalidateOptionsMenu();
-
-    void invalidateOptionsMenu__super();
 
     boolean isChangingConfigurations();
 
-    boolean isChangingConfigurations__super();
-
     boolean isDestroyed();
-
-    boolean isDestroyed__super();
 
     boolean isFinishing();
 
-    boolean isFinishing__super();
-
     boolean isImmersive();
-
-    boolean isImmersive__super();
 
     boolean isRestricted();
 
-    boolean isRestricted__super();
-
     boolean isTaskRoot();
-
-    boolean isTaskRoot__super();
 
     boolean isVoiceInteraction();
 
     boolean isVoiceInteractionRoot();
 
-    boolean isVoiceInteractionRoot__super();
-
-    boolean isVoiceInteraction__super();
-
     boolean moveTaskToBack(final boolean nonRoot);
-
-    boolean moveTaskToBack__super(final boolean nonRoot);
 
     boolean navigateUpTo(final Intent upIntent);
 
     boolean navigateUpToFromChild(final Activity child, final Intent upIntent);
 
-    boolean navigateUpToFromChild__super(final Activity child, final Intent upIntent);
-
-    boolean navigateUpTo__super(final Intent upIntent);
-
     void onActionModeFinished(final android.view.ActionMode mode);
-
-    void onActionModeFinished__super(final android.view.ActionMode mode);
 
     void onActionModeStarted(final android.view.ActionMode mode);
 
-    void onActionModeStarted__super(final android.view.ActionMode mode);
-
     void onActivityReenter(final int resultCode, final Intent data);
-
-    void onActivityReenter__super(final int resultCode, final Intent data);
 
     void onActivityResult(final int requestCode, final int resultCode, final Intent data);
 
-    void onActivityResult__super(final int requestCode, final int resultCode, final Intent data);
-
     void onApplyThemeResource(final Resources.Theme theme, final int resid, final boolean first);
-
-    void onApplyThemeResource__super(final Resources.Theme theme, final int resid,
-            final boolean first);
 
     void onAttachFragment(final Fragment fragment);
 
     void onAttachFragment(final android.app.Fragment fragment);
 
-    void onAttachFragment__super(final Fragment fragment);
-
-    void onAttachFragment__super(final android.app.Fragment fragment);
-
     void onAttachedToWindow();
-
-    void onAttachedToWindow__super();
 
     void onBackPressed();
 
-    void onBackPressed__super();
-
     void onChildTitleChanged(final Activity childActivity, final CharSequence title);
-
-    void onChildTitleChanged__super(final Activity childActivity, final CharSequence title);
 
     void onConfigurationChanged(final Configuration newConfig);
 
-    void onConfigurationChanged__super(final Configuration newConfig);
-
     void onContentChanged();
-
-    void onContentChanged__super();
 
     boolean onContextItemSelected(final MenuItem item);
 
-    boolean onContextItemSelected__super(final MenuItem item);
-
     void onContextMenuClosed(final Menu menu);
-
-    void onContextMenuClosed__super(final Menu menu);
 
     void onCreate(final Bundle savedInstanceState, final PersistableBundle persistentState);
 
@@ -653,215 +374,106 @@ public interface ICompositeActivity
     void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo);
 
-    void onCreateContextMenu__super(final ContextMenu menu, final View v,
-            final ContextMenu.ContextMenuInfo menuInfo);
-
     CharSequence onCreateDescription();
-
-    CharSequence onCreateDescription__super();
 
     Dialog onCreateDialog(final int id);
 
     Dialog onCreateDialog(final int id, final Bundle args);
 
-    Dialog onCreateDialog__super(final int id);
-
-    Dialog onCreateDialog__super(final int id, final Bundle args);
-
     void onCreateNavigateUpTaskStack(final TaskStackBuilder builder);
-
-    void onCreateNavigateUpTaskStack__super(final TaskStackBuilder builder);
 
     boolean onCreateOptionsMenu(final Menu menu);
 
-    boolean onCreateOptionsMenu__super(final Menu menu);
-
     boolean onCreatePanelMenu(final int featureId, final Menu menu);
 
-    boolean onCreatePanelMenu__super(final int featureId, final Menu menu);
-
     View onCreatePanelView(final int featureId);
-
-    View onCreatePanelView__super(final int featureId);
 
     void onCreateSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder);
 
-    void onCreateSupportNavigateUpTaskStack__super(
-            @NonNull final android.support.v4.app.TaskStackBuilder builder);
-
     boolean onCreateThumbnail(final Bitmap outBitmap, final Canvas canvas);
-
-    boolean onCreateThumbnail__super(final Bitmap outBitmap, final Canvas canvas);
 
     View onCreateView(final View parent, final String name, final Context context,
             final AttributeSet attrs);
 
     View onCreateView(final String name, final Context context, final AttributeSet attrs);
 
-    View onCreateView__super(final View parent, final String name, final Context context,
-            final AttributeSet attrs);
-
-    View onCreateView__super(final String name, final Context context, final AttributeSet attrs);
-
-    void onCreate__super(final Bundle savedInstanceState, final PersistableBundle persistentState);
-
-    void onCreate__super(@Nullable final Bundle savedInstanceState);
-
     void onDestroy();
-
-    void onDestroy__super();
 
     void onDetachedFromWindow();
 
-    void onDetachedFromWindow__super();
-
     void onEnterAnimationComplete();
-
-    void onEnterAnimationComplete__super();
 
     boolean onGenericMotionEvent(final MotionEvent event);
 
-    boolean onGenericMotionEvent__super(final MotionEvent event);
-
     boolean onKeyDown(final int keyCode, final KeyEvent event);
-
-    boolean onKeyDown__super(final int keyCode, final KeyEvent event);
 
     boolean onKeyLongPress(final int keyCode, final KeyEvent event);
 
-    boolean onKeyLongPress__super(final int keyCode, final KeyEvent event);
-
     boolean onKeyMultiple(final int keyCode, final int repeatCount, final KeyEvent event);
-
-    boolean onKeyMultiple__super(final int keyCode, final int repeatCount, final KeyEvent event);
 
     boolean onKeyShortcut(final int keyCode, final KeyEvent event);
 
-    boolean onKeyShortcut__super(final int keyCode, final KeyEvent event);
-
     boolean onKeyUp(final int keyCode, final KeyEvent event);
-
-    boolean onKeyUp__super(final int keyCode, final KeyEvent event);
 
     void onLowMemory();
 
-    void onLowMemory__super();
-
     boolean onMenuOpened(final int featureId, final Menu menu);
-
-    boolean onMenuOpened__super(final int featureId, final Menu menu);
 
     boolean onNavigateUp();
 
     boolean onNavigateUpFromChild(final Activity child);
 
-    boolean onNavigateUpFromChild__super(final Activity child);
-
-    boolean onNavigateUp__super();
-
     void onNewIntent(final Intent intent);
-
-    void onNewIntent__super(final Intent intent);
 
     boolean onOptionsItemSelected(final MenuItem item);
 
-    boolean onOptionsItemSelected__super(final MenuItem item);
-
     void onOptionsMenuClosed(final Menu menu);
-
-    void onOptionsMenuClosed__super(final Menu menu);
 
     void onPanelClosed(final int featureId, final Menu menu);
 
-    void onPanelClosed__super(final int featureId, final Menu menu);
-
     void onPause();
-
-    void onPause__super();
 
     void onPostCreate(final Bundle savedInstanceState, final PersistableBundle persistentState);
 
     void onPostCreate(@Nullable final Bundle savedInstanceState);
 
-    void onPostCreate__super(final Bundle savedInstanceState,
-            final PersistableBundle persistentState);
-
-    void onPostCreate__super(@Nullable final Bundle savedInstanceState);
-
     void onPostResume();
-
-    void onPostResume__super();
 
     void onPrepareDialog(final int id, final Dialog dialog);
 
     void onPrepareDialog(final int id, final Dialog dialog, final Bundle args);
 
-    void onPrepareDialog__super(final int id, final Dialog dialog);
-
-    void onPrepareDialog__super(final int id, final Dialog dialog, final Bundle args);
-
     void onPrepareNavigateUpTaskStack(final TaskStackBuilder builder);
-
-    void onPrepareNavigateUpTaskStack__super(final TaskStackBuilder builder);
 
     boolean onPrepareOptionsMenu(final Menu menu);
 
-    boolean onPrepareOptionsMenu__super(final Menu menu);
-
     boolean onPrepareOptionsPanel(final View view, final Menu menu);
 
-    boolean onPrepareOptionsPanel__super(final View view, final Menu menu);
-
     boolean onPreparePanel(final int featureId, final View view, final Menu menu);
-
-    boolean onPreparePanel__super(final int featureId, final View view, final Menu menu);
 
     void onPrepareSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder);
 
-    void onPrepareSupportNavigateUpTaskStack__super(
-            @NonNull final android.support.v4.app.TaskStackBuilder builder);
-
     void onProvideAssistContent(final AssistContent outContent);
-
-    void onProvideAssistContent__super(final AssistContent outContent);
 
     void onProvideAssistData(final Bundle data);
 
-    void onProvideAssistData__super(final Bundle data);
-
     Uri onProvideReferrer();
-
-    Uri onProvideReferrer__super();
 
     void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions,
             @NonNull final int[] grantResults);
 
-    void onRequestPermissionsResult__super(final int requestCode,
-            @NonNull final String[] permissions, @NonNull final int[] grantResults);
-
     void onRestart();
-
-    void onRestart__super();
 
     void onRestoreInstanceState(final Bundle savedInstanceState,
             final PersistableBundle persistentState);
 
     void onRestoreInstanceState(final Bundle savedInstanceState);
 
-    void onRestoreInstanceState__super(final Bundle savedInstanceState,
-            final PersistableBundle persistentState);
-
-    void onRestoreInstanceState__super(final Bundle savedInstanceState);
-
     void onResume();
 
     void onResumeFragments();
-
-    void onResumeFragments__super();
-
-    void onResume__super();
 
     Object onRetainCompositeCustomNonConfigurationInstance();
 
@@ -871,186 +483,92 @@ public interface ICompositeActivity
 
     void onSaveInstanceState(final Bundle outState);
 
-    void onSaveInstanceState__super(final Bundle outState,
-            final PersistableBundle outPersistentState);
-
-    void onSaveInstanceState__super(final Bundle outState);
-
     boolean onSearchRequested(final SearchEvent searchEvent);
 
     boolean onSearchRequested();
 
-    boolean onSearchRequested__super(final SearchEvent searchEvent);
-
-    boolean onSearchRequested__super();
-
     void onStart();
-
-    void onStart__super();
 
     void onStateNotSaved();
 
-    void onStateNotSaved__super();
-
     void onStop();
-
-    void onStop__super();
 
     void onSupportActionModeFinished(@NonNull final ActionMode mode);
 
-    void onSupportActionModeFinished__super(@NonNull final ActionMode mode);
-
     void onSupportActionModeStarted(@NonNull final ActionMode mode);
-
-    void onSupportActionModeStarted__super(@NonNull final ActionMode mode);
 
     void onSupportContentChanged();
 
-    void onSupportContentChanged__super();
-
     boolean onSupportNavigateUp();
-
-    boolean onSupportNavigateUp__super();
 
     void onTitleChanged(final CharSequence title, final int color);
 
-    void onTitleChanged__super(final CharSequence title, final int color);
-
     boolean onTouchEvent(final MotionEvent event);
-
-    boolean onTouchEvent__super(final MotionEvent event);
 
     boolean onTrackballEvent(final MotionEvent event);
 
-    boolean onTrackballEvent__super(final MotionEvent event);
-
     void onTrimMemory(final int level);
-
-    void onTrimMemory__super(final int level);
 
     void onUserInteraction();
 
-    void onUserInteraction__super();
-
     void onUserLeaveHint();
-
-    void onUserLeaveHint__super();
 
     void onVisibleBehindCanceled();
 
-    void onVisibleBehindCanceled__super();
-
     void onWindowAttributesChanged(final WindowManager.LayoutParams params);
-
-    void onWindowAttributesChanged__super(final WindowManager.LayoutParams params);
 
     void onWindowFocusChanged(final boolean hasFocus);
 
-    void onWindowFocusChanged__super(final boolean hasFocus);
-
     android.view.ActionMode onWindowStartingActionMode(
             final android.view.ActionMode.Callback callback);
 
     android.view.ActionMode onWindowStartingActionMode(
-            final android.view.ActionMode.Callback callback, final int type);
-
-    android.view.ActionMode onWindowStartingActionMode__super(
-            final android.view.ActionMode.Callback callback);
-
-    android.view.ActionMode onWindowStartingActionMode__super(
             final android.view.ActionMode.Callback callback, final int type);
 
     ActionMode onWindowStartingSupportActionMode(@NonNull final ActionMode.Callback callback);
 
-    ActionMode onWindowStartingSupportActionMode__super(
-            @NonNull final ActionMode.Callback callback);
-
     void openContextMenu(final View view);
-
-    void openContextMenu__super(final View view);
 
     FileInputStream openFileInput(final String name) throws FileNotFoundException;
 
-    FileInputStream openFileInput__super(final String name) throws FileNotFoundException;
-
     FileOutputStream openFileOutput(final String name, final int mode) throws FileNotFoundException;
-
-    FileOutputStream openFileOutput__super(final String name, final int mode)
-            throws FileNotFoundException;
 
     void openOptionsMenu();
 
-    void openOptionsMenu__super();
-
     SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory);
 
     SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
-            final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler);
-
-    SQLiteDatabase openOrCreateDatabase__super(final String name, final int mode,
-            final SQLiteDatabase.CursorFactory factory);
-
-    SQLiteDatabase openOrCreateDatabase__super(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler);
 
     void overridePendingTransition(final int enterAnim, final int exitAnim);
 
-    void overridePendingTransition__super(final int enterAnim, final int exitAnim);
-
     Drawable peekWallpaper();
-
-    Drawable peekWallpaper__super();
 
     void postponeEnterTransition();
 
-    void postponeEnterTransition__super();
-
     void recreate();
-
-    void recreate__super();
 
     void registerComponentCallbacks(final ComponentCallbacks callback);
 
-    void registerComponentCallbacks__super(final ComponentCallbacks callback);
-
     void registerForContextMenu(final View view);
-
-    void registerForContextMenu__super(final View view);
 
     Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter);
 
     Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter,
             final String broadcastPermission, final Handler scheduler);
 
-    Intent registerReceiver__super(final BroadcastReceiver receiver, final IntentFilter filter);
-
-    Intent registerReceiver__super(final BroadcastReceiver receiver, final IntentFilter filter,
-            final String broadcastPermission, final Handler scheduler);
-
     boolean releaseInstance();
-
-    boolean releaseInstance__super();
 
     void removeStickyBroadcast(final Intent intent);
 
     void removeStickyBroadcastAsUser(final Intent intent, final UserHandle user);
 
-    void removeStickyBroadcastAsUser__super(final Intent intent, final UserHandle user);
-
-    void removeStickyBroadcast__super(final Intent intent);
-
     void reportFullyDrawn();
-
-    void reportFullyDrawn__super();
 
     boolean requestVisibleBehind(final boolean visible);
 
-    boolean requestVisibleBehind__super(final boolean visible);
-
     void revokeUriPermission(final Uri uri, final int modeFlags);
-
-    void revokeUriPermission__super(final Uri uri, final int modeFlags);
 
     void sendBroadcast(final Intent intent);
 
@@ -1060,15 +578,6 @@ public interface ICompositeActivity
 
     void sendBroadcastAsUser(final Intent intent, final UserHandle user,
             final String receiverPermission);
-
-    void sendBroadcastAsUser__super(final Intent intent, final UserHandle user);
-
-    void sendBroadcastAsUser__super(final Intent intent, final UserHandle user,
-            final String receiverPermission);
-
-    void sendBroadcast__super(final Intent intent);
-
-    void sendBroadcast__super(final Intent intent, final String receiverPermission);
 
     void sendOrderedBroadcast(final Intent intent, final String receiverPermission);
 
@@ -1081,24 +590,9 @@ public interface ICompositeActivity
             final Handler scheduler, final int initialCode, final String initialData,
             final Bundle initialExtras);
 
-    void sendOrderedBroadcastAsUser__super(final Intent intent, final UserHandle user,
-            final String receiverPermission, final BroadcastReceiver resultReceiver,
-            final Handler scheduler, final int initialCode, final String initialData,
-            final Bundle initialExtras);
-
-    void sendOrderedBroadcast__super(final Intent intent, final String receiverPermission);
-
-    void sendOrderedBroadcast__super(final Intent intent, final String receiverPermission,
-            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
-            final String initialData, final Bundle initialExtras);
-
     void sendStickyBroadcast(final Intent intent);
 
     void sendStickyBroadcastAsUser(final Intent intent, final UserHandle user);
-
-    void sendStickyBroadcastAsUser__super(final Intent intent, final UserHandle user);
-
-    void sendStickyBroadcast__super(final Intent intent);
 
     void sendStickyOrderedBroadcast(final Intent intent, final BroadcastReceiver resultReceiver,
             final Handler scheduler, final int initialCode, final String initialData,
@@ -1108,21 +602,9 @@ public interface ICompositeActivity
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras);
 
-    void sendStickyOrderedBroadcastAsUser__super(final Intent intent, final UserHandle user,
-            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
-            final String initialData, final Bundle initialExtras);
-
-    void sendStickyOrderedBroadcast__super(final Intent intent,
-            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
-            final String initialData, final Bundle initialExtras);
-
     void setActionBar(final Toolbar toolbar);
 
-    void setActionBar__super(final Toolbar toolbar);
-
     void setContentTransitionManager(final TransitionManager tm);
-
-    void setContentTransitionManager__super(final TransitionManager tm);
 
     void setContentView(@LayoutRes final int layoutResID);
 
@@ -1130,47 +612,23 @@ public interface ICompositeActivity
 
     void setContentView(final View view, final ViewGroup.LayoutParams params);
 
-    void setContentView__super(@LayoutRes final int layoutResID);
-
-    void setContentView__super(final View view);
-
-    void setContentView__super(final View view, final ViewGroup.LayoutParams params);
-
     void setEnterSharedElementCallback(final SharedElementCallback callback);
 
     void setEnterSharedElementCallback(final android.app.SharedElementCallback callback);
-
-    void setEnterSharedElementCallback__super(final SharedElementCallback callback);
-
-    void setEnterSharedElementCallback__super(final android.app.SharedElementCallback callback);
 
     void setExitSharedElementCallback(final SharedElementCallback listener);
 
     void setExitSharedElementCallback(final android.app.SharedElementCallback callback);
 
-    void setExitSharedElementCallback__super(final SharedElementCallback listener);
-
-    void setExitSharedElementCallback__super(final android.app.SharedElementCallback callback);
-
     void setFinishOnTouchOutside(final boolean finish);
-
-    void setFinishOnTouchOutside__super(final boolean finish);
 
     void setImmersive(final boolean i);
 
-    void setImmersive__super(final boolean i);
-
     void setIntent(final Intent newIntent);
-
-    void setIntent__super(final Intent newIntent);
 
     void setRequestedOrientation(final int requestedOrientation);
 
-    void setRequestedOrientation__super(final int requestedOrientation);
-
     void setSupportActionBar(@Nullable final android.support.v7.widget.Toolbar toolbar);
-
-    void setSupportActionBar__super(@Nullable final android.support.v7.widget.Toolbar toolbar);
 
     void setSupportProgress(final int progress);
 
@@ -1178,23 +636,11 @@ public interface ICompositeActivity
 
     void setSupportProgressBarIndeterminateVisibility(final boolean visible);
 
-    void setSupportProgressBarIndeterminateVisibility__super(final boolean visible);
-
-    void setSupportProgressBarIndeterminate__super(final boolean indeterminate);
-
     void setSupportProgressBarVisibility(final boolean visible);
-
-    void setSupportProgressBarVisibility__super(final boolean visible);
-
-    void setSupportProgress__super(final int progress);
 
     void setTaskDescription(final ActivityManager.TaskDescription taskDescription);
 
-    void setTaskDescription__super(final ActivityManager.TaskDescription taskDescription);
-
     void setTheme(@StyleRes final int resid);
-
-    void setTheme__super(@StyleRes final int resid);
 
     void setTitle(final CharSequence title);
 
@@ -1202,57 +648,28 @@ public interface ICompositeActivity
 
     void setTitleColor(final int textColor);
 
-    void setTitleColor__super(final int textColor);
-
-    void setTitle__super(final CharSequence title);
-
-    void setTitle__super(final int titleId);
-
     void setVisible(final boolean visible);
-
-    void setVisible__super(final boolean visible);
 
     void setWallpaper(final Bitmap bitmap) throws IOException;
 
     void setWallpaper(final InputStream data) throws IOException;
 
-    void setWallpaper__super(final Bitmap bitmap) throws IOException;
-
-    void setWallpaper__super(final InputStream data) throws IOException;
-
     boolean shouldShowRequestPermissionRationale(final String permission);
-
-    boolean shouldShowRequestPermissionRationale__super(final String permission);
 
     boolean shouldUpRecreateTask(final Intent targetIntent);
 
-    boolean shouldUpRecreateTask__super(final Intent targetIntent);
-
     boolean showAssist(final Bundle args);
 
-    boolean showAssist__super(final Bundle args);
-
     void showLockTaskEscapeMessage();
-
-    void showLockTaskEscapeMessage__super();
 
     android.view.ActionMode startActionMode(final android.view.ActionMode.Callback callback);
 
     android.view.ActionMode startActionMode(final android.view.ActionMode.Callback callback,
             final int type);
 
-    android.view.ActionMode startActionMode__super(final android.view.ActionMode.Callback callback);
-
-    android.view.ActionMode startActionMode__super(final android.view.ActionMode.Callback callback,
-            final int type);
-
     void startActivities(final Intent[] intents);
 
     void startActivities(final Intent[] intents, final Bundle options);
-
-    void startActivities__super(final Intent[] intents);
-
-    void startActivities__super(final Intent[] intents, final Bundle options);
 
     void startActivity(final Intent intent);
 
@@ -1262,22 +679,11 @@ public interface ICompositeActivity
 
     void startActivityForResult(final Intent intent, final int requestCode, final Bundle options);
 
-    void startActivityForResult__super(final Intent intent, final int requestCode);
-
-    void startActivityForResult__super(final Intent intent, final int requestCode,
-            final Bundle options);
-
     void startActivityFromChild(final Activity child, final Intent intent, final int requestCode);
 
     void startActivityFromChild(final Activity child, final Intent intent, final int requestCode,
             final Bundle options);
 
-    void startActivityFromChild__super(final Activity child, final Intent intent,
-            final int requestCode);
-
-    void startActivityFromChild__super(final Activity child, final Intent intent,
-            final int requestCode, final Bundle options);
-
     void startActivityFromFragment(final Fragment fragment, final Intent intent,
             final int requestCode);
 
@@ -1288,39 +694,15 @@ public interface ICompositeActivity
             final int requestCode);
 
     void startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
-            final int requestCode, final Bundle options);
-
-    void startActivityFromFragment__super(final Fragment fragment, final Intent intent,
-            final int requestCode);
-
-    void startActivityFromFragment__super(final Fragment fragment, final Intent intent,
-            final int requestCode, @Nullable final Bundle options);
-
-    void startActivityFromFragment__super(final android.app.Fragment fragment, final Intent intent,
-            final int requestCode);
-
-    void startActivityFromFragment__super(final android.app.Fragment fragment, final Intent intent,
             final int requestCode, final Bundle options);
 
     boolean startActivityIfNeeded(final Intent intent, final int requestCode);
 
     boolean startActivityIfNeeded(final Intent intent, final int requestCode, final Bundle options);
 
-    boolean startActivityIfNeeded__super(final Intent intent, final int requestCode);
-
-    boolean startActivityIfNeeded__super(final Intent intent, final int requestCode,
-            final Bundle options);
-
-    void startActivity__super(final Intent intent);
-
-    void startActivity__super(final Intent intent, final Bundle options);
-
     boolean startInstrumentation(final ComponentName className, final String profileFile,
             final Bundle arguments);
 
-    boolean startInstrumentation__super(final ComponentName className, final String profileFile,
-            final Bundle arguments);
-
     void startIntentSender(final IntentSender intent, final Intent fillInIntent,
             final int flagsMask, final int flagsValues, final int extraFlags)
             throws IntentSender.SendIntentException;
@@ -1337,14 +719,6 @@ public interface ICompositeActivity
             final Intent fillInIntent, final int flagsMask, final int flagsValues,
             final int extraFlags, final Bundle options) throws IntentSender.SendIntentException;
 
-    void startIntentSenderForResult__super(final IntentSender intent, final int requestCode,
-            final Intent fillInIntent, final int flagsMask, final int flagsValues,
-            final int extraFlags) throws IntentSender.SendIntentException;
-
-    void startIntentSenderForResult__super(final IntentSender intent, final int requestCode,
-            final Intent fillInIntent, final int flagsMask, final int flagsValues,
-            final int extraFlags, final Bundle options) throws IntentSender.SendIntentException;
-
     void startIntentSenderFromChild(final Activity child, final IntentSender intent,
             final int requestCode, final Intent fillInIntent, final int flagsMask,
             final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException;
@@ -1352,120 +726,745 @@ public interface ICompositeActivity
     void startIntentSenderFromChild(final Activity child, final IntentSender intent,
             final int requestCode, final Intent fillInIntent, final int flagsMask,
             final int flagsValues, final int extraFlags, final Bundle options)
-            throws IntentSender.SendIntentException;
-
-    void startIntentSenderFromChild__super(final Activity child, final IntentSender intent,
-            final int requestCode, final Intent fillInIntent, final int flagsMask,
-            final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException;
-
-    void startIntentSenderFromChild__super(final Activity child, final IntentSender intent,
-            final int requestCode, final Intent fillInIntent, final int flagsMask,
-            final int flagsValues, final int extraFlags, final Bundle options)
-            throws IntentSender.SendIntentException;
-
-    void startIntentSender__super(final IntentSender intent, final Intent fillInIntent,
-            final int flagsMask, final int flagsValues, final int extraFlags)
-            throws IntentSender.SendIntentException;
-
-    void startIntentSender__super(final IntentSender intent, final Intent fillInIntent,
-            final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException;
 
     void startLockTask();
 
-    void startLockTask__super();
-
     void startManagingCursor(final Cursor c);
-
-    void startManagingCursor__super(final Cursor c);
 
     boolean startNextMatchingActivity(final Intent intent);
 
     boolean startNextMatchingActivity(final Intent intent, final Bundle options);
 
-    boolean startNextMatchingActivity__super(final Intent intent);
-
-    boolean startNextMatchingActivity__super(final Intent intent, final Bundle options);
-
     void startPostponedEnterTransition();
-
-    void startPostponedEnterTransition__super();
 
     void startSearch(final String initialQuery, final boolean selectInitialQuery,
             final Bundle appSearchData, final boolean globalSearch);
 
-    void startSearch__super(final String initialQuery, final boolean selectInitialQuery,
-            final Bundle appSearchData, final boolean globalSearch);
-
     ComponentName startService(final Intent service);
-
-    ComponentName startService__super(final Intent service);
 
     ActionMode startSupportActionMode(@NonNull final ActionMode.Callback callback);
 
-    ActionMode startSupportActionMode__super(@NonNull final ActionMode.Callback callback);
-
     void stopLockTask();
-
-    void stopLockTask__super();
 
     void stopManagingCursor(final Cursor c);
 
-    void stopManagingCursor__super(final Cursor c);
-
     boolean stopService(final Intent name);
 
-    boolean stopService__super(final Intent name);
+    void super_addContentView(final View view, final ViewGroup.LayoutParams params);
+
+    void super_applyOverrideConfiguration(final Configuration overrideConfiguration);
+
+    void super_attachBaseContext(final Context newBase);
+
+    boolean super_bindService(final Intent service, final ServiceConnection conn, final int flags);
+
+    int super_checkCallingOrSelfPermission(final String permission);
+
+    int super_checkCallingOrSelfUriPermission(final Uri uri, final int modeFlags);
+
+    int super_checkCallingPermission(final String permission);
+
+    int super_checkCallingUriPermission(final Uri uri, final int modeFlags);
+
+    int super_checkPermission(final String permission, final int pid, final int uid);
+
+    int super_checkSelfPermission(final String permission);
+
+    int super_checkUriPermission(final Uri uri, final int pid, final int uid, final int modeFlags);
+
+    int super_checkUriPermission(final Uri uri, final String readPermission,
+            final String writePermission, final int pid, final int uid, final int modeFlags);
+
+    void super_clearWallpaper() throws IOException;
+
+    void super_closeContextMenu();
+
+    void super_closeOptionsMenu();
+
+    Context super_createConfigurationContext(final Configuration overrideConfiguration);
+
+    Context super_createDisplayContext(final Display display);
+
+    Context super_createPackageContext(final String packageName, final int flags)
+            throws PackageManager.NameNotFoundException;
+
+    PendingIntent super_createPendingResult(final int requestCode, final Intent data,
+            final int flags);
+
+    String[] super_databaseList();
+
+    boolean super_deleteDatabase(final String name);
+
+    boolean super_deleteFile(final String name);
+
+    boolean super_dispatchGenericMotionEvent(final MotionEvent ev);
+
+    boolean super_dispatchKeyEvent(final KeyEvent event);
+
+    boolean super_dispatchKeyShortcutEvent(final KeyEvent event);
+
+    boolean super_dispatchPopulateAccessibilityEvent(final AccessibilityEvent event);
+
+    boolean super_dispatchTouchEvent(final MotionEvent ev);
+
+    boolean super_dispatchTrackballEvent(final MotionEvent ev);
+
+    void super_dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
+            final String[] args);
+
+    void super_enforceCallingOrSelfPermission(final String permission, final String message);
+
+    void super_enforceCallingOrSelfUriPermission(final Uri uri, final int modeFlags,
+            final String message);
+
+    void super_enforceCallingPermission(final String permission, final String message);
+
+    void super_enforceCallingUriPermission(final Uri uri, final int modeFlags,
+            final String message);
+
+    void super_enforcePermission(final String permission, final int pid, final int uid,
+            final String message);
+
+    void super_enforceUriPermission(final Uri uri, final int pid, final int uid,
+            final int modeFlags, final String message);
+
+    void super_enforceUriPermission(final Uri uri, final String readPermission,
+            final String writePermission, final int pid, final int uid, final int modeFlags,
+            final String message);
+
+    String[] super_fileList();
+
+    View super_findViewById(@IdRes final int id);
+
+    void super_finish();
+
+    void super_finishActivity(final int requestCode);
+
+    void super_finishActivityFromChild(final Activity child, final int requestCode);
+
+    void super_finishAffinity();
+
+    void super_finishAfterTransition();
+
+    void super_finishAndRemoveTask();
+
+    void super_finishFromChild(final Activity child);
+
+    android.app.ActionBar super_getActionBar();
+
+    Context super_getApplicationContext();
+
+    ApplicationInfo super_getApplicationInfo();
+
+    AssetManager super_getAssets();
+
+    Context super_getBaseContext();
+
+    File super_getCacheDir();
+
+    ComponentName super_getCallingActivity();
+
+    String super_getCallingPackage();
+
+    int super_getChangingConfigurations();
+
+    ClassLoader super_getClassLoader();
+
+    File super_getCodeCacheDir();
+
+    ComponentName super_getComponentName();
+
+    ContentResolver super_getContentResolver();
+
+    Scene super_getContentScene();
+
+    TransitionManager super_getContentTransitionManager();
+
+    View super_getCurrentFocus();
+
+    File super_getDatabasePath(final String name);
+
+    AppCompatDelegate super_getDelegate();
+
+    File super_getDir(final String name, final int mode);
+
+    ActionBarDrawerToggle.Delegate super_getDrawerToggleDelegate();
+
+    File super_getExternalCacheDir();
+
+    File[] super_getExternalCacheDirs();
+
+    File super_getExternalFilesDir(final String type);
+
+    File[] super_getExternalFilesDirs(final String type);
+
+    File[] super_getExternalMediaDirs();
+
+    File super_getFileStreamPath(final String name);
+
+    File super_getFilesDir();
+
+    android.app.FragmentManager super_getFragmentManager();
+
+    Intent super_getIntent();
+
+    LayoutInflater super_getLayoutInflater();
+
+    android.app.LoaderManager super_getLoaderManager();
+
+    String super_getLocalClassName();
+
+    Looper super_getMainLooper();
+
+    MenuInflater super_getMenuInflater();
+
+    File super_getNoBackupFilesDir();
+
+    File super_getObbDir();
+
+    File[] super_getObbDirs();
+
+    String super_getPackageCodePath();
+
+    PackageManager super_getPackageManager();
+
+    String super_getPackageName();
+
+    String super_getPackageResourcePath();
+
+    Intent super_getParentActivityIntent();
+
+    SharedPreferences super_getPreferences(final int mode);
+
+    Uri super_getReferrer();
+
+    int super_getRequestedOrientation();
+
+    Resources super_getResources();
+
+    SharedPreferences super_getSharedPreferences(final String name, final int mode);
+
+    ActionBar super_getSupportActionBar();
+
+    FragmentManager super_getSupportFragmentManager();
+
+    LoaderManager super_getSupportLoaderManager();
+
+    Intent super_getSupportParentActivityIntent();
+
+    Object super_getSystemService(final String name);
+
+    String super_getSystemServiceName(final Class<?> serviceClass);
+
+    int super_getTaskId();
+
+    Resources.Theme super_getTheme();
+
+    VoiceInteractor super_getVoiceInteractor();
+
+    Drawable super_getWallpaper();
+
+    int super_getWallpaperDesiredMinimumHeight();
+
+    int super_getWallpaperDesiredMinimumWidth();
+
+    Window super_getWindow();
+
+    WindowManager super_getWindowManager();
+
+    void super_grantUriPermission(final String toPackage, final Uri uri, final int modeFlags);
+
+    boolean super_hasWindowFocus();
+
+    void super_invalidateOptionsMenu();
+
+    boolean super_isChangingConfigurations();
+
+    boolean super_isDestroyed();
+
+    boolean super_isFinishing();
+
+    boolean super_isImmersive();
+
+    boolean super_isRestricted();
+
+    boolean super_isTaskRoot();
+
+    boolean super_isVoiceInteraction();
+
+    boolean super_isVoiceInteractionRoot();
+
+    boolean super_moveTaskToBack(final boolean nonRoot);
+
+    boolean super_navigateUpTo(final Intent upIntent);
+
+    boolean super_navigateUpToFromChild(final Activity child, final Intent upIntent);
+
+    void super_onActionModeFinished(final android.view.ActionMode mode);
+
+    void super_onActionModeStarted(final android.view.ActionMode mode);
+
+    void super_onActivityReenter(final int resultCode, final Intent data);
+
+    void super_onActivityResult(final int requestCode, final int resultCode, final Intent data);
+
+    void super_onApplyThemeResource(final Resources.Theme theme, final int resid,
+            final boolean first);
+
+    void super_onAttachFragment(final Fragment fragment);
+
+    void super_onAttachFragment(final android.app.Fragment fragment);
+
+    void super_onAttachedToWindow();
+
+    void super_onBackPressed();
+
+    void super_onChildTitleChanged(final Activity childActivity, final CharSequence title);
+
+    void super_onConfigurationChanged(final Configuration newConfig);
+
+    void super_onContentChanged();
+
+    boolean super_onContextItemSelected(final MenuItem item);
+
+    void super_onContextMenuClosed(final Menu menu);
+
+    void super_onCreate(final Bundle savedInstanceState, final PersistableBundle persistentState);
+
+    void super_onCreate(@Nullable final Bundle savedInstanceState);
+
+    void super_onCreateContextMenu(final ContextMenu menu, final View v,
+            final ContextMenu.ContextMenuInfo menuInfo);
+
+    CharSequence super_onCreateDescription();
+
+    Dialog super_onCreateDialog(final int id);
+
+    Dialog super_onCreateDialog(final int id, final Bundle args);
+
+    void super_onCreateNavigateUpTaskStack(final TaskStackBuilder builder);
+
+    boolean super_onCreateOptionsMenu(final Menu menu);
+
+    boolean super_onCreatePanelMenu(final int featureId, final Menu menu);
+
+    View super_onCreatePanelView(final int featureId);
+
+    void super_onCreateSupportNavigateUpTaskStack(
+            @NonNull final android.support.v4.app.TaskStackBuilder builder);
+
+    boolean super_onCreateThumbnail(final Bitmap outBitmap, final Canvas canvas);
+
+    View super_onCreateView(final View parent, final String name, final Context context,
+            final AttributeSet attrs);
+
+    View super_onCreateView(final String name, final Context context, final AttributeSet attrs);
+
+    void super_onDestroy();
+
+    void super_onDetachedFromWindow();
+
+    void super_onEnterAnimationComplete();
+
+    boolean super_onGenericMotionEvent(final MotionEvent event);
+
+    boolean super_onKeyDown(final int keyCode, final KeyEvent event);
+
+    boolean super_onKeyLongPress(final int keyCode, final KeyEvent event);
+
+    boolean super_onKeyMultiple(final int keyCode, final int repeatCount, final KeyEvent event);
+
+    boolean super_onKeyShortcut(final int keyCode, final KeyEvent event);
+
+    boolean super_onKeyUp(final int keyCode, final KeyEvent event);
+
+    void super_onLowMemory();
+
+    boolean super_onMenuOpened(final int featureId, final Menu menu);
+
+    boolean super_onNavigateUp();
+
+    boolean super_onNavigateUpFromChild(final Activity child);
+
+    void super_onNewIntent(final Intent intent);
+
+    boolean super_onOptionsItemSelected(final MenuItem item);
+
+    void super_onOptionsMenuClosed(final Menu menu);
+
+    void super_onPanelClosed(final int featureId, final Menu menu);
+
+    void super_onPause();
+
+    void super_onPostCreate(final Bundle savedInstanceState,
+            final PersistableBundle persistentState);
+
+    void super_onPostCreate(@Nullable final Bundle savedInstanceState);
+
+    void super_onPostResume();
+
+    void super_onPrepareDialog(final int id, final Dialog dialog);
+
+    void super_onPrepareDialog(final int id, final Dialog dialog, final Bundle args);
+
+    void super_onPrepareNavigateUpTaskStack(final TaskStackBuilder builder);
+
+    boolean super_onPrepareOptionsMenu(final Menu menu);
+
+    boolean super_onPrepareOptionsPanel(final View view, final Menu menu);
+
+    boolean super_onPreparePanel(final int featureId, final View view, final Menu menu);
+
+    void super_onPrepareSupportNavigateUpTaskStack(
+            @NonNull final android.support.v4.app.TaskStackBuilder builder);
+
+    void super_onProvideAssistContent(final AssistContent outContent);
+
+    void super_onProvideAssistData(final Bundle data);
+
+    Uri super_onProvideReferrer();
+
+    void super_onRequestPermissionsResult(final int requestCode,
+            @NonNull final String[] permissions, @NonNull final int[] grantResults);
+
+    void super_onRestart();
+
+    void super_onRestoreInstanceState(final Bundle savedInstanceState,
+            final PersistableBundle persistentState);
+
+    void super_onRestoreInstanceState(final Bundle savedInstanceState);
+
+    void super_onResume();
+
+    void super_onResumeFragments();
+
+    void super_onSaveInstanceState(final Bundle outState,
+            final PersistableBundle outPersistentState);
+
+    void super_onSaveInstanceState(final Bundle outState);
+
+    boolean super_onSearchRequested(final SearchEvent searchEvent);
+
+    boolean super_onSearchRequested();
+
+    void super_onStart();
+
+    void super_onStateNotSaved();
+
+    void super_onStop();
+
+    void super_onSupportActionModeFinished(@NonNull final ActionMode mode);
+
+    void super_onSupportActionModeStarted(@NonNull final ActionMode mode);
+
+    void super_onSupportContentChanged();
+
+    boolean super_onSupportNavigateUp();
+
+    void super_onTitleChanged(final CharSequence title, final int color);
+
+    boolean super_onTouchEvent(final MotionEvent event);
+
+    boolean super_onTrackballEvent(final MotionEvent event);
+
+    void super_onTrimMemory(final int level);
+
+    void super_onUserInteraction();
+
+    void super_onUserLeaveHint();
+
+    void super_onVisibleBehindCanceled();
+
+    void super_onWindowAttributesChanged(final WindowManager.LayoutParams params);
+
+    void super_onWindowFocusChanged(final boolean hasFocus);
+
+    android.view.ActionMode super_onWindowStartingActionMode(
+            final android.view.ActionMode.Callback callback);
+
+    android.view.ActionMode super_onWindowStartingActionMode(
+            final android.view.ActionMode.Callback callback, final int type);
+
+    ActionMode super_onWindowStartingSupportActionMode(@NonNull final ActionMode.Callback callback);
+
+    void super_openContextMenu(final View view);
+
+    FileInputStream super_openFileInput(final String name) throws FileNotFoundException;
+
+    FileOutputStream super_openFileOutput(final String name, final int mode)
+            throws FileNotFoundException;
+
+    void super_openOptionsMenu();
+
+    SQLiteDatabase super_openOrCreateDatabase(final String name, final int mode,
+            final SQLiteDatabase.CursorFactory factory);
+
+    SQLiteDatabase super_openOrCreateDatabase(final String name, final int mode,
+            final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler);
+
+    void super_overridePendingTransition(final int enterAnim, final int exitAnim);
+
+    Drawable super_peekWallpaper();
+
+    void super_postponeEnterTransition();
+
+    void super_recreate();
+
+    void super_registerComponentCallbacks(final ComponentCallbacks callback);
+
+    void super_registerForContextMenu(final View view);
+
+    Intent super_registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter);
+
+    Intent super_registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter,
+            final String broadcastPermission, final Handler scheduler);
+
+    boolean super_releaseInstance();
+
+    void super_removeStickyBroadcast(final Intent intent);
+
+    void super_removeStickyBroadcastAsUser(final Intent intent, final UserHandle user);
+
+    void super_reportFullyDrawn();
+
+    boolean super_requestVisibleBehind(final boolean visible);
+
+    void super_revokeUriPermission(final Uri uri, final int modeFlags);
+
+    void super_sendBroadcast(final Intent intent);
+
+    void super_sendBroadcast(final Intent intent, final String receiverPermission);
+
+    void super_sendBroadcastAsUser(final Intent intent, final UserHandle user);
+
+    void super_sendBroadcastAsUser(final Intent intent, final UserHandle user,
+            final String receiverPermission);
+
+    void super_sendOrderedBroadcast(final Intent intent, final String receiverPermission);
+
+    void super_sendOrderedBroadcast(final Intent intent, final String receiverPermission,
+            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
+            final String initialData, final Bundle initialExtras);
+
+    void super_sendOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
+            final String receiverPermission, final BroadcastReceiver resultReceiver,
+            final Handler scheduler, final int initialCode, final String initialData,
+            final Bundle initialExtras);
+
+    void super_sendStickyBroadcast(final Intent intent);
+
+    void super_sendStickyBroadcastAsUser(final Intent intent, final UserHandle user);
+
+    void super_sendStickyOrderedBroadcast(final Intent intent,
+            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
+            final String initialData, final Bundle initialExtras);
+
+    void super_sendStickyOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
+            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
+            final String initialData, final Bundle initialExtras);
+
+    void super_setActionBar(final Toolbar toolbar);
+
+    void super_setContentTransitionManager(final TransitionManager tm);
+
+    void super_setContentView(@LayoutRes final int layoutResID);
+
+    void super_setContentView(final View view);
+
+    void super_setContentView(final View view, final ViewGroup.LayoutParams params);
+
+    void super_setEnterSharedElementCallback(final SharedElementCallback callback);
+
+    void super_setEnterSharedElementCallback(final android.app.SharedElementCallback callback);
+
+    void super_setExitSharedElementCallback(final SharedElementCallback listener);
+
+    void super_setExitSharedElementCallback(final android.app.SharedElementCallback callback);
+
+    void super_setFinishOnTouchOutside(final boolean finish);
+
+    void super_setImmersive(final boolean i);
+
+    void super_setIntent(final Intent newIntent);
+
+    void super_setRequestedOrientation(final int requestedOrientation);
+
+    void super_setSupportActionBar(@Nullable final android.support.v7.widget.Toolbar toolbar);
+
+    void super_setSupportProgress(final int progress);
+
+    void super_setSupportProgressBarIndeterminate(final boolean indeterminate);
+
+    void super_setSupportProgressBarIndeterminateVisibility(final boolean visible);
+
+    void super_setSupportProgressBarVisibility(final boolean visible);
+
+    void super_setTaskDescription(final ActivityManager.TaskDescription taskDescription);
+
+    void super_setTheme(@StyleRes final int resid);
+
+    void super_setTitle(final CharSequence title);
+
+    void super_setTitle(final int titleId);
+
+    void super_setTitleColor(final int textColor);
+
+    void super_setVisible(final boolean visible);
+
+    void super_setWallpaper(final Bitmap bitmap) throws IOException;
+
+    void super_setWallpaper(final InputStream data) throws IOException;
+
+    boolean super_shouldShowRequestPermissionRationale(final String permission);
+
+    boolean super_shouldUpRecreateTask(final Intent targetIntent);
+
+    boolean super_showAssist(final Bundle args);
+
+    void super_showLockTaskEscapeMessage();
+
+    android.view.ActionMode super_startActionMode(final android.view.ActionMode.Callback callback);
+
+    android.view.ActionMode super_startActionMode(final android.view.ActionMode.Callback callback,
+            final int type);
+
+    void super_startActivities(final Intent[] intents);
+
+    void super_startActivities(final Intent[] intents, final Bundle options);
+
+    void super_startActivity(final Intent intent);
+
+    void super_startActivity(final Intent intent, final Bundle options);
+
+    void super_startActivityForResult(final Intent intent, final int requestCode);
+
+    void super_startActivityForResult(final Intent intent, final int requestCode,
+            final Bundle options);
+
+    void super_startActivityFromChild(final Activity child, final Intent intent,
+            final int requestCode);
+
+    void super_startActivityFromChild(final Activity child, final Intent intent,
+            final int requestCode, final Bundle options);
+
+    void super_startActivityFromFragment(final Fragment fragment, final Intent intent,
+            final int requestCode);
+
+    void super_startActivityFromFragment(final Fragment fragment, final Intent intent,
+            final int requestCode, @Nullable final Bundle options);
+
+    void super_startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
+            final int requestCode);
+
+    void super_startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
+            final int requestCode, final Bundle options);
+
+    boolean super_startActivityIfNeeded(final Intent intent, final int requestCode);
+
+    boolean super_startActivityIfNeeded(final Intent intent, final int requestCode,
+            final Bundle options);
+
+    boolean super_startInstrumentation(final ComponentName className, final String profileFile,
+            final Bundle arguments);
+
+    void super_startIntentSender(final IntentSender intent, final Intent fillInIntent,
+            final int flagsMask, final int flagsValues, final int extraFlags)
+            throws IntentSender.SendIntentException;
+
+    void super_startIntentSender(final IntentSender intent, final Intent fillInIntent,
+            final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
+            throws IntentSender.SendIntentException;
+
+    void super_startIntentSenderForResult(final IntentSender intent, final int requestCode,
+            final Intent fillInIntent, final int flagsMask, final int flagsValues,
+            final int extraFlags) throws IntentSender.SendIntentException;
+
+    void super_startIntentSenderForResult(final IntentSender intent, final int requestCode,
+            final Intent fillInIntent, final int flagsMask, final int flagsValues,
+            final int extraFlags, final Bundle options) throws IntentSender.SendIntentException;
+
+    void super_startIntentSenderFromChild(final Activity child, final IntentSender intent,
+            final int requestCode, final Intent fillInIntent, final int flagsMask,
+            final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException;
+
+    void super_startIntentSenderFromChild(final Activity child, final IntentSender intent,
+            final int requestCode, final Intent fillInIntent, final int flagsMask,
+            final int flagsValues, final int extraFlags, final Bundle options)
+            throws IntentSender.SendIntentException;
+
+    void super_startLockTask();
+
+    void super_startManagingCursor(final Cursor c);
+
+    boolean super_startNextMatchingActivity(final Intent intent);
+
+    boolean super_startNextMatchingActivity(final Intent intent, final Bundle options);
+
+    void super_startPostponedEnterTransition();
+
+    void super_startSearch(final String initialQuery, final boolean selectInitialQuery,
+            final Bundle appSearchData, final boolean globalSearch);
+
+    ComponentName super_startService(final Intent service);
+
+    ActionMode super_startSupportActionMode(@NonNull final ActionMode.Callback callback);
+
+    void super_stopLockTask();
+
+    void super_stopManagingCursor(final Cursor c);
+
+    boolean super_stopService(final Intent name);
+
+    void super_supportFinishAfterTransition();
+
+    void super_supportInvalidateOptionsMenu();
+
+    void super_supportNavigateUpTo(@NonNull final Intent upIntent);
+
+    void super_supportPostponeEnterTransition();
+
+    boolean super_supportRequestWindowFeature(final int featureId);
+
+    boolean super_supportShouldUpRecreateTask(@NonNull final Intent targetIntent);
+
+    void super_supportStartPostponedEnterTransition();
+
+    void super_takeKeyEvents(final boolean get);
+
+    void super_triggerSearch(final String query, final Bundle appSearchData);
+
+    void super_unbindService(final ServiceConnection conn);
+
+    void super_unregisterComponentCallbacks(final ComponentCallbacks callback);
+
+    void super_unregisterForContextMenu(final View view);
+
+    void super_unregisterReceiver(final BroadcastReceiver receiver);
 
     void supportFinishAfterTransition();
 
-    void supportFinishAfterTransition__super();
-
     void supportInvalidateOptionsMenu();
-
-    void supportInvalidateOptionsMenu__super();
 
     void supportNavigateUpTo(@NonNull final Intent upIntent);
 
-    void supportNavigateUpTo__super(@NonNull final Intent upIntent);
-
     void supportPostponeEnterTransition();
-
-    void supportPostponeEnterTransition__super();
 
     boolean supportRequestWindowFeature(final int featureId);
 
-    boolean supportRequestWindowFeature__super(final int featureId);
-
     boolean supportShouldUpRecreateTask(@NonNull final Intent targetIntent);
-
-    boolean supportShouldUpRecreateTask__super(@NonNull final Intent targetIntent);
 
     void supportStartPostponedEnterTransition();
 
-    void supportStartPostponedEnterTransition__super();
-
     void takeKeyEvents(final boolean get);
-
-    void takeKeyEvents__super(final boolean get);
 
     void triggerSearch(final String query, final Bundle appSearchData);
 
-    void triggerSearch__super(final String query, final Bundle appSearchData);
-
     void unbindService(final ServiceConnection conn);
-
-    void unbindService__super(final ServiceConnection conn);
 
     void unregisterComponentCallbacks(final ComponentCallbacks callback);
 
-    void unregisterComponentCallbacks__super(final ComponentCallbacks callback);
-
     void unregisterForContextMenu(final View view);
 
-    void unregisterForContextMenu__super(final View view);
-
     void unregisterReceiver(final BroadcastReceiver receiver);
-
-    void unregisterReceiver__super(final BroadcastReceiver receiver);
 }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/CompositeDialogFragment.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/CompositeDialogFragment.java
@@ -70,14 +70,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.dismissAllowingStateLoss();
     }
 
-    public void dismissAllowingStateLoss__super() {
-        super.dismissAllowingStateLoss();
-    }
-
-    public void dismiss__super() {
-        super.dismiss();
-    }
-
     /**
      * Print the Fragments's state into the given stream.
      *
@@ -93,11 +85,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.dump(prefix, fd, writer, args);
     }
 
-    public void dump__super(final String prefix, final FileDescriptor fd, final PrintWriter writer,
-            final String[] args) {
-        super.dump(prefix, fd, writer, args);
-    }
-
     /**
      * Returns whether the the exit transition and enter transition overlap or not.
      * When true, the enter transition will start as soon as possible. When false, the
@@ -109,10 +96,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public boolean getAllowEnterTransitionOverlap() {
         return delegate.getAllowEnterTransitionOverlap();
-    }
-
-    public boolean getAllowEnterTransitionOverlap__super() {
-        return super.getAllowEnterTransitionOverlap();
     }
 
     /**
@@ -128,10 +111,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getAllowReturnTransitionOverlap();
     }
 
-    public boolean getAllowReturnTransitionOverlap__super() {
-        return super.getAllowReturnTransitionOverlap();
-    }
-
     /**
      * Return the {@link Context} this fragment is currently associated with.
      */
@@ -140,17 +119,9 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getContext();
     }
 
-    public Context getContext__super() {
-        return super.getContext();
-    }
-
     @Override
     public Dialog getDialog() {
         return delegate.getDialog();
-    }
-
-    public Dialog getDialog__super() {
-        return super.getDialog();
     }
 
     /**
@@ -165,10 +136,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public Object getEnterTransition() {
         return delegate.getEnterTransition();
-    }
-
-    public Object getEnterTransition__super() {
-        return super.getEnterTransition();
     }
 
     /**
@@ -188,10 +155,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getExitTransition();
     }
 
-    public Object getExitTransition__super() {
-        return super.getExitTransition();
-    }
-
     /**
      * @hide Hack so that DialogFragment can make its Dialog before creating
      * its views, and the view construction can use the dialog's context for
@@ -202,20 +165,12 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getLayoutInflater(savedInstanceState);
     }
 
-    public LayoutInflater getLayoutInflater__super(final Bundle savedInstanceState) {
-        return super.getLayoutInflater(savedInstanceState);
-    }
-
     /**
      * Return the LoaderManager for this fragment, creating it if needed.
      */
     @Override
     public LoaderManager getLoaderManager() {
         return delegate.getLoaderManager();
-    }
-
-    public LoaderManager getLoaderManager__super() {
-        return super.getLoaderManager();
     }
 
     /**
@@ -235,10 +190,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getReenterTransition();
     }
 
-    public Object getReenterTransition__super() {
-        return super.getReenterTransition();
-    }
-
     /**
      * Returns the Transition that will be used to move Views out of the scene when the Fragment is
      * preparing to be removed, hidden, or detached because of popping the back stack. The exiting
@@ -256,10 +207,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getReturnTransition();
     }
 
-    public Object getReturnTransition__super() {
-        return super.getReturnTransition();
-    }
-
     /**
      * Returns the Transition that will be used for shared elements transferred into the content
      * Scene. Typical Transitions will affect size and location, such as
@@ -272,10 +219,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public Object getSharedElementEnterTransition() {
         return delegate.getSharedElementEnterTransition();
-    }
-
-    public Object getSharedElementEnterTransition__super() {
-        return super.getSharedElementEnterTransition();
     }
 
     /**
@@ -295,10 +238,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getSharedElementReturnTransition();
     }
 
-    public Object getSharedElementReturnTransition__super() {
-        return super.getSharedElementReturnTransition();
-    }
-
     /**
      * Return the current value of {@link #setShowsDialog(boolean)}.
      */
@@ -307,17 +246,9 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getShowsDialog();
     }
 
-    public boolean getShowsDialog__super() {
-        return super.getShowsDialog();
-    }
-
     @Override
     public int getTheme() {
         return delegate.getTheme();
-    }
-
-    public int getTheme__super() {
-        return super.getTheme();
     }
 
     /**
@@ -327,10 +258,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public boolean getUserVisibleHint() {
         return delegate.getUserVisibleHint();
-    }
-
-    public boolean getUserVisibleHint__super() {
-        return super.getUserVisibleHint();
     }
 
     /**
@@ -345,21 +272,12 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.getView();
     }
 
-    @Nullable
-    public View getView__super() {
-        return super.getView();
-    }
-
     /**
      * Return the current value of {@link #setCancelable(boolean)}.
      */
     @Override
     public boolean isCancelable() {
         return delegate.isCancelable();
-    }
-
-    public boolean isCancelable__super() {
-        return super.isCancelable();
     }
 
     /**
@@ -380,10 +298,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onActivityCreated(savedInstanceState);
     }
 
-    public void onActivityCreated__super(@Nullable final Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-    }
-
     /**
      * Receive the result from a previous call to
      * {@link #startActivityForResult(Intent, int)}.  This follows the
@@ -400,11 +314,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         delegate.onActivityResult(requestCode, resultCode, data);
-    }
-
-    public void onActivityResult__super(final int requestCode, final int resultCode,
-            final Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
     }
 
     /**
@@ -426,30 +335,14 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onAttach(activity);
     }
 
-    public void onAttach__super(final Context context) {
-        super.onAttach(context);
-    }
-
-    public void onAttach__super(final Activity activity) {
-        super.onAttach(activity);
-    }
-
     @Override
     public void onCancel(final DialogInterface dialog) {
         delegate.onCancel(dialog);
     }
 
-    public void onCancel__super(final DialogInterface dialog) {
-        super.onCancel(dialog);
-    }
-
     @Override
     public void onConfigurationChanged(final Configuration newConfig) {
         delegate.onConfigurationChanged(newConfig);
-    }
-
-    public void onConfigurationChanged__super(final Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
     }
 
     /**
@@ -472,10 +365,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public boolean onContextItemSelected(final MenuItem item) {
         return delegate.onContextItemSelected(item);
-    }
-
-    public boolean onContextItemSelected__super(final MenuItem item) {
-        return super.onContextItemSelected(item);
     }
 
     /**
@@ -505,11 +394,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.onCreateAnimation(transit, enter, nextAnim);
     }
 
-    public Animation onCreateAnimation__super(final int transit, final boolean enter,
-            final int nextAnim) {
-        return super.onCreateAnimation(transit, enter, nextAnim);
-    }
-
     /**
      * Called when a context menu for the {@code view} is about to be shown.
      * Unlike {@link #onCreateOptionsMenu}, this will be called every
@@ -531,11 +415,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     public void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo) {
         delegate.onCreateContextMenu(menu, v, menuInfo);
-    }
-
-    public void onCreateContextMenu__super(final ContextMenu menu, final View v,
-            final ContextMenu.ContextMenuInfo menuInfo) {
-        super.onCreateContextMenu(menu, v, menuInfo);
     }
 
     /**
@@ -565,11 +444,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.onCreateDialog(savedInstanceState);
     }
 
-    @NonNull
-    public Dialog onCreateDialog__super(final Bundle savedInstanceState) {
-        return super.onCreateDialog(savedInstanceState);
-    }
-
     /**
      * Initialize the contents of the Activity's standard options menu.  You
      * should place your menu items in to <var>menu</var>.  For this method
@@ -585,10 +459,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
         delegate.onCreateOptionsMenu(menu, inflater);
-    }
-
-    public void onCreateOptionsMenu__super(final Menu menu, final MenuInflater inflater) {
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
     /**
@@ -617,16 +487,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.onCreateView(inflater, container, savedInstanceState);
     }
 
-    @Nullable
-    public View onCreateView__super(final LayoutInflater inflater,
-            @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
-        return super.onCreateView(inflater, container, savedInstanceState);
-    }
-
-    public void onCreate__super(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
     /**
      * Called when the fragment is no longer in use.  This is called
      * after {@link #onStop()} and before {@link #onDetach()}.
@@ -648,10 +508,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onDestroyOptionsMenu();
     }
 
-    public void onDestroyOptionsMenu__super() {
-        super.onDestroyOptionsMenu();
-    }
-
     /**
      * Called when the view previously created by {@link #onCreateView} has
      * been detached from the fragment.  The next time the fragment needs
@@ -666,14 +522,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onDestroyView();
     }
 
-    public void onDestroyView__super() {
-        super.onDestroyView();
-    }
-
-    public void onDestroy__super() {
-        super.onDestroy();
-    }
-
     /**
      * Called when the fragment is no longer attached to its activity.  This
      * is called after {@link #onDestroy()}.
@@ -683,17 +531,9 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onDetach();
     }
 
-    public void onDetach__super() {
-        super.onDetach();
-    }
-
     @Override
     public void onDismiss(final DialogInterface dialog) {
         delegate.onDismiss(dialog);
-    }
-
-    public void onDismiss__super(final DialogInterface dialog) {
-        super.onDismiss(dialog);
     }
 
     /**
@@ -707,10 +547,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onHiddenChanged(final boolean hidden) {
         delegate.onHiddenChanged(hidden);
-    }
-
-    public void onHiddenChanged__super(final boolean hidden) {
-        super.onHiddenChanged(hidden);
     }
 
     /**
@@ -771,23 +607,9 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onInflate(activity, attrs, savedInstanceState);
     }
 
-    public void onInflate__super(final Context context, final AttributeSet attrs,
-            final Bundle savedInstanceState) {
-        super.onInflate(context, attrs, savedInstanceState);
-    }
-
-    public void onInflate__super(final Activity activity, final AttributeSet attrs,
-            final Bundle savedInstanceState) {
-        super.onInflate(activity, attrs, savedInstanceState);
-    }
-
     @Override
     public void onLowMemory() {
         delegate.onLowMemory();
-    }
-
-    public void onLowMemory__super() {
-        super.onLowMemory();
     }
 
     /**
@@ -811,10 +633,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         return delegate.onOptionsItemSelected(item);
     }
 
-    public boolean onOptionsItemSelected__super(final MenuItem item) {
-        return super.onOptionsItemSelected(item);
-    }
-
     /**
      * This hook is called whenever the options menu is being closed (either by the user canceling
      * the menu with the back/menu button, or when an item is selected).
@@ -827,10 +645,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onOptionsMenuClosed(menu);
     }
 
-    public void onOptionsMenuClosed__super(final Menu menu) {
-        super.onOptionsMenuClosed(menu);
-    }
-
     /**
      * Called when the Fragment is no longer resumed.  This is generally
      * tied to {@link Activity#onPause() Activity.onPause} of the containing
@@ -839,10 +653,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onPause() {
         delegate.onPause();
-    }
-
-    public void onPause__super() {
-        super.onPause();
     }
 
     /**
@@ -861,10 +671,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onPrepareOptionsMenu(final Menu menu) {
         delegate.onPrepareOptionsMenu(menu);
-    }
-
-    public void onPrepareOptionsMenu__super(final Menu menu) {
-        super.onPrepareOptionsMenu(menu);
     }
 
     /**
@@ -889,11 +695,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
-    public void onRequestPermissionsResult__super(final int requestCode,
-            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
-
     /**
      * Called when the fragment is visible to the user and actively running.
      * This is generally
@@ -903,10 +704,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onResume() {
         delegate.onResume();
-    }
-
-    public void onResume__super() {
-        super.onResume();
     }
 
     /**
@@ -933,10 +730,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onSaveInstanceState(outState);
     }
 
-    public void onSaveInstanceState__super(final Bundle outState) {
-        super.onSaveInstanceState(outState);
-    }
-
     /**
      * Called when the Fragment is visible to the user.  This is generally
      * tied to {@link Activity#onStart() Activity.onStart} of the containing
@@ -947,10 +740,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onStart();
     }
 
-    public void onStart__super() {
-        super.onStart();
-    }
-
     /**
      * Called when the Fragment is no longer started.  This is generally
      * tied to {@link Activity#onStop() Activity.onStop} of the containing
@@ -959,10 +748,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onStop() {
         delegate.onStop();
-    }
-
-    public void onStop__super() {
-        super.onStop();
     }
 
     /**
@@ -981,10 +766,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.onViewCreated(view, savedInstanceState);
     }
 
-    public void onViewCreated__super(final View view, @Nullable final Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-    }
-
     /**
      * Called when all saved state has been restored into the view hierarchy
      * of the fragment.  This can be used to do initialization based on saved
@@ -999,10 +780,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void onViewStateRestored(@Nullable final Bundle savedInstanceState) {
         delegate.onViewStateRestored(savedInstanceState);
-    }
-
-    public void onViewStateRestored__super(@Nullable final Bundle savedInstanceState) {
-        super.onViewStateRestored(savedInstanceState);
     }
 
     /**
@@ -1020,10 +797,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.registerForContextMenu(view);
     }
 
-    public void registerForContextMenu__super(final View view) {
-        super.registerForContextMenu(view);
-    }
-
     /**
      * Sets whether the the exit transition and enter transition overlap or not.
      * When true, the enter transition will start as soon as possible. When false, the
@@ -1035,10 +808,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setAllowEnterTransitionOverlap(final boolean allow) {
         delegate.setAllowEnterTransitionOverlap(allow);
-    }
-
-    public void setAllowEnterTransitionOverlap__super(final boolean allow) {
-        super.setAllowEnterTransitionOverlap(allow);
     }
 
     /**
@@ -1054,10 +823,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setAllowReturnTransitionOverlap(allow);
     }
 
-    public void setAllowReturnTransitionOverlap__super(final boolean allow) {
-        super.setAllowReturnTransitionOverlap(allow);
-    }
-
     /**
      * Supply the construction arguments for this fragment.  This can only
      * be called before the fragment has been attached to its activity; that
@@ -1068,10 +833,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setArguments(final Bundle args) {
         delegate.setArguments(args);
-    }
-
-    public void setArguments__super(final Bundle args) {
-        super.setArguments(args);
     }
 
     /**
@@ -1088,10 +849,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setCancelable(cancelable);
     }
 
-    public void setCancelable__super(final boolean cancelable) {
-        super.setCancelable(cancelable);
-    }
-
     /**
      * When custom transitions are used with Fragments, the enter transition callback
      * is called when this Fragment is attached or detached when not popping the back stack.
@@ -1102,10 +859,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
         delegate.setEnterSharedElementCallback(callback);
-    }
-
-    public void setEnterSharedElementCallback__super(final SharedElementCallback callback) {
-        super.setEnterSharedElementCallback(callback);
     }
 
     /**
@@ -1123,10 +876,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setEnterTransition(transition);
     }
 
-    public void setEnterTransition__super(final Object transition) {
-        super.setEnterTransition(transition);
-    }
-
     /**
      * When custom transitions are used with Fragments, the exit transition callback
      * is called when this Fragment is attached or detached when popping the back stack.
@@ -1137,10 +886,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setExitSharedElementCallback(final SharedElementCallback callback) {
         delegate.setExitSharedElementCallback(callback);
-    }
-
-    public void setExitSharedElementCallback__super(final SharedElementCallback callback) {
-        super.setExitSharedElementCallback(callback);
     }
 
     /**
@@ -1161,10 +906,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setExitTransition(transition);
     }
 
-    public void setExitTransition__super(final Object transition) {
-        super.setExitTransition(transition);
-    }
-
     /**
      * Report that this fragment would like to participate in populating
      * the options menu by receiving a call to {@link #onCreateOptionsMenu}
@@ -1175,10 +916,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setHasOptionsMenu(final boolean hasMenu) {
         delegate.setHasOptionsMenu(hasMenu);
-    }
-
-    public void setHasOptionsMenu__super(final boolean hasMenu) {
-        super.setHasOptionsMenu(hasMenu);
     }
 
     /**
@@ -1194,10 +931,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setInitialSavedState(state);
     }
 
-    public void setInitialSavedState__super(final Fragment.SavedState state) {
-        super.setInitialSavedState(state);
-    }
-
     /**
      * Set a hint for whether this fragment's menu should be visible.  This
      * is useful if you know that a fragment has been placed in your view
@@ -1210,10 +943,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setMenuVisibility(final boolean menuVisible) {
         delegate.setMenuVisibility(menuVisible);
-    }
-
-    public void setMenuVisibility__super(final boolean menuVisible) {
-        super.setMenuVisibility(menuVisible);
     }
 
     /**
@@ -1232,10 +961,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setReenterTransition(final Object transition) {
         delegate.setReenterTransition(transition);
-    }
-
-    public void setReenterTransition__super(final Object transition) {
-        super.setReenterTransition(transition);
     }
 
     /**
@@ -1257,10 +982,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setRetainInstance(retain);
     }
 
-    public void setRetainInstance__super(final boolean retain) {
-        super.setRetainInstance(retain);
-    }
-
     /**
      * Sets the Transition that will be used to move Views out of the scene when the Fragment is
      * preparing to be removed, hidden, or detached because of popping the back stack. The exiting
@@ -1280,10 +1001,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setReturnTransition(transition);
     }
 
-    public void setReturnTransition__super(final Object transition) {
-        super.setReturnTransition(transition);
-    }
-
     /**
      * Sets the Transition that will be used for shared elements transferred into the content
      * Scene. Typical Transitions will affect size and location, such as
@@ -1296,10 +1013,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setSharedElementEnterTransition(final Object transition) {
         delegate.setSharedElementEnterTransition(transition);
-    }
-
-    public void setSharedElementEnterTransition__super(final Object transition) {
-        super.setSharedElementEnterTransition(transition);
     }
 
     /**
@@ -1317,10 +1030,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setSharedElementReturnTransition(final Object transition) {
         delegate.setSharedElementReturnTransition(transition);
-    }
-
-    public void setSharedElementReturnTransition__super(final Object transition) {
-        super.setSharedElementReturnTransition(transition);
     }
 
     /**
@@ -1345,10 +1054,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setShowsDialog(showsDialog);
     }
 
-    public void setShowsDialog__super(final boolean showsDialog) {
-        super.setShowsDialog(showsDialog);
-    }
-
     /**
      * Call to customize the basic appearance and behavior of the
      * fragment's dialog.  This can be used for some common dialog behaviors,
@@ -1367,10 +1072,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setStyle(style, theme);
     }
 
-    public void setStyle__super(final int style, @StyleRes final int theme) {
-        super.setStyle(style, theme);
-    }
-
     /**
      * Optional target for this fragment.  This may be used, for example,
      * if this fragment is being started by another, and when done wants to
@@ -1385,10 +1086,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void setTargetFragment(final Fragment fragment, final int requestCode) {
         delegate.setTargetFragment(fragment, requestCode);
-    }
-
-    public void setTargetFragment__super(final Fragment fragment, final int requestCode) {
-        super.setTargetFragment(fragment, requestCode);
     }
 
     /**
@@ -1410,20 +1107,12 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.setUserVisibleHint(isVisibleToUser);
     }
 
-    public void setUserVisibleHint__super(final boolean isVisibleToUser) {
-        super.setUserVisibleHint(isVisibleToUser);
-    }
-
     /**
      * @hide
      */
     @Override
     public void setupDialog(final Dialog dialog, final int style) {
         delegate.setupDialog(dialog, style);
-    }
-
-    public void setupDialog__super(final Dialog dialog, final int style) {
-        super.setupDialog(dialog, style);
     }
 
     /**
@@ -1448,10 +1137,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public boolean shouldShowRequestPermissionRationale(@NonNull final String permission) {
         return delegate.shouldShowRequestPermissionRationale(permission);
-    }
-
-    public boolean shouldShowRequestPermissionRationale__super(@NonNull final String permission) {
-        return super.shouldShowRequestPermissionRationale(permission);
     }
 
     /**
@@ -1484,14 +1169,6 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public int show(final FragmentTransaction transaction, final String tag) {
         return delegate.show(transaction, tag);
-    }
-
-    public void show__super(final FragmentManager manager, final String tag) {
-        super.show(manager, tag);
-    }
-
-    public int show__super(final FragmentTransaction transaction, final String tag) {
-        return super.show(transaction, tag);
     }
 
     /**
@@ -1531,30 +1208,441 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
         delegate.startActivityForResult(intent, requestCode, options);
     }
 
-    public void startActivityForResult__super(final Intent intent, final int requestCode) {
+    @Override
+    public void super_dismiss() {
+        super.dismiss();
+    }
+
+    @Override
+    public void super_dismissAllowingStateLoss() {
+        super.dismissAllowingStateLoss();
+    }
+
+    @Override
+    public void super_dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
+            final String[] args) {
+        super.dump(prefix, fd, writer, args);
+    }
+
+    @Override
+    public boolean super_getAllowEnterTransitionOverlap() {
+        return super.getAllowEnterTransitionOverlap();
+    }
+
+    @Override
+    public boolean super_getAllowReturnTransitionOverlap() {
+        return super.getAllowReturnTransitionOverlap();
+    }
+
+    @Override
+    public Context super_getContext() {
+        return super.getContext();
+    }
+
+    @Override
+    public Dialog super_getDialog() {
+        return super.getDialog();
+    }
+
+    @Override
+    public Object super_getEnterTransition() {
+        return super.getEnterTransition();
+    }
+
+    @Override
+    public Object super_getExitTransition() {
+        return super.getExitTransition();
+    }
+
+    @Override
+    public LayoutInflater super_getLayoutInflater(final Bundle savedInstanceState) {
+        return super.getLayoutInflater(savedInstanceState);
+    }
+
+    @Override
+    public LoaderManager super_getLoaderManager() {
+        return super.getLoaderManager();
+    }
+
+    @Override
+    public Object super_getReenterTransition() {
+        return super.getReenterTransition();
+    }
+
+    @Override
+    public Object super_getReturnTransition() {
+        return super.getReturnTransition();
+    }
+
+    @Override
+    public Object super_getSharedElementEnterTransition() {
+        return super.getSharedElementEnterTransition();
+    }
+
+    @Override
+    public Object super_getSharedElementReturnTransition() {
+        return super.getSharedElementReturnTransition();
+    }
+
+    @Override
+    public boolean super_getShowsDialog() {
+        return super.getShowsDialog();
+    }
+
+    @Override
+    public int super_getTheme() {
+        return super.getTheme();
+    }
+
+    @Override
+    public boolean super_getUserVisibleHint() {
+        return super.getUserVisibleHint();
+    }
+
+    @Nullable
+    @Override
+    public View super_getView() {
+        return super.getView();
+    }
+
+    @Override
+    public boolean super_isCancelable() {
+        return super.isCancelable();
+    }
+
+    @Override
+    public void super_onActivityCreated(@Nullable final Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+    }
+
+    @Override
+    public void super_onActivityResult(final int requestCode, final int resultCode,
+            final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void super_onAttach(final Context context) {
+        super.onAttach(context);
+    }
+
+    @Override
+    public void super_onAttach(final Activity activity) {
+        super.onAttach(activity);
+    }
+
+    @Override
+    public void super_onCancel(final DialogInterface dialog) {
+        super.onCancel(dialog);
+    }
+
+    @Override
+    public void super_onConfigurationChanged(final Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    public boolean super_onContextItemSelected(final MenuItem item) {
+        return super.onContextItemSelected(item);
+    }
+
+    @Override
+    public void super_onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public Animation super_onCreateAnimation(final int transit, final boolean enter,
+            final int nextAnim) {
+        return super.onCreateAnimation(transit, enter, nextAnim);
+    }
+
+    @Override
+    public void super_onCreateContextMenu(final ContextMenu menu, final View v,
+            final ContextMenu.ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+    }
+
+    @NonNull
+    @Override
+    public Dialog super_onCreateDialog(final Bundle savedInstanceState) {
+        return super.onCreateDialog(savedInstanceState);
+    }
+
+    @Override
+    public void super_onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Nullable
+    @Override
+    public View super_onCreateView(final LayoutInflater inflater,
+            @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
+        return super.onCreateView(inflater, container, savedInstanceState);
+    }
+
+    @Override
+    public void super_onDestroy() {
+        super.onDestroy();
+    }
+
+    @Override
+    public void super_onDestroyOptionsMenu() {
+        super.onDestroyOptionsMenu();
+    }
+
+    @Override
+    public void super_onDestroyView() {
+        super.onDestroyView();
+    }
+
+    @Override
+    public void super_onDetach() {
+        super.onDetach();
+    }
+
+    @Override
+    public void super_onDismiss(final DialogInterface dialog) {
+        super.onDismiss(dialog);
+    }
+
+    @Override
+    public void super_onHiddenChanged(final boolean hidden) {
+        super.onHiddenChanged(hidden);
+    }
+
+    @Override
+    public void super_onInflate(final Context context, final AttributeSet attrs,
+            final Bundle savedInstanceState) {
+        super.onInflate(context, attrs, savedInstanceState);
+    }
+
+    @Override
+    public void super_onInflate(final Activity activity, final AttributeSet attrs,
+            final Bundle savedInstanceState) {
+        super.onInflate(activity, attrs, savedInstanceState);
+    }
+
+    @Override
+    public void super_onLowMemory() {
+        super.onLowMemory();
+    }
+
+    @Override
+    public boolean super_onOptionsItemSelected(final MenuItem item) {
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void super_onOptionsMenuClosed(final Menu menu) {
+        super.onOptionsMenuClosed(menu);
+    }
+
+    @Override
+    public void super_onPause() {
+        super.onPause();
+    }
+
+    @Override
+    public void super_onPrepareOptionsMenu(final Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public void super_onRequestPermissionsResult(final int requestCode,
+            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    @Override
+    public void super_onResume() {
+        super.onResume();
+    }
+
+    @Override
+    public void super_onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void super_onStart() {
+        super.onStart();
+    }
+
+    @Override
+    public void super_onStop() {
+        super.onStop();
+    }
+
+    @Override
+    public void super_onViewCreated(final View view, @Nullable final Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+    }
+
+    @Override
+    public void super_onViewStateRestored(@Nullable final Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+    }
+
+    @Override
+    public void super_registerForContextMenu(final View view) {
+        super.registerForContextMenu(view);
+    }
+
+    @Override
+    public void super_setAllowEnterTransitionOverlap(final boolean allow) {
+        super.setAllowEnterTransitionOverlap(allow);
+    }
+
+    @Override
+    public void super_setAllowReturnTransitionOverlap(final boolean allow) {
+        super.setAllowReturnTransitionOverlap(allow);
+    }
+
+    @Override
+    public void super_setArguments(final Bundle args) {
+        super.setArguments(args);
+    }
+
+    @Override
+    public void super_setCancelable(final boolean cancelable) {
+        super.setCancelable(cancelable);
+    }
+
+    @Override
+    public void super_setEnterSharedElementCallback(final SharedElementCallback callback) {
+        super.setEnterSharedElementCallback(callback);
+    }
+
+    @Override
+    public void super_setEnterTransition(final Object transition) {
+        super.setEnterTransition(transition);
+    }
+
+    @Override
+    public void super_setExitSharedElementCallback(final SharedElementCallback callback) {
+        super.setExitSharedElementCallback(callback);
+    }
+
+    @Override
+    public void super_setExitTransition(final Object transition) {
+        super.setExitTransition(transition);
+    }
+
+    @Override
+    public void super_setHasOptionsMenu(final boolean hasMenu) {
+        super.setHasOptionsMenu(hasMenu);
+    }
+
+    @Override
+    public void super_setInitialSavedState(final Fragment.SavedState state) {
+        super.setInitialSavedState(state);
+    }
+
+    @Override
+    public void super_setMenuVisibility(final boolean menuVisible) {
+        super.setMenuVisibility(menuVisible);
+    }
+
+    @Override
+    public void super_setReenterTransition(final Object transition) {
+        super.setReenterTransition(transition);
+    }
+
+    @Override
+    public void super_setRetainInstance(final boolean retain) {
+        super.setRetainInstance(retain);
+    }
+
+    @Override
+    public void super_setReturnTransition(final Object transition) {
+        super.setReturnTransition(transition);
+    }
+
+    @Override
+    public void super_setSharedElementEnterTransition(final Object transition) {
+        super.setSharedElementEnterTransition(transition);
+    }
+
+    @Override
+    public void super_setSharedElementReturnTransition(final Object transition) {
+        super.setSharedElementReturnTransition(transition);
+    }
+
+    @Override
+    public void super_setShowsDialog(final boolean showsDialog) {
+        super.setShowsDialog(showsDialog);
+    }
+
+    @Override
+    public void super_setStyle(final int style, @StyleRes final int theme) {
+        super.setStyle(style, theme);
+    }
+
+    @Override
+    public void super_setTargetFragment(final Fragment fragment, final int requestCode) {
+        super.setTargetFragment(fragment, requestCode);
+    }
+
+    @Override
+    public void super_setUserVisibleHint(final boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+    }
+
+    @Override
+    public void super_setupDialog(final Dialog dialog, final int style) {
+        super.setupDialog(dialog, style);
+    }
+
+    @Override
+    public boolean super_shouldShowRequestPermissionRationale(@NonNull final String permission) {
+        return super.shouldShowRequestPermissionRationale(permission);
+    }
+
+    @Override
+    public void super_show(final FragmentManager manager, final String tag) {
+        super.show(manager, tag);
+    }
+
+    @Override
+    public int super_show(final FragmentTransaction transaction, final String tag) {
+        return super.show(transaction, tag);
+    }
+
+    @Override
+    public void super_startActivity(final Intent intent) {
+        super.startActivity(intent);
+    }
+
+    @Override
+    public void super_startActivity(final Intent intent, @Nullable final Bundle options) {
+        super.startActivity(intent, options);
+    }
+
+    @Override
+    public void super_startActivityForResult(final Intent intent, final int requestCode) {
         super.startActivityForResult(intent, requestCode);
     }
 
-    public void startActivityForResult__super(final Intent intent, final int requestCode,
+    @Override
+    public void super_startActivityForResult(final Intent intent, final int requestCode,
             @Nullable final Bundle options) {
         super.startActivityForResult(intent, requestCode, options);
     }
 
-    public void startActivity__super(final Intent intent) {
-        super.startActivity(intent);
+    @Override
+    public String super_toString() {
+        return super.toString();
     }
 
-    public void startActivity__super(final Intent intent, @Nullable final Bundle options) {
-        super.startActivity(intent, options);
+    @Override
+    public void super_unregisterForContextMenu(final View view) {
+        super.unregisterForContextMenu(view);
     }
 
     @Override
     public String toString() {
         return delegate.toString();
-    }
-
-    public String toString__super() {
-        return super.toString();
     }
 
     /**
@@ -1567,9 +1655,5 @@ public class CompositeDialogFragment extends DialogFragment implements IComposit
     @Override
     public void unregisterForContextMenu(final View view) {
         delegate.unregisterForContextMenu(view);
-    }
-
-    public void unregisterForContextMenu__super(final View view) {
-        super.unregisterForContextMenu(view);
     }
 }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/CompositeFragment.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/CompositeFragment.java
@@ -57,11 +57,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.dump(prefix, fd, writer, args);
     }
 
-    public void dump__super(final String prefix, final FileDescriptor fd, final PrintWriter writer,
-            final String[] args) {
-        super.dump(prefix, fd, writer, args);
-    }
-
     /**
      * Returns whether the the exit transition and enter transition overlap or not.
      * When true, the enter transition will start as soon as possible. When false, the
@@ -73,10 +68,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public boolean getAllowEnterTransitionOverlap() {
         return delegate.getAllowEnterTransitionOverlap();
-    }
-
-    public boolean getAllowEnterTransitionOverlap__super() {
-        return super.getAllowEnterTransitionOverlap();
     }
 
     /**
@@ -92,20 +83,12 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.getAllowReturnTransitionOverlap();
     }
 
-    public boolean getAllowReturnTransitionOverlap__super() {
-        return super.getAllowReturnTransitionOverlap();
-    }
-
     /**
      * Return the {@link Context} this fragment is currently associated with.
      */
     @Override
     public Context getContext() {
         return delegate.getContext();
-    }
-
-    public Context getContext__super() {
-        return super.getContext();
     }
 
     /**
@@ -120,10 +103,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public Object getEnterTransition() {
         return delegate.getEnterTransition();
-    }
-
-    public Object getEnterTransition__super() {
-        return super.getEnterTransition();
     }
 
     /**
@@ -143,10 +122,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.getExitTransition();
     }
 
-    public Object getExitTransition__super() {
-        return super.getExitTransition();
-    }
-
     /**
      * @hide Hack so that DialogFragment can make its Dialog before creating
      * its views, and the view construction can use the dialog's context for
@@ -157,20 +132,12 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.getLayoutInflater(savedInstanceState);
     }
 
-    public LayoutInflater getLayoutInflater__super(final Bundle savedInstanceState) {
-        return super.getLayoutInflater(savedInstanceState);
-    }
-
     /**
      * Return the LoaderManager for this fragment, creating it if needed.
      */
     @Override
     public LoaderManager getLoaderManager() {
         return delegate.getLoaderManager();
-    }
-
-    public LoaderManager getLoaderManager__super() {
-        return super.getLoaderManager();
     }
 
     /**
@@ -190,10 +157,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.getReenterTransition();
     }
 
-    public Object getReenterTransition__super() {
-        return super.getReenterTransition();
-    }
-
     /**
      * Returns the Transition that will be used to move Views out of the scene when the Fragment is
      * preparing to be removed, hidden, or detached because of popping the back stack. The exiting
@@ -211,10 +174,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.getReturnTransition();
     }
 
-    public Object getReturnTransition__super() {
-        return super.getReturnTransition();
-    }
-
     /**
      * Returns the Transition that will be used for shared elements transferred into the content
      * Scene. Typical Transitions will affect size and location, such as
@@ -227,10 +186,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public Object getSharedElementEnterTransition() {
         return delegate.getSharedElementEnterTransition();
-    }
-
-    public Object getSharedElementEnterTransition__super() {
-        return super.getSharedElementEnterTransition();
     }
 
     /**
@@ -250,10 +205,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.getSharedElementReturnTransition();
     }
 
-    public Object getSharedElementReturnTransition__super() {
-        return super.getSharedElementReturnTransition();
-    }
-
     /**
      * @return The current value of the user-visible hint on this fragment.
      * @see #setUserVisibleHint(boolean)
@@ -261,10 +212,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public boolean getUserVisibleHint() {
         return delegate.getUserVisibleHint();
-    }
-
-    public boolean getUserVisibleHint__super() {
-        return super.getUserVisibleHint();
     }
 
     /**
@@ -277,11 +224,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public View getView() {
         return delegate.getView();
-    }
-
-    @Nullable
-    public View getView__super() {
-        return super.getView();
     }
 
     /**
@@ -302,10 +244,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onActivityCreated(savedInstanceState);
     }
 
-    public void onActivityCreated__super(@Nullable final Bundle savedInstanceState) {
-        super.onActivityCreated(savedInstanceState);
-    }
-
     /**
      * Receive the result from a previous call to
      * {@link #startActivityForResult(Intent, int)}.  This follows the
@@ -322,11 +260,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         delegate.onActivityResult(requestCode, resultCode, data);
-    }
-
-    public void onActivityResult__super(final int requestCode, final int resultCode,
-            final Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
     }
 
     /**
@@ -348,22 +281,9 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onAttach(activity);
     }
 
-    public void onAttach__super(final Context context) {
-        super.onAttach(context);
-    }
-
-    public void onAttach__super(final Activity activity) {
-        super.onAttach(activity);
-    }
-
-
     @Override
     public void onConfigurationChanged(final Configuration newConfig) {
         delegate.onConfigurationChanged(newConfig);
-    }
-
-    public void onConfigurationChanged__super(final Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
     }
 
     /**
@@ -386,10 +306,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public boolean onContextItemSelected(final MenuItem item) {
         return delegate.onContextItemSelected(item);
-    }
-
-    public boolean onContextItemSelected__super(final MenuItem item) {
-        return super.onContextItemSelected(item);
     }
 
     /**
@@ -419,11 +335,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.onCreateAnimation(transit, enter, nextAnim);
     }
 
-    public Animation onCreateAnimation__super(final int transit, final boolean enter,
-            final int nextAnim) {
-        return super.onCreateAnimation(transit, enter, nextAnim);
-    }
-
     /**
      * Called when a context menu for the {@code view} is about to be shown.
      * Unlike {@link #onCreateOptionsMenu}, this will be called every
@@ -447,11 +358,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onCreateContextMenu(menu, v, menuInfo);
     }
 
-    public void onCreateContextMenu__super(final ContextMenu menu, final View v,
-            final ContextMenu.ContextMenuInfo menuInfo) {
-        super.onCreateContextMenu(menu, v, menuInfo);
-    }
-
     /**
      * Initialize the contents of the Activity's standard options menu.  You
      * should place your menu items in to <var>menu</var>.  For this method
@@ -467,10 +373,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
         delegate.onCreateOptionsMenu(menu, inflater);
-    }
-
-    public void onCreateOptionsMenu__super(final Menu menu, final MenuInflater inflater) {
-        super.onCreateOptionsMenu(menu, inflater);
     }
 
     /**
@@ -499,16 +401,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.onCreateView(inflater, container, savedInstanceState);
     }
 
-    @Nullable
-    public View onCreateView__super(final LayoutInflater inflater,
-            @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
-        return super.onCreateView(inflater, container, savedInstanceState);
-    }
-
-    public void onCreate__super(@Nullable final Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-    }
-
     /**
      * Called when the fragment is no longer in use.  This is called
      * after {@link #onStop()} and before {@link #onDetach()}.
@@ -530,10 +422,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onDestroyOptionsMenu();
     }
 
-    public void onDestroyOptionsMenu__super() {
-        super.onDestroyOptionsMenu();
-    }
-
     /**
      * Called when the view previously created by {@link #onCreateView} has
      * been detached from the fragment.  The next time the fragment needs
@@ -548,14 +436,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onDestroyView();
     }
 
-    public void onDestroyView__super() {
-        super.onDestroyView();
-    }
-
-    public void onDestroy__super() {
-        super.onDestroy();
-    }
-
     /**
      * Called when the fragment is no longer attached to its activity.  This
      * is called after {@link #onDestroy()}.
@@ -563,10 +443,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onDetach() {
         delegate.onDetach();
-    }
-
-    public void onDetach__super() {
-        super.onDetach();
     }
 
     /**
@@ -580,10 +456,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onHiddenChanged(final boolean hidden) {
         delegate.onHiddenChanged(hidden);
-    }
-
-    public void onHiddenChanged__super(final boolean hidden) {
-        super.onHiddenChanged(hidden);
     }
 
     /**
@@ -644,24 +516,9 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onInflate(activity, attrs, savedInstanceState);
     }
 
-    public void onInflate__super(final Context context, final AttributeSet attrs,
-            final Bundle savedInstanceState) {
-        super.onInflate(context, attrs, savedInstanceState);
-    }
-
-    public void onInflate__super(final Activity activity, final AttributeSet attrs,
-            final Bundle savedInstanceState) {
-        super.onInflate(activity, attrs, savedInstanceState);
-    }
-
-
     @Override
     public void onLowMemory() {
         delegate.onLowMemory();
-    }
-
-    public void onLowMemory__super() {
-        super.onLowMemory();
     }
 
     /**
@@ -685,10 +542,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         return delegate.onOptionsItemSelected(item);
     }
 
-    public boolean onOptionsItemSelected__super(final MenuItem item) {
-        return super.onOptionsItemSelected(item);
-    }
-
     /**
      * This hook is called whenever the options menu is being closed (either by the user canceling
      * the menu with the back/menu button, or when an item is selected).
@@ -701,10 +554,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onOptionsMenuClosed(menu);
     }
 
-    public void onOptionsMenuClosed__super(final Menu menu) {
-        super.onOptionsMenuClosed(menu);
-    }
-
     /**
      * Called when the Fragment is no longer resumed.  This is generally
      * tied to {@link Activity#onPause() Activity.onPause} of the containing
@@ -713,10 +562,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onPause() {
         delegate.onPause();
-    }
-
-    public void onPause__super() {
-        super.onPause();
     }
 
     /**
@@ -735,10 +580,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onPrepareOptionsMenu(final Menu menu) {
         delegate.onPrepareOptionsMenu(menu);
-    }
-
-    public void onPrepareOptionsMenu__super(final Menu menu) {
-        super.onPrepareOptionsMenu(menu);
     }
 
     /**
@@ -763,11 +604,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
-    public void onRequestPermissionsResult__super(final int requestCode,
-            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-    }
-
     /**
      * Called when the fragment is visible to the user and actively running.
      * This is generally
@@ -777,10 +613,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onResume() {
         delegate.onResume();
-    }
-
-    public void onResume__super() {
-        super.onResume();
     }
 
     /**
@@ -807,10 +639,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onSaveInstanceState(outState);
     }
 
-    public void onSaveInstanceState__super(final Bundle outState) {
-        super.onSaveInstanceState(outState);
-    }
-
     /**
      * Called when the Fragment is visible to the user.  This is generally
      * tied to {@link Activity#onStart() Activity.onStart} of the containing
@@ -821,10 +649,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onStart();
     }
 
-    public void onStart__super() {
-        super.onStart();
-    }
-
     /**
      * Called when the Fragment is no longer started.  This is generally
      * tied to {@link Activity#onStop() Activity.onStop} of the containing
@@ -833,10 +657,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onStop() {
         delegate.onStop();
-    }
-
-    public void onStop__super() {
-        super.onStop();
     }
 
     /**
@@ -855,10 +675,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.onViewCreated(view, savedInstanceState);
     }
 
-    public void onViewCreated__super(final View view, @Nullable final Bundle savedInstanceState) {
-        super.onViewCreated(view, savedInstanceState);
-    }
-
     /**
      * Called when all saved state has been restored into the view hierarchy
      * of the fragment.  This can be used to do initialization based on saved
@@ -873,10 +689,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void onViewStateRestored(@Nullable final Bundle savedInstanceState) {
         delegate.onViewStateRestored(savedInstanceState);
-    }
-
-    public void onViewStateRestored__super(@Nullable final Bundle savedInstanceState) {
-        super.onViewStateRestored(savedInstanceState);
     }
 
     /**
@@ -894,10 +706,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.registerForContextMenu(view);
     }
 
-    public void registerForContextMenu__super(final View view) {
-        super.registerForContextMenu(view);
-    }
-
     /**
      * Sets whether the the exit transition and enter transition overlap or not.
      * When true, the enter transition will start as soon as possible. When false, the
@@ -909,10 +717,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setAllowEnterTransitionOverlap(final boolean allow) {
         delegate.setAllowEnterTransitionOverlap(allow);
-    }
-
-    public void setAllowEnterTransitionOverlap__super(final boolean allow) {
-        super.setAllowEnterTransitionOverlap(allow);
     }
 
     /**
@@ -928,10 +732,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setAllowReturnTransitionOverlap(allow);
     }
 
-    public void setAllowReturnTransitionOverlap__super(final boolean allow) {
-        super.setAllowReturnTransitionOverlap(allow);
-    }
-
     /**
      * Supply the construction arguments for this fragment.  This can only
      * be called before the fragment has been attached to its activity; that
@@ -944,10 +744,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setArguments(args);
     }
 
-    public void setArguments__super(final Bundle args) {
-        super.setArguments(args);
-    }
-
     /**
      * When custom transitions are used with Fragments, the enter transition callback
      * is called when this Fragment is attached or detached when not popping the back stack.
@@ -958,10 +754,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
         delegate.setEnterSharedElementCallback(callback);
-    }
-
-    public void setEnterSharedElementCallback__super(final SharedElementCallback callback) {
-        super.setEnterSharedElementCallback(callback);
     }
 
     /**
@@ -979,10 +771,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setEnterTransition(transition);
     }
 
-    public void setEnterTransition__super(final Object transition) {
-        super.setEnterTransition(transition);
-    }
-
     /**
      * When custom transitions are used with Fragments, the exit transition callback
      * is called when this Fragment is attached or detached when popping the back stack.
@@ -993,10 +781,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setExitSharedElementCallback(final SharedElementCallback callback) {
         delegate.setExitSharedElementCallback(callback);
-    }
-
-    public void setExitSharedElementCallback__super(final SharedElementCallback callback) {
-        super.setExitSharedElementCallback(callback);
     }
 
     /**
@@ -1017,10 +801,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setExitTransition(transition);
     }
 
-    public void setExitTransition__super(final Object transition) {
-        super.setExitTransition(transition);
-    }
-
     /**
      * Report that this fragment would like to participate in populating
      * the options menu by receiving a call to {@link #onCreateOptionsMenu}
@@ -1031,10 +811,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setHasOptionsMenu(final boolean hasMenu) {
         delegate.setHasOptionsMenu(hasMenu);
-    }
-
-    public void setHasOptionsMenu__super(final boolean hasMenu) {
-        super.setHasOptionsMenu(hasMenu);
     }
 
     /**
@@ -1050,10 +826,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setInitialSavedState(state);
     }
 
-    public void setInitialSavedState__super(final Fragment.SavedState state) {
-        super.setInitialSavedState(state);
-    }
-
     /**
      * Set a hint for whether this fragment's menu should be visible.  This
      * is useful if you know that a fragment has been placed in your view
@@ -1066,10 +838,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setMenuVisibility(final boolean menuVisible) {
         delegate.setMenuVisibility(menuVisible);
-    }
-
-    public void setMenuVisibility__super(final boolean menuVisible) {
-        super.setMenuVisibility(menuVisible);
     }
 
     /**
@@ -1088,10 +856,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setReenterTransition(final Object transition) {
         delegate.setReenterTransition(transition);
-    }
-
-    public void setReenterTransition__super(final Object transition) {
-        super.setReenterTransition(transition);
     }
 
     /**
@@ -1113,10 +877,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setRetainInstance(retain);
     }
 
-    public void setRetainInstance__super(final boolean retain) {
-        super.setRetainInstance(retain);
-    }
-
     /**
      * Sets the Transition that will be used to move Views out of the scene when the Fragment is
      * preparing to be removed, hidden, or detached because of popping the back stack. The exiting
@@ -1136,10 +896,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setReturnTransition(transition);
     }
 
-    public void setReturnTransition__super(final Object transition) {
-        super.setReturnTransition(transition);
-    }
-
     /**
      * Sets the Transition that will be used for shared elements transferred into the content
      * Scene. Typical Transitions will affect size and location, such as
@@ -1152,10 +908,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setSharedElementEnterTransition(final Object transition) {
         delegate.setSharedElementEnterTransition(transition);
-    }
-
-    public void setSharedElementEnterTransition__super(final Object transition) {
-        super.setSharedElementEnterTransition(transition);
     }
 
     /**
@@ -1175,10 +927,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.setSharedElementReturnTransition(transition);
     }
 
-    public void setSharedElementReturnTransition__super(final Object transition) {
-        super.setSharedElementReturnTransition(transition);
-    }
-
     /**
      * Optional target for this fragment.  This may be used, for example,
      * if this fragment is being started by another, and when done wants to
@@ -1193,10 +941,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setTargetFragment(final Fragment fragment, final int requestCode) {
         delegate.setTargetFragment(fragment, requestCode);
-    }
-
-    public void setTargetFragment__super(final Fragment fragment, final int requestCode) {
-        super.setTargetFragment(fragment, requestCode);
     }
 
     /**
@@ -1216,10 +960,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void setUserVisibleHint(final boolean isVisibleToUser) {
         delegate.setUserVisibleHint(isVisibleToUser);
-    }
-
-    public void setUserVisibleHint__super(final boolean isVisibleToUser) {
-        super.setUserVisibleHint(isVisibleToUser);
     }
 
     /**
@@ -1244,10 +984,6 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public boolean shouldShowRequestPermissionRationale(@NonNull final String permission) {
         return delegate.shouldShowRequestPermissionRationale(permission);
-    }
-
-    public boolean shouldShowRequestPermissionRationale__super(@NonNull final String permission) {
-        return super.shouldShowRequestPermissionRationale(permission);
     }
 
     /**
@@ -1287,30 +1023,365 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
         delegate.startActivityForResult(intent, requestCode, options);
     }
 
-    public void startActivityForResult__super(final Intent intent, final int requestCode) {
+    @Override
+    public void super_dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
+            final String[] args) {
+        super.dump(prefix, fd, writer, args);
+    }
+
+    @Override
+    public boolean super_getAllowEnterTransitionOverlap() {
+        return super.getAllowEnterTransitionOverlap();
+    }
+
+    @Override
+    public boolean super_getAllowReturnTransitionOverlap() {
+        return super.getAllowReturnTransitionOverlap();
+    }
+
+    @Override
+    public Context super_getContext() {
+        return super.getContext();
+    }
+
+    @Override
+    public Object super_getEnterTransition() {
+        return super.getEnterTransition();
+    }
+
+    @Override
+    public Object super_getExitTransition() {
+        return super.getExitTransition();
+    }
+
+    @Override
+    public LayoutInflater super_getLayoutInflater(final Bundle savedInstanceState) {
+        return super.getLayoutInflater(savedInstanceState);
+    }
+
+    @Override
+    public LoaderManager super_getLoaderManager() {
+        return super.getLoaderManager();
+    }
+
+    @Override
+    public Object super_getReenterTransition() {
+        return super.getReenterTransition();
+    }
+
+    @Override
+    public Object super_getReturnTransition() {
+        return super.getReturnTransition();
+    }
+
+    @Override
+    public Object super_getSharedElementEnterTransition() {
+        return super.getSharedElementEnterTransition();
+    }
+
+    @Override
+    public Object super_getSharedElementReturnTransition() {
+        return super.getSharedElementReturnTransition();
+    }
+
+    @Override
+    public boolean super_getUserVisibleHint() {
+        return super.getUserVisibleHint();
+    }
+
+    @Nullable
+    @Override
+    public View super_getView() {
+        return super.getView();
+    }
+
+    @Override
+    public void super_onActivityCreated(@Nullable final Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
+    }
+
+    @Override
+    public void super_onActivityResult(final int requestCode, final int resultCode,
+            final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+    }
+
+    @Override
+    public void super_onAttach(final Context context) {
+        super.onAttach(context);
+    }
+
+    @Override
+    public void super_onAttach(final Activity activity) {
+        super.onAttach(activity);
+    }
+
+    @Override
+    public void super_onConfigurationChanged(final Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    public boolean super_onContextItemSelected(final MenuItem item) {
+        return super.onContextItemSelected(item);
+    }
+
+    @Override
+    public void super_onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public Animation super_onCreateAnimation(final int transit, final boolean enter,
+            final int nextAnim) {
+        return super.onCreateAnimation(transit, enter, nextAnim);
+    }
+
+    @Override
+    public void super_onCreateContextMenu(final ContextMenu menu, final View v,
+            final ContextMenu.ContextMenuInfo menuInfo) {
+        super.onCreateContextMenu(menu, v, menuInfo);
+    }
+
+    @Override
+    public void super_onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
+        super.onCreateOptionsMenu(menu, inflater);
+    }
+
+    @Nullable
+    @Override
+    public View super_onCreateView(final LayoutInflater inflater,
+            @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
+        return super.onCreateView(inflater, container, savedInstanceState);
+    }
+
+    @Override
+    public void super_onDestroy() {
+        super.onDestroy();
+    }
+
+    @Override
+    public void super_onDestroyOptionsMenu() {
+        super.onDestroyOptionsMenu();
+    }
+
+    @Override
+    public void super_onDestroyView() {
+        super.onDestroyView();
+    }
+
+    @Override
+    public void super_onDetach() {
+        super.onDetach();
+    }
+
+    @Override
+    public void super_onHiddenChanged(final boolean hidden) {
+        super.onHiddenChanged(hidden);
+    }
+
+    @Override
+    public void super_onInflate(final Context context, final AttributeSet attrs,
+            final Bundle savedInstanceState) {
+        super.onInflate(context, attrs, savedInstanceState);
+    }
+
+    @Override
+    public void super_onInflate(final Activity activity, final AttributeSet attrs,
+            final Bundle savedInstanceState) {
+        super.onInflate(activity, attrs, savedInstanceState);
+    }
+
+    @Override
+    public void super_onLowMemory() {
+        super.onLowMemory();
+    }
+
+    @Override
+    public boolean super_onOptionsItemSelected(final MenuItem item) {
+        return super.onOptionsItemSelected(item);
+    }
+
+    @Override
+    public void super_onOptionsMenuClosed(final Menu menu) {
+        super.onOptionsMenuClosed(menu);
+    }
+
+    @Override
+    public void super_onPause() {
+        super.onPause();
+    }
+
+    @Override
+    public void super_onPrepareOptionsMenu(final Menu menu) {
+        super.onPrepareOptionsMenu(menu);
+    }
+
+    @Override
+    public void super_onRequestPermissionsResult(final int requestCode,
+            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults);
+    }
+
+    @Override
+    public void super_onResume() {
+        super.onResume();
+    }
+
+    @Override
+    public void super_onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+    }
+
+    @Override
+    public void super_onStart() {
+        super.onStart();
+    }
+
+    @Override
+    public void super_onStop() {
+        super.onStop();
+    }
+
+    @Override
+    public void super_onViewCreated(final View view, @Nullable final Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+    }
+
+    @Override
+    public void super_onViewStateRestored(@Nullable final Bundle savedInstanceState) {
+        super.onViewStateRestored(savedInstanceState);
+    }
+
+    @Override
+    public void super_registerForContextMenu(final View view) {
+        super.registerForContextMenu(view);
+    }
+
+    @Override
+    public void super_setAllowEnterTransitionOverlap(final boolean allow) {
+        super.setAllowEnterTransitionOverlap(allow);
+    }
+
+    @Override
+    public void super_setAllowReturnTransitionOverlap(final boolean allow) {
+        super.setAllowReturnTransitionOverlap(allow);
+    }
+
+    @Override
+    public void super_setArguments(final Bundle args) {
+        super.setArguments(args);
+    }
+
+    @Override
+    public void super_setEnterSharedElementCallback(final SharedElementCallback callback) {
+        super.setEnterSharedElementCallback(callback);
+    }
+
+    @Override
+    public void super_setEnterTransition(final Object transition) {
+        super.setEnterTransition(transition);
+    }
+
+    @Override
+    public void super_setExitSharedElementCallback(final SharedElementCallback callback) {
+        super.setExitSharedElementCallback(callback);
+    }
+
+    @Override
+    public void super_setExitTransition(final Object transition) {
+        super.setExitTransition(transition);
+    }
+
+    @Override
+    public void super_setHasOptionsMenu(final boolean hasMenu) {
+        super.setHasOptionsMenu(hasMenu);
+    }
+
+    @Override
+    public void super_setInitialSavedState(final Fragment.SavedState state) {
+        super.setInitialSavedState(state);
+    }
+
+    @Override
+    public void super_setMenuVisibility(final boolean menuVisible) {
+        super.setMenuVisibility(menuVisible);
+    }
+
+    @Override
+    public void super_setReenterTransition(final Object transition) {
+        super.setReenterTransition(transition);
+    }
+
+    @Override
+    public void super_setRetainInstance(final boolean retain) {
+        super.setRetainInstance(retain);
+    }
+
+    @Override
+    public void super_setReturnTransition(final Object transition) {
+        super.setReturnTransition(transition);
+    }
+
+    @Override
+    public void super_setSharedElementEnterTransition(final Object transition) {
+        super.setSharedElementEnterTransition(transition);
+    }
+
+    @Override
+    public void super_setSharedElementReturnTransition(final Object transition) {
+        super.setSharedElementReturnTransition(transition);
+    }
+
+    @Override
+    public void super_setTargetFragment(final Fragment fragment, final int requestCode) {
+        super.setTargetFragment(fragment, requestCode);
+    }
+
+    @Override
+    public void super_setUserVisibleHint(final boolean isVisibleToUser) {
+        super.setUserVisibleHint(isVisibleToUser);
+    }
+
+    @Override
+    public boolean super_shouldShowRequestPermissionRationale(@NonNull final String permission) {
+        return super.shouldShowRequestPermissionRationale(permission);
+    }
+
+    @Override
+    public void super_startActivity(final Intent intent) {
+        super.startActivity(intent);
+    }
+
+    @Override
+    public void super_startActivity(final Intent intent, @Nullable final Bundle options) {
+        super.startActivity(intent, options);
+    }
+
+    @Override
+    public void super_startActivityForResult(final Intent intent, final int requestCode) {
         super.startActivityForResult(intent, requestCode);
     }
 
-    public void startActivityForResult__super(final Intent intent, final int requestCode,
+    @Override
+    public void super_startActivityForResult(final Intent intent, final int requestCode,
             @Nullable final Bundle options) {
         super.startActivityForResult(intent, requestCode, options);
     }
 
-    public void startActivity__super(final Intent intent) {
-        super.startActivity(intent);
+    @Override
+    public String super_toString() {
+        return super.toString();
     }
 
-    public void startActivity__super(final Intent intent, @Nullable final Bundle options) {
-        super.startActivity(intent, options);
+    @Override
+    public void super_unregisterForContextMenu(final View view) {
+        super.unregisterForContextMenu(view);
     }
 
     @Override
     public String toString() {
         return delegate.toString();
-    }
-
-    public String toString__super() {
-        return super.toString();
     }
 
     /**
@@ -1323,9 +1394,5 @@ public class CompositeFragment extends Fragment implements ICompositeFragment {
     @Override
     public void unregisterForContextMenu(final View view) {
         delegate.unregisterForContextMenu(view);
-    }
-
-    public void unregisterForContextMenu__super(final View view) {
-        super.unregisterForContextMenu(view);
     }
 }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
@@ -73,7 +73,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().dismiss__super();
+                getOriginal().super_dismiss();
             }
         });
     }
@@ -88,7 +88,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().dismissAllowingStateLoss__super();
+                getOriginal().super_dismissAllowingStateLoss();
             }
         });
     }
@@ -122,7 +122,7 @@ public class DialogFragmentDelegate
         }, new SuperCall<Dialog>() {
             @Override
             public Dialog call(final Object... args) {
-                return getOriginal().getDialog__super();
+                return getOriginal().super_getDialog();
             }
         });
     }
@@ -171,7 +171,7 @@ public class DialogFragmentDelegate
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().getShowsDialog__super();
+                return getOriginal().super_getShowsDialog();
             }
         });
     }
@@ -188,7 +188,7 @@ public class DialogFragmentDelegate
         }, new SuperCall<Integer>() {
             @Override
             public Integer call(final Object... args) {
-                return getOriginal().getTheme__super();
+                return getOriginal().super_getTheme();
             }
         });
     }
@@ -213,7 +213,7 @@ public class DialogFragmentDelegate
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().isCancelable__super();
+                return getOriginal().super_isCancelable();
             }
         });
     }
@@ -244,7 +244,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onCancel__super((DialogInterface) args[0]);
+                getOriginal().super_onCancel((DialogInterface) args[0]);
             }
         }, dialog);
     }
@@ -283,7 +283,7 @@ public class DialogFragmentDelegate
                 }, new SuperCall<Dialog>() {
                     @Override
                     public Dialog call(final Object... args) {
-                        return getOriginal().onCreateDialog__super((Bundle) args[0]);
+                        return getOriginal().super_onCreateDialog((Bundle) args[0]);
                     }
                 }, savedInstanceState);
     }
@@ -323,7 +323,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onDismiss__super((DialogInterface) args[0]);
+                getOriginal().super_onDismiss((DialogInterface) args[0]);
             }
         }, dialog);
     }
@@ -417,7 +417,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setCancelable__super((boolean) args[0]);
+                getOriginal().super_setCancelable((boolean) args[0]);
             }
         }, cancelable);
     }
@@ -480,7 +480,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setShowsDialog__super((boolean) args[0]);
+                getOriginal().super_setShowsDialog((boolean) args[0]);
             }
         }, showsDialog);
     }
@@ -495,7 +495,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setStyle__super((int) args[0], (int) args[1]);
+                getOriginal().super_setStyle((int) args[0], (int) args[1]);
             }
         }, style, theme);
     }
@@ -518,7 +518,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setupDialog__super((Dialog) args[0], (int) args[1]);
+                getOriginal().super_setupDialog((Dialog) args[0], (int) args[1]);
             }
         }, dialog, style);
     }
@@ -537,7 +537,7 @@ public class DialogFragmentDelegate
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().show__super((FragmentManager) args[0], (String) args[1]);
+                getOriginal().super_show((FragmentManager) args[0], (String) args[1]);
             }
         }, manager, tag);
     }
@@ -557,7 +557,7 @@ public class DialogFragmentDelegate
                     @Override
                     public Integer call(final Object... args) {
                         return getOriginal()
-                                .show__super((FragmentTransaction) args[0], (String) args[1]);
+                                .super_show((FragmentTransaction) args[0], (String) args[1]);
                     }
                 }, transaction, tag);
     }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
@@ -52,7 +52,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().dump__super((String) args[0], (FileDescriptor) args[1],
+                        getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
                                 (PrintWriter) args[2], (String[]) args[3]);
                     }
                 }, prefix, fd, writer, args);
@@ -72,7 +72,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().getAllowEnterTransitionOverlap__super();
+                        return getOriginal().super_getAllowEnterTransitionOverlap();
                     }
                 });
     }
@@ -91,7 +91,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().getAllowReturnTransitionOverlap__super();
+                        return getOriginal().super_getAllowReturnTransitionOverlap();
                     }
                 });
     }
@@ -109,7 +109,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<Context>() {
             @Override
             public Context call(final Object... args) {
-                return getOriginal().getContext__super();
+                return getOriginal().super_getContext();
             }
         });
     }
@@ -127,7 +127,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<Object>() {
             @Override
             public Object call(final Object... args) {
-                return getOriginal().getEnterTransition__super();
+                return getOriginal().super_getEnterTransition();
             }
         });
     }
@@ -145,7 +145,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<Object>() {
             @Override
             public Object call(final Object... args) {
-                return getOriginal().getExitTransition__super();
+                return getOriginal().super_getExitTransition();
             }
         });
     }
@@ -164,7 +164,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCall<LayoutInflater>() {
                     @Override
                     public LayoutInflater call(final Object... args) {
-                        return getOriginal().getLayoutInflater__super((Bundle) args[0]);
+                        return getOriginal().super_getLayoutInflater((Bundle) args[0]);
                     }
                 }, savedInstanceState);
     }
@@ -182,7 +182,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<LoaderManager>() {
             @Override
             public LoaderManager call(final Object... args) {
-                return getOriginal().getLoaderManager__super();
+                return getOriginal().super_getLoaderManager();
             }
         });
     }
@@ -200,7 +200,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<Object>() {
             @Override
             public Object call(final Object... args) {
-                return getOriginal().getReenterTransition__super();
+                return getOriginal().super_getReenterTransition();
             }
         });
     }
@@ -218,7 +218,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<Object>() {
             @Override
             public Object call(final Object... args) {
-                return getOriginal().getReturnTransition__super();
+                return getOriginal().super_getReturnTransition();
             }
         });
     }
@@ -237,7 +237,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCall<Object>() {
                     @Override
                     public Object call(final Object... args) {
-                        return getOriginal().getSharedElementEnterTransition__super();
+                        return getOriginal().super_getSharedElementEnterTransition();
                     }
                 });
     }
@@ -256,7 +256,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCall<Object>() {
                     @Override
                     public Object call(final Object... args) {
-                        return getOriginal().getSharedElementReturnTransition__super();
+                        return getOriginal().super_getSharedElementReturnTransition();
                     }
                 });
     }
@@ -274,7 +274,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().getUserVisibleHint__super();
+                return getOriginal().super_getUserVisibleHint();
             }
         });
     }
@@ -292,7 +292,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<View>() {
             @Override
             public View call(final Object... args) {
-                return getOriginal().getView__super();
+                return getOriginal().super_getView();
             }
         });
     }
@@ -307,7 +307,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onActivityCreated__super((Bundle) args[0]);
+                getOriginal().super_onActivityCreated((Bundle) args[0]);
             }
         }, savedInstanceState);
     }
@@ -323,7 +323,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
             @Override
             public void call(final Object... args) {
                 getOriginal()
-                        .onActivityResult__super((int) args[0], (int) args[1], (Intent) args[2]);
+                        .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
             }
         }, requestCode, resultCode, data);
     }
@@ -338,7 +338,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onAttach__super((Context) args[0]);
+                getOriginal().super_onAttach((Context) args[0]);
             }
         }, context);
     }
@@ -353,7 +353,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onAttach__super((Activity) args[0]);
+                getOriginal().super_onAttach((Activity) args[0]);
             }
         }, activity);
     }
@@ -368,7 +368,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onConfigurationChanged__super((Configuration) args[0]);
+                getOriginal().super_onConfigurationChanged((Configuration) args[0]);
             }
         }, newConfig);
     }
@@ -387,7 +387,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onContextItemSelected__super((MenuItem) args[0]);
+                        return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
                     }
                 }, item);
     }
@@ -402,7 +402,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onCreate__super((Bundle) args[0]);
+                getOriginal().super_onCreate((Bundle) args[0]);
             }
         }, savedInstanceState);
     }
@@ -423,7 +423,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                     @Override
                     public Animation call(final Object... args) {
                         return getOriginal()
-                                .onCreateAnimation__super((int) args[0], (boolean) args[1],
+                                .super_onCreateAnimation((int) args[0], (boolean) args[1],
                                         (int) args[2]);
                     }
                 }, transit, enter, nextAnim);
@@ -443,7 +443,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                     @Override
                     public void call(final Object... args) {
                         getOriginal()
-                                .onCreateContextMenu__super((ContextMenu) args[0], (View) args[1],
+                                .super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
                                         (ContextMenu.ContextMenuInfo) args[2]);
                     }
                 }, menu, v, menuInfo);
@@ -459,7 +459,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onCreateOptionsMenu__super((Menu) args[0], (MenuInflater) args[1]);
+                getOriginal().super_onCreateOptionsMenu((Menu) args[0], (MenuInflater) args[1]);
             }
         }, menu, inflater);
     }
@@ -481,7 +481,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                     @Override
                     public View call(final Object... args) {
                         return getOriginal()
-                                .onCreateView__super((LayoutInflater) args[0], (ViewGroup) args[1],
+                                .super_onCreateView((LayoutInflater) args[0], (ViewGroup) args[1],
                                         (Bundle) args[2]);
                     }
                 }, inflater, container, savedInstanceState);
@@ -497,7 +497,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onDestroy__super();
+                getOriginal().super_onDestroy();
             }
         });
     }
@@ -512,7 +512,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onDestroyOptionsMenu__super();
+                getOriginal().super_onDestroyOptionsMenu();
             }
         });
     }
@@ -527,7 +527,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onDestroyView__super();
+                getOriginal().super_onDestroyView();
             }
         });
     }
@@ -542,7 +542,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onDetach__super();
+                getOriginal().super_onDetach();
             }
         });
     }
@@ -557,7 +557,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onHiddenChanged__super((boolean) args[0]);
+                getOriginal().super_onHiddenChanged((boolean) args[0]);
             }
         }, hidden);
     }
@@ -574,7 +574,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onInflate__super((Context) args[0], (AttributeSet) args[1],
+                getOriginal().super_onInflate((Context) args[0], (AttributeSet) args[1],
                         (Bundle) args[2]);
             }
         }, context, attrs, savedInstanceState);
@@ -592,7 +592,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onInflate__super((Activity) args[0], (AttributeSet) args[1],
+                getOriginal().super_onInflate((Activity) args[0], (AttributeSet) args[1],
                         (Bundle) args[2]);
             }
         }, activity, attrs, savedInstanceState);
@@ -608,7 +608,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onLowMemory__super();
+                getOriginal().super_onLowMemory();
             }
         });
     }
@@ -627,7 +627,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCall<Boolean>() {
                     @Override
                     public Boolean call(final Object... args) {
-                        return getOriginal().onOptionsItemSelected__super((MenuItem) args[0]);
+                        return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
                     }
                 }, item);
     }
@@ -642,7 +642,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onOptionsMenuClosed__super((Menu) args[0]);
+                getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
             }
         }, menu);
     }
@@ -657,7 +657,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPause__super();
+                getOriginal().super_onPause();
             }
         });
     }
@@ -672,7 +672,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onPrepareOptionsMenu__super((Menu) args[0]);
+                getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
             }
         }, menu);
     }
@@ -690,8 +690,9 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().onRequestPermissionsResult__super((int) args[0],
-                                (String[]) args[1], (int[]) args[2]);
+                        getOriginal()
+                                .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
+                                        (int[]) args[2]);
                     }
                 }, requestCode, permissions, grantResults);
     }
@@ -706,7 +707,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onResume__super();
+                getOriginal().super_onResume();
             }
         });
     }
@@ -721,7 +722,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onSaveInstanceState__super((Bundle) args[0]);
+                getOriginal().super_onSaveInstanceState((Bundle) args[0]);
             }
         }, outState);
     }
@@ -736,7 +737,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onStart__super();
+                getOriginal().super_onStart();
             }
         });
     }
@@ -751,7 +752,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onStop__super();
+                getOriginal().super_onStop();
             }
         });
     }
@@ -766,7 +767,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onViewCreated__super((View) args[0], (Bundle) args[1]);
+                getOriginal().super_onViewCreated((View) args[0], (Bundle) args[1]);
             }
         }, view, savedInstanceState);
     }
@@ -781,7 +782,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().onViewStateRestored__super((Bundle) args[0]);
+                getOriginal().super_onViewStateRestored((Bundle) args[0]);
             }
         }, savedInstanceState);
     }
@@ -796,7 +797,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().registerForContextMenu__super((View) args[0]);
+                getOriginal().super_registerForContextMenu((View) args[0]);
             }
         }, view);
     }
@@ -811,7 +812,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setAllowEnterTransitionOverlap__super((boolean) args[0]);
+                getOriginal().super_setAllowEnterTransitionOverlap((boolean) args[0]);
             }
         }, allow);
     }
@@ -826,7 +827,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setAllowReturnTransitionOverlap__super((boolean) args[0]);
+                getOriginal().super_setAllowReturnTransitionOverlap((boolean) args[0]);
             }
         }, allow);
     }
@@ -841,7 +842,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setArguments__super((Bundle) args[0]);
+                getOriginal().super_setArguments((Bundle) args[0]);
             }
         }, args);
     }
@@ -858,7 +859,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setEnterSharedElementCallback__super(
+                        getOriginal().super_setEnterSharedElementCallback(
                                 (SharedElementCallback) args[0]);
                     }
                 }, callback);
@@ -874,7 +875,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setEnterTransition__super((Object) args[0]);
+                getOriginal().super_setEnterTransition((Object) args[0]);
             }
         }, transition);
     }
@@ -891,7 +892,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().setExitSharedElementCallback__super(
+                        getOriginal().super_setExitSharedElementCallback(
                                 (SharedElementCallback) args[0]);
                     }
                 }, callback);
@@ -907,7 +908,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setExitTransition__super((Object) args[0]);
+                getOriginal().super_setExitTransition((Object) args[0]);
             }
         }, transition);
     }
@@ -922,7 +923,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setHasOptionsMenu__super((boolean) args[0]);
+                getOriginal().super_setHasOptionsMenu((boolean) args[0]);
             }
         }, hasMenu);
     }
@@ -937,7 +938,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setInitialSavedState__super((Fragment.SavedState) args[0]);
+                getOriginal().super_setInitialSavedState((Fragment.SavedState) args[0]);
             }
         }, state);
     }
@@ -952,7 +953,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setMenuVisibility__super((boolean) args[0]);
+                getOriginal().super_setMenuVisibility((boolean) args[0]);
             }
         }, menuVisible);
     }
@@ -967,7 +968,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setReenterTransition__super((Object) args[0]);
+                getOriginal().super_setReenterTransition((Object) args[0]);
             }
         }, transition);
     }
@@ -982,7 +983,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setRetainInstance__super((boolean) args[0]);
+                getOriginal().super_setRetainInstance((boolean) args[0]);
             }
         }, retain);
     }
@@ -997,7 +998,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setReturnTransition__super((Object) args[0]);
+                getOriginal().super_setReturnTransition((Object) args[0]);
             }
         }, transition);
     }
@@ -1012,7 +1013,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setSharedElementEnterTransition__super((Object) args[0]);
+                getOriginal().super_setSharedElementEnterTransition((Object) args[0]);
             }
         }, transition);
     }
@@ -1027,7 +1028,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setSharedElementReturnTransition__super((Object) args[0]);
+                getOriginal().super_setSharedElementReturnTransition((Object) args[0]);
             }
         }, transition);
     }
@@ -1042,7 +1043,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setTargetFragment__super((Fragment) args[0], (int) args[1]);
+                getOriginal().super_setTargetFragment((Fragment) args[0], (int) args[1]);
             }
         }, fragment, requestCode);
     }
@@ -1057,7 +1058,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().setUserVisibleHint__super((boolean) args[0]);
+                getOriginal().super_setUserVisibleHint((boolean) args[0]);
             }
         }, isVisibleToUser);
     }
@@ -1078,7 +1079,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                     @Override
                     public Boolean call(final Object... args) {
                         return getOriginal()
-                                .shouldShowRequestPermissionRationale__super((String) args[0]);
+                                .super_shouldShowRequestPermissionRationale((String) args[0]);
                     }
                 }, permission);
     }
@@ -1093,7 +1094,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivity__super((Intent) args[0]);
+                getOriginal().super_startActivity((Intent) args[0]);
             }
         }, intent);
     }
@@ -1108,7 +1109,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivity__super((Intent) args[0], (Bundle) args[1]);
+                getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
             }
         }, intent, options);
     }
@@ -1123,7 +1124,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().startActivityForResult__super((Intent) args[0], (int) args[1]);
+                getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
             }
         }, intent, requestCode);
     }
@@ -1141,7 +1142,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
                 }, new SuperCallVoid() {
                     @Override
                     public void call(final Object... args) {
-                        getOriginal().startActivityForResult__super((Intent) args[0], (int) args[1],
+                        getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
                                 (Bundle) args[2]);
                     }
                 }, intent, requestCode, options);
@@ -1160,7 +1161,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCall<String>() {
             @Override
             public String call(final Object... args) {
-                return getOriginal().toString__super();
+                return getOriginal().super_toString();
             }
         });
     }
@@ -1175,7 +1176,7 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
         }, new SuperCallVoid() {
             @Override
             public void call(final Object... args) {
-                getOriginal().unregisterForContextMenu__super((View) args[0]);
+                getOriginal().super_unregisterForContextMenu((View) args[0]);
             }
         }, view);
     }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/ICompositeDialogFragment.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/ICompositeDialogFragment.java
@@ -18,95 +18,95 @@ public interface ICompositeDialogFragment extends ICompositeFragment {
 
     void dismissAllowingStateLoss();
 
-    void dismissAllowingStateLoss__super();
-
-    void dismiss__super();
-
     Dialog getDialog();
-
-    Dialog getDialog__super();
 
     LayoutInflater getLayoutInflater(final Bundle savedInstanceState);
 
-    LayoutInflater getLayoutInflater__super(final Bundle savedInstanceState);
-
     boolean getShowsDialog();
-
-    boolean getShowsDialog__super();
 
     int getTheme();
 
-    int getTheme__super();
-
     boolean isCancelable();
-
-    boolean isCancelable__super();
 
     void onActivityCreated(final Bundle savedInstanceState);
 
-    void onActivityCreated__super(final Bundle savedInstanceState);
-
     void onAttach(final Activity activity);
 
-    void onAttach__super(final Activity activity);
-
     void onCancel(final DialogInterface dialog);
-
-    void onCancel__super(final DialogInterface dialog);
 
     void onCreate(@Nullable final Bundle savedInstanceState);
 
     Dialog onCreateDialog(final Bundle savedInstanceState);
 
-    Dialog onCreateDialog__super(final Bundle savedInstanceState);
-
-    void onCreate__super(@Nullable final Bundle savedInstanceState);
-
     void onDestroyView();
-
-    void onDestroyView__super();
 
     void onDetach();
 
-    void onDetach__super();
-
     void onDismiss(final DialogInterface dialog);
-
-    void onDismiss__super(final DialogInterface dialog);
 
     void onSaveInstanceState(final Bundle outState);
 
-    void onSaveInstanceState__super(final Bundle outState);
-
     void onStart();
-
-    void onStart__super();
 
     void onStop();
 
-    void onStop__super();
-
     void setCancelable(final boolean cancelable);
-
-    void setCancelable__super(final boolean cancelable);
 
     void setShowsDialog(final boolean showsDialog);
 
-    void setShowsDialog__super(final boolean showsDialog);
-
     void setStyle(final int style, @StyleRes final int theme);
 
-    void setStyle__super(final int style, @StyleRes final int theme);
-
     void setupDialog(final Dialog dialog, final int style);
-
-    void setupDialog__super(final Dialog dialog, final int style);
 
     void show(final FragmentManager manager, final String tag);
 
     int show(final FragmentTransaction transaction, final String tag);
 
-    void show__super(final FragmentManager manager, final String tag);
+    void super_dismiss();
 
-    int show__super(final FragmentTransaction transaction, final String tag);
+    void super_dismissAllowingStateLoss();
+
+    Dialog super_getDialog();
+
+    LayoutInflater super_getLayoutInflater(final Bundle savedInstanceState);
+
+    boolean super_getShowsDialog();
+
+    int super_getTheme();
+
+    boolean super_isCancelable();
+
+    void super_onActivityCreated(final Bundle savedInstanceState);
+
+    void super_onAttach(final Activity activity);
+
+    void super_onCancel(final DialogInterface dialog);
+
+    void super_onCreate(@Nullable final Bundle savedInstanceState);
+
+    Dialog super_onCreateDialog(final Bundle savedInstanceState);
+
+    void super_onDestroyView();
+
+    void super_onDetach();
+
+    void super_onDismiss(final DialogInterface dialog);
+
+    void super_onSaveInstanceState(final Bundle outState);
+
+    void super_onStart();
+
+    void super_onStop();
+
+    void super_setCancelable(final boolean cancelable);
+
+    void super_setShowsDialog(final boolean showsDialog);
+
+    void super_setStyle(final int style, @StyleRes final int theme);
+
+    void super_setupDialog(final Dialog dialog, final int style);
+
+    void super_show(final FragmentManager manager, final String tag);
+
+    int super_show(final FragmentTransaction transaction, final String tag);
 }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/ICompositeFragment.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/fragment/ICompositeFragment.java
@@ -30,128 +30,65 @@ public interface ICompositeFragment {
     void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args);
 
-    void dump__super(final String prefix, final FileDescriptor fd, final PrintWriter writer,
-            final String[] args);
-
     boolean getAllowEnterTransitionOverlap();
-
-    boolean getAllowEnterTransitionOverlap__super();
 
     boolean getAllowReturnTransitionOverlap();
 
-    boolean getAllowReturnTransitionOverlap__super();
-
     Context getContext();
-
-    Context getContext__super();
 
     Object getEnterTransition();
 
-    Object getEnterTransition__super();
-
     Object getExitTransition();
-
-    Object getExitTransition__super();
 
     LayoutInflater getLayoutInflater(final Bundle savedInstanceState);
 
-    LayoutInflater getLayoutInflater__super(final Bundle savedInstanceState);
-
     LoaderManager getLoaderManager();
-
-    LoaderManager getLoaderManager__super();
 
     Object getReenterTransition();
 
-    Object getReenterTransition__super();
-
     Object getReturnTransition();
-
-    Object getReturnTransition__super();
 
     Object getSharedElementEnterTransition();
 
-    Object getSharedElementEnterTransition__super();
-
     Object getSharedElementReturnTransition();
-
-    Object getSharedElementReturnTransition__super();
 
     boolean getUserVisibleHint();
 
-    boolean getUserVisibleHint__super();
-
     View getView();
-
-    View getView__super();
 
     void onActivityCreated(@Nullable final Bundle savedInstanceState);
 
-    void onActivityCreated__super(@Nullable final Bundle savedInstanceState);
-
     void onActivityResult(final int requestCode, final int resultCode, final Intent data);
-
-    void onActivityResult__super(final int requestCode, final int resultCode, final Intent data);
 
     void onAttach(final Context context);
 
     void onAttach(final Activity activity);
 
-    void onAttach__super(final Context context);
-
-    void onAttach__super(final Activity activity);
-
     void onConfigurationChanged(final Configuration newConfig);
 
-    void onConfigurationChanged__super(final Configuration newConfig);
-
     boolean onContextItemSelected(final MenuItem item);
-
-    boolean onContextItemSelected__super(final MenuItem item);
 
     void onCreate(@Nullable final Bundle savedInstanceState);
 
     Animation onCreateAnimation(final int transit, final boolean enter, final int nextAnim);
 
-    Animation onCreateAnimation__super(final int transit, final boolean enter, final int nextAnim);
-
     void onCreateContextMenu(final ContextMenu menu, final View v,
-            final ContextMenu.ContextMenuInfo menuInfo);
-
-    void onCreateContextMenu__super(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo);
 
     void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater);
 
-    void onCreateOptionsMenu__super(final Menu menu, final MenuInflater inflater);
-
     View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
             @Nullable final Bundle savedInstanceState);
-
-    View onCreateView__super(final LayoutInflater inflater, @Nullable final ViewGroup container,
-            @Nullable final Bundle savedInstanceState);
-
-    void onCreate__super(@Nullable final Bundle savedInstanceState);
 
     void onDestroy();
 
     void onDestroyOptionsMenu();
 
-    void onDestroyOptionsMenu__super();
-
     void onDestroyView();
-
-    void onDestroyView__super();
-
-    void onDestroy__super();
 
     void onDetach();
 
-    void onDetach__super();
-
     void onHiddenChanged(final boolean hidden);
-
-    void onHiddenChanged__super(final boolean hidden);
 
     void onInflate(final Context context, final AttributeSet attrs,
             final Bundle savedInstanceState);
@@ -159,137 +96,68 @@ public interface ICompositeFragment {
     void onInflate(final Activity activity, final AttributeSet attrs,
             final Bundle savedInstanceState);
 
-    void onInflate__super(final Context context, final AttributeSet attrs,
-            final Bundle savedInstanceState);
-
-    void onInflate__super(final Activity activity, final AttributeSet attrs,
-            final Bundle savedInstanceState);
-
     void onLowMemory();
-
-    void onLowMemory__super();
 
     boolean onOptionsItemSelected(final MenuItem item);
 
-    boolean onOptionsItemSelected__super(final MenuItem item);
-
     void onOptionsMenuClosed(final Menu menu);
-
-    void onOptionsMenuClosed__super(final Menu menu);
 
     void onPause();
 
-    void onPause__super();
-
     void onPrepareOptionsMenu(final Menu menu);
-
-    void onPrepareOptionsMenu__super(final Menu menu);
 
     void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions,
             @NonNull final int[] grantResults);
 
-    void onRequestPermissionsResult__super(final int requestCode,
-            @NonNull final String[] permissions, @NonNull final int[] grantResults);
-
     void onResume();
-
-    void onResume__super();
 
     void onSaveInstanceState(final Bundle outState);
 
-    void onSaveInstanceState__super(final Bundle outState);
-
     void onStart();
-
-    void onStart__super();
 
     void onStop();
 
-    void onStop__super();
-
     void onViewCreated(final View view, @Nullable final Bundle savedInstanceState);
-
-    void onViewCreated__super(final View view, @Nullable final Bundle savedInstanceState);
 
     void onViewStateRestored(@Nullable final Bundle savedInstanceState);
 
-    void onViewStateRestored__super(@Nullable final Bundle savedInstanceState);
-
     void registerForContextMenu(final View view);
-
-    void registerForContextMenu__super(final View view);
 
     void setAllowEnterTransitionOverlap(final boolean allow);
 
-    void setAllowEnterTransitionOverlap__super(final boolean allow);
-
     void setAllowReturnTransitionOverlap(final boolean allow);
-
-    void setAllowReturnTransitionOverlap__super(final boolean allow);
 
     void setArguments(final Bundle args);
 
-    void setArguments__super(final Bundle args);
-
     void setEnterSharedElementCallback(final SharedElementCallback callback);
-
-    void setEnterSharedElementCallback__super(final SharedElementCallback callback);
 
     void setEnterTransition(final Object transition);
 
-    void setEnterTransition__super(final Object transition);
-
     void setExitSharedElementCallback(final SharedElementCallback callback);
-
-    void setExitSharedElementCallback__super(final SharedElementCallback callback);
 
     void setExitTransition(final Object transition);
 
-    void setExitTransition__super(final Object transition);
-
     void setHasOptionsMenu(final boolean hasMenu);
-
-    void setHasOptionsMenu__super(final boolean hasMenu);
 
     void setInitialSavedState(final Fragment.SavedState state);
 
-    void setInitialSavedState__super(final Fragment.SavedState state);
-
     void setMenuVisibility(final boolean menuVisible);
-
-    void setMenuVisibility__super(final boolean menuVisible);
 
     void setReenterTransition(final Object transition);
 
-    void setReenterTransition__super(final Object transition);
-
     void setRetainInstance(final boolean retain);
-
-    void setRetainInstance__super(final boolean retain);
 
     void setReturnTransition(final Object transition);
 
-    void setReturnTransition__super(final Object transition);
-
     void setSharedElementEnterTransition(final Object transition);
-
-    void setSharedElementEnterTransition__super(final Object transition);
 
     void setSharedElementReturnTransition(final Object transition);
 
-    void setSharedElementReturnTransition__super(final Object transition);
-
     void setTargetFragment(final Fragment fragment, final int requestCode);
-
-    void setTargetFragment__super(final Fragment fragment, final int requestCode);
 
     void setUserVisibleHint(final boolean isVisibleToUser);
 
-    void setUserVisibleHint__super(final boolean isVisibleToUser);
-
     boolean shouldShowRequestPermissionRationale(@NonNull final String permission);
-
-    boolean shouldShowRequestPermissionRationale__super(@NonNull final String permission);
 
     void startActivity(final Intent intent);
 
@@ -300,20 +168,152 @@ public interface ICompositeFragment {
     void startActivityForResult(final Intent intent, final int requestCode,
             @Nullable final Bundle options);
 
-    void startActivityForResult__super(final Intent intent, final int requestCode);
+    void super_dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
+            final String[] args);
 
-    void startActivityForResult__super(final Intent intent, final int requestCode,
+    boolean super_getAllowEnterTransitionOverlap();
+
+    boolean super_getAllowReturnTransitionOverlap();
+
+    Context super_getContext();
+
+    Object super_getEnterTransition();
+
+    Object super_getExitTransition();
+
+    LayoutInflater super_getLayoutInflater(final Bundle savedInstanceState);
+
+    LoaderManager super_getLoaderManager();
+
+    Object super_getReenterTransition();
+
+    Object super_getReturnTransition();
+
+    Object super_getSharedElementEnterTransition();
+
+    Object super_getSharedElementReturnTransition();
+
+    boolean super_getUserVisibleHint();
+
+    View super_getView();
+
+    void super_onActivityCreated(@Nullable final Bundle savedInstanceState);
+
+    void super_onActivityResult(final int requestCode, final int resultCode, final Intent data);
+
+    void super_onAttach(final Context context);
+
+    void super_onAttach(final Activity activity);
+
+    void super_onConfigurationChanged(final Configuration newConfig);
+
+    boolean super_onContextItemSelected(final MenuItem item);
+
+    void super_onCreate(@Nullable final Bundle savedInstanceState);
+
+    Animation super_onCreateAnimation(final int transit, final boolean enter, final int nextAnim);
+
+    void super_onCreateContextMenu(final ContextMenu menu, final View v,
+            final ContextMenu.ContextMenuInfo menuInfo);
+
+    void super_onCreateOptionsMenu(final Menu menu, final MenuInflater inflater);
+
+    View super_onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
+            @Nullable final Bundle savedInstanceState);
+
+    void super_onDestroy();
+
+    void super_onDestroyOptionsMenu();
+
+    void super_onDestroyView();
+
+    void super_onDetach();
+
+    void super_onHiddenChanged(final boolean hidden);
+
+    void super_onInflate(final Context context, final AttributeSet attrs,
+            final Bundle savedInstanceState);
+
+    void super_onInflate(final Activity activity, final AttributeSet attrs,
+            final Bundle savedInstanceState);
+
+    void super_onLowMemory();
+
+    boolean super_onOptionsItemSelected(final MenuItem item);
+
+    void super_onOptionsMenuClosed(final Menu menu);
+
+    void super_onPause();
+
+    void super_onPrepareOptionsMenu(final Menu menu);
+
+    void super_onRequestPermissionsResult(final int requestCode,
+            @NonNull final String[] permissions, @NonNull final int[] grantResults);
+
+    void super_onResume();
+
+    void super_onSaveInstanceState(final Bundle outState);
+
+    void super_onStart();
+
+    void super_onStop();
+
+    void super_onViewCreated(final View view, @Nullable final Bundle savedInstanceState);
+
+    void super_onViewStateRestored(@Nullable final Bundle savedInstanceState);
+
+    void super_registerForContextMenu(final View view);
+
+    void super_setAllowEnterTransitionOverlap(final boolean allow);
+
+    void super_setAllowReturnTransitionOverlap(final boolean allow);
+
+    void super_setArguments(final Bundle args);
+
+    void super_setEnterSharedElementCallback(final SharedElementCallback callback);
+
+    void super_setEnterTransition(final Object transition);
+
+    void super_setExitSharedElementCallback(final SharedElementCallback callback);
+
+    void super_setExitTransition(final Object transition);
+
+    void super_setHasOptionsMenu(final boolean hasMenu);
+
+    void super_setInitialSavedState(final Fragment.SavedState state);
+
+    void super_setMenuVisibility(final boolean menuVisible);
+
+    void super_setReenterTransition(final Object transition);
+
+    void super_setRetainInstance(final boolean retain);
+
+    void super_setReturnTransition(final Object transition);
+
+    void super_setSharedElementEnterTransition(final Object transition);
+
+    void super_setSharedElementReturnTransition(final Object transition);
+
+    void super_setTargetFragment(final Fragment fragment, final int requestCode);
+
+    void super_setUserVisibleHint(final boolean isVisibleToUser);
+
+    boolean super_shouldShowRequestPermissionRationale(@NonNull final String permission);
+
+    void super_startActivity(final Intent intent);
+
+    void super_startActivity(final Intent intent, @Nullable final Bundle options);
+
+    void super_startActivityForResult(final Intent intent, final int requestCode);
+
+    void super_startActivityForResult(final Intent intent, final int requestCode,
             @Nullable final Bundle options);
 
-    void startActivity__super(final Intent intent);
+    String super_toString();
 
-    void startActivity__super(final Intent intent, @Nullable final Bundle options);
+    void super_unregisterForContextMenu(final View view);
 
     String toString();
 
-    String toString__super();
-
     void unregisterForContextMenu(final View view);
-
-    void unregisterForContextMenu__super(final View view);
 }

--- a/activity/src/test/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegateTest.java
+++ b/activity/src/test/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegateTest.java
@@ -48,7 +48,7 @@ public class ActivityDelegateTest {
         verify(a, never()).onKeyDown(1, event);
         verify(b).onKeyDown(1, event);
         verify(c).onKeyDown(1, event);
-        verify(activity, never()).onKeyDown__super(1, event);
+        verify(activity, never()).super_onKeyDown(1, event);
     }
 
     @Test
@@ -71,7 +71,7 @@ public class ActivityDelegateTest {
         verify(a).onKeyDown(1, event);
         verify(b).onKeyDown(1, event);
         verify(c).onKeyDown(1, event);
-        verify(activity).onKeyDown__super(1, event);
+        verify(activity).super_onKeyDown(1, event);
     }
 
     @Test
@@ -132,7 +132,7 @@ public class ActivityDelegateTest {
         // twice because of the error above
         verify(b, times(2)).setContentView(layoutResID);
         verify(c).setContentView(layoutResID);
-        verify(activity, never()).setContentView__super(layoutResID);
+        verify(activity, never()).super_setContentView(layoutResID);
         verify(activity, never()).setContentView(layoutResID);
     }
 
@@ -161,7 +161,7 @@ public class ActivityDelegateTest {
         verify(a).onKeyDown(25, event);
         verify(b).onKeyDown(1, event);
         verify(c).onKeyDown(1, event);
-        verify(activity).onKeyDown__super(25, event);
+        verify(activity).super_onKeyDown(25, event);
     }
 
     @Test
@@ -206,7 +206,7 @@ public class ActivityDelegateTest {
         inOrder.verify(b).onPause();
         inOrder.verify(beforeBSuper).call();
         inOrder.verify(a).onPause();
-        inOrder.verify(activity).onPause__super();
+        inOrder.verify(activity).super_onPause();
         inOrder.verify(afterBSuper).call();
         inOrder.verify(afterCSuper).call();
 
@@ -221,7 +221,7 @@ public class ActivityDelegateTest {
 
         final KeyEvent event = mock(KeyEvent.class);
         delegate.onKeyDown(1, event);
-        verify(activity).onKeyDown__super(1, event);
+        verify(activity).super_onKeyDown(1, event);
     }
 
     @Test
@@ -238,7 +238,7 @@ public class ActivityDelegateTest {
         delegate.onKeyDown(1, event);
 
         verify(a).onKeyDown(1, event);
-        verify(activity).onKeyDown__super(1, event);
+        verify(activity).super_onKeyDown(1, event);
     }
 /*
     @Test
@@ -324,7 +324,7 @@ public class ActivityDelegateTest {
         verify(a, never()).onKeyDown(25, event);
         verify(b).onKeyDown(25, event);
         verify(c).onKeyDown(1, event);
-        verify(activity, never()).onKeyDown__super(25, event);
+        verify(activity, never()).super_onKeyDown(25, event);
     }
 
     @Test
@@ -347,7 +347,7 @@ public class ActivityDelegateTest {
         verify(a).onContextItemSelected(item);
         verify(b).onContextItemSelected(item);
         verify(c).onContextItemSelected(item);
-        verify(activity).onContextItemSelected__super(item);
+        verify(activity).super_onContextItemSelected(item);
     }
 
     @Test
@@ -375,7 +375,7 @@ public class ActivityDelegateTest {
         verify(a, never()).onContextItemSelected(item);
         verify(b).onContextItemSelected(item);
         verify(c).onContextItemSelected(item);
-        verify(activity, never()).onContextItemSelected__super(item);
+        verify(activity, never()).super_onContextItemSelected(item);
     }
 
 

--- a/generator/src/main/kotlin/parse/JavaFileParser.kt
+++ b/generator/src/main/kotlin/parse/JavaFileParser.kt
@@ -48,7 +48,7 @@ fun parseJavaFile(file: File): AnalyzedJavaFile {
         val returnType = groups[4]?.value!!
         val name = groups[5]?.value!!
         val parameters = groups[6]?.value?.replace("\n", " ")?.replace(",\\h+".toRegex(), ", ")
-        val throws = groups[7]?.value?.replace("\n", " ")
+        val throws = groups[7]?.value?.replace("\n", " ")?.replace(",\\h+".toRegex(), ", ")?.trim()
 
         val paramNames = mutableListOf<String>()
         val paramType = mutableListOf<String>()

--- a/generator/src/main/kotlin/writer/CompositeWriter.kt
+++ b/generator/src/main/kotlin/writer/CompositeWriter.kt
@@ -96,7 +96,8 @@ private fun AnalyzedJavaMethod.callSuper(): String {
 
     return """
             |$formattedAnnotations
-            |public $returnType ${name}__super($rawParameters) $exceptions{
+            |@Override
+            |public $returnType super_$name($rawParameters) $exceptions{
             |    ${returnWhenNotVoid}super.$name(${parameterNames.joinToString()});
             |}
             """.replaceIndentByMargin("    ")

--- a/generator/src/main/kotlin/writer/DelegateWriter.kt
+++ b/generator/src/main/kotlin/writer/DelegateWriter.kt
@@ -182,7 +182,7 @@ fun AnalyzedJavaMethod.hook(originalGetterName: String = "getOriginal()",
     sb.appendln("            @Override")
     sb.appendln("            public void call(final Object... args) {")
     if (throws) sb.appendln("                try {")
-    sb.appendln("                $originalGetterName.${name}__super(${typedArgs.joinToString()});")
+    sb.appendln("                $originalGetterName.super_$name(${typedArgs.joinToString()});")
     if (throws) {
         sb.appendln("            } catch ($exceptionType e) {")
         sb.appendln("                throw new SuppressedException(e);")
@@ -222,7 +222,7 @@ fun AnalyzedJavaMethod.callFunction(originalGetterName: String = "getOriginal()"
         }, new SuperCall<$boxedReturnType>() {
             @Override
             public $boxedReturnType call(final Object... args) { ${if (throws) "\ntry {" else ""}
-                return $originalGetterName.${name}__super(${typedArgs.joinToString()}); ${if (throws) "\n} catch ($exceptionType e) {\n throw new SuppressedException(e);\n }" else ""}
+                return $originalGetterName.super_${name}(${typedArgs.joinToString()}); ${if (throws) "\n} catch ($exceptionType e) {\n throw new SuppressedException(e);\n }" else ""}
             }
         }${if (parameterNames.size > 0) ", " else ""}$varargs);
     }

--- a/generator/src/main/kotlin/writer/InterfaceWriter.kt
+++ b/generator/src/main/kotlin/writer/InterfaceWriter.kt
@@ -45,7 +45,7 @@ fun writeInterface(javaFile: AnalyzedJavaFile,
         output = transform(output)
     }
 
-    val out = File("${outPath}${javaPackage.replace('.', '/')}/$javaClassName.java")
+    val out = File("$outPath${javaPackage.replace('.', '/')}/$javaClassName.java")
     out.parentFile.mkdirs()
     out.printWriter().use { it.write(output) }
     System.out.println("wrote ${out.absolutePath}")
@@ -62,6 +62,6 @@ private fun AnalyzedJavaMethod.toInterface(): String {
 private fun AnalyzedJavaMethod.toSuperInterface(): String {
     return """
             |
-            |$returnType ${name}__super($rawParameters) $exceptions;
+            |$returnType super_$name($rawParameters) $exceptions;
             """.replaceIndentByMargin("    ")
 }


### PR DESCRIPTION
super methods started with the real method name. Where always visible when searching for "onC..."
renamed $name__super -> super_$name
