### PR TITLE
Hotfix OOM by accidentally causing a stackoverflow 

### DIFF
--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -1418,15 +1418,6 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         });
     }
 
-    public Object getLastCompositeCustomNonConfigurationInstance() {
-        final Object nci = getOriginal().getLastCustomNonConfigurationInstance();
-        if (nci instanceof NonConfigurationInstanceWrapper) {
-            final NonConfigurationInstanceWrapper all = (NonConfigurationInstanceWrapper) nci;
-            return all.getSuperNonConfigurationInstance();
-        }
-        return null;
-    }
-
     public Object getLastNonConfigurationInstance(final String key) {
         final Object nci = getOriginal().getLastCustomNonConfigurationInstance();
         if (nci instanceof NonConfigurationInstanceWrapper) {

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/CompositeActivity.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/CompositeActivity.java
@@ -745,7 +745,7 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
      * @return see {@link #AppCompatActivity#getLastCustomNonConfigurationInstance()}
      */
     public Object getLastCompositeCustomNonConfigurationInstance() {
-        return delegate.getLastCompositeCustomNonConfigurationInstance();
+        return null;
     }
 
     /**

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/CompositeActivity.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/CompositeActivity.java
@@ -2178,6 +2178,8 @@ public class CompositeActivity extends AppCompatActivity implements ICompositeAc
     }
 
     /**
+     * save any object over configuration changes, get it with {@link #getLastCompositeCustomNonConfigurationInstance()}
+     *
      * @return see {@link #AppCompatActivity#onRetainCustomNonConfigurationInstance()}
      */
     public Object onRetainCompositeCustomNonConfigurationInstance() {

--- a/generator/src/main/kotlin/types/Activity.kt
+++ b/generator/src/main/kotlin/types/Activity.kt
@@ -108,7 +108,7 @@ val activity_custom_nonConfigurationInstance_handling = """
         | * @return see {@link #AppCompatActivity#getLastCustomNonConfigurationInstance()}
         | */
         |public Object getLastCompositeCustomNonConfigurationInstance() {
-        |    return delegate.getLastCompositeCustomNonConfigurationInstance();
+        |    return null;
         |}
         |
         |/**

--- a/generator/src/main/kotlin/types/Activity.kt
+++ b/generator/src/main/kotlin/types/Activity.kt
@@ -112,6 +112,7 @@ val activity_custom_nonConfigurationInstance_handling = """
         |}
         |
         |/**
+        | * save any object over configuration changes, get it with {@link #getLastCompositeCustomNonConfigurationInstance()}
         | * @return see {@link #AppCompatActivity#onRetainCustomNonConfigurationInstance()}
         | */
         |public Object onRetainCompositeCustomNonConfigurationInstance() {
@@ -120,15 +121,6 @@ val activity_custom_nonConfigurationInstance_handling = """
         """.replaceIndentByMargin("    ")
 
 val delegate_custom_nonConfigurationInstance_handling = """
-        |
-        |public Object getLastCompositeCustomNonConfigurationInstance() {
-        |    final Object nci = getOriginal().getLastCustomNonConfigurationInstance();
-        |    if (nci instanceof NonConfigurationInstanceWrapper) {
-        |        final NonConfigurationInstanceWrapper all = (NonConfigurationInstanceWrapper) nci;
-        |        return all.getSuperNonConfigurationInstance();
-        |    }
-        |    return null;
-        |}
         |
         |public Object getLastNonConfigurationInstance(final String key) {
         |    final Object nci = getOriginal().getLastCustomNonConfigurationInstance();


### PR DESCRIPTION
when calling `getLastNonConfigurationInstance(key)`
