### PR TITLE
Feature/performance

### DIFF
--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -81,6 +81,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.util.ListIterator;
 
 
 public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, ActivityPlugin> {
@@ -1209,21 +1210,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         }, name);
     }
 
+    final PluginCall<ActivityPlugin, AppCompatDelegate> fiudsojf
+            = new PluginCall<ActivityPlugin, AppCompatDelegate>() {
+        @Override
+        public AppCompatDelegate call(final NamedSuperCall<AppCompatDelegate> superCall,
+                final ActivityPlugin plugin, final Object... args) {
+
+            return plugin.getDelegate(superCall);
+
+        }
+    };
+    final SuperCall<AppCompatDelegate> diso = new SuperCall<AppCompatDelegate>() {
+        @Override
+        public AppCompatDelegate call(final Object... args) {
+            return getOriginal().super_getDelegate();
+        }
+    };
+
+
     public AppCompatDelegate getDelegate() {
-        return callFunction("getDelegate()", new PluginCall<ActivityPlugin, AppCompatDelegate>() {
-            @Override
-            public AppCompatDelegate call(final NamedSuperCall<AppCompatDelegate> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
-
-                return plugin.getDelegate(superCall);
-
-            }
-        }, new SuperCall<AppCompatDelegate>() {
-            @Override
-            public AppCompatDelegate call(final Object... args) {
-                return getOriginal().super_getDelegate();
-            }
-        });
+        return callFunction("getDelegate()", fiudsojf, diso);
     }
 
     public File getDir(final String name, final int mode) {
@@ -1713,22 +1719,50 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         });
     }
 
+
+    //private GetResourcesSuperCall mGetResourcesSuperCall = new GetResourcesSuperCall();
+
     public Resources getResources() {
-        return callFunction("getResources()", new PluginCall<ActivityPlugin, Resources>() {
-            @Override
-            public Resources call(final NamedSuperCall<Resources> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getResources();
+        }
 
-                return plugin.getResources(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Resources>() {
+        final NamedSuperCall<Resources> superCall =
+                new NamedSuperCall<Resources>("getResources()") {
+
             @Override
             public Resources call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getResources(this);
+                } else {
+                    return getOriginal().super_getResources();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+/*    private class GetResourcesSuperCall extends NamedSuperCall<Resources> {
+
+        private ListIterator<ActivityPlugin> iterator;
+
+        public GetResourcesSuperCall() {
+            super("getResources()");
+        }
+
+        @Override
+        public Resources call(final Object... args) {
+            if (iterator.hasPrevious()) {
+                ActivityPlugin plugin = iterator.previous();
+                return plugin.getResources(this);
+            } else {
                 return getOriginal().super_getResources();
             }
-        });
-    }
+        }
+    }*/
+
 
     public SharedPreferences getSharedPreferences(final String name, final int mode) {
         return callFunction("getSharedPreferences(String, int)",
@@ -3339,38 +3373,42 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         return all;
     }
 
+    final PluginCallVoid<ActivityPlugin> onSaveInstanceStatemethodCall = new PluginCallVoid<ActivityPlugin>() {
+        @Override
+        public void call(final NamedSuperCall<Void> superCall,
+                final ActivityPlugin plugin, final Object... args) {
+            plugin.onSaveInstanceState(superCall, (Bundle) args[0],
+                    (PersistableBundle) args[1]);
+        }
+    };
+    final SuperCallVoid onSaveInstantstateactivitySuper = new SuperCallVoid() {
+        @Override
+        public void call(final Object... args) {
+            getOriginal().super_onSaveInstanceState((Bundle) args[0],
+                    (PersistableBundle) args[1]);
+        }
+    };
     public void onSaveInstanceState(final Bundle outState,
             final PersistableBundle outPersistentState) {
         callHook("onSaveInstanceState(Bundle, PersistableBundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onSaveInstanceState(superCall, (Bundle) args[0],
-                                (PersistableBundle) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onSaveInstanceState((Bundle) args[0],
-                                (PersistableBundle) args[1]);
-                    }
-                }, outState, outPersistentState);
+                onSaveInstanceStatemethodCall, onSaveInstantstateactivitySuper, outState, outPersistentState);
     }
 
+    final PluginCallVoid<ActivityPlugin> aslkfjawer = new PluginCallVoid<ActivityPlugin>() {
+        @Override
+        public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
+                final Object... args) {
+            plugin.onSaveInstanceState(superCall, (Bundle) args[0]);
+        }
+    };
+    final SuperCallVoid oisanfs = new SuperCallVoid() {
+        @Override
+        public void call(final Object... args) {
+            getOriginal().super_onSaveInstanceState((Bundle) args[0]);
+        }
+    };
     public void onSaveInstanceState(final Bundle outState) {
-        callHook("onSaveInstanceState(Bundle)", new PluginCallVoid<ActivityPlugin>() {
-            @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onSaveInstanceState(superCall, (Bundle) args[0]);
-            }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onSaveInstanceState((Bundle) args[0]);
-            }
-        }, outState);
+        callHook("onSaveInstanceState(Bundle)", aslkfjawer, oisanfs, outState);
     }
 
     public boolean onSearchRequested(final SearchEvent searchEvent) {

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -2,10 +2,6 @@ package com.pascalwelsch.compositeandroid.activity;
 
 import com.pascalwelsch.compositeandroid.core.AbstractDelegate;
 import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
-import com.pascalwelsch.compositeandroid.core.PluginCall;
-import com.pascalwelsch.compositeandroid.core.PluginCallVoid;
-import com.pascalwelsch.compositeandroid.core.SuperCall;
-import com.pascalwelsch.compositeandroid.core.SuperCallVoid;
 
 import android.app.Activity;
 import android.app.ActivityManager;
@@ -83,7 +79,6 @@ import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.ListIterator;
 
-
 public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, ActivityPlugin> {
 
 
@@ -94,1334 +89,1765 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
 
     public void addContentView(final View view, final ViewGroup.LayoutParams params) {
-        callHook("addContentView(View, ViewGroup.LayoutParams)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.addContentView(superCall, (View) args[0],
-                                (ViewGroup.LayoutParams) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_addContentView((View) args[0],
-                                (ViewGroup.LayoutParams) args[1]);
-                    }
-                }, view, params);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_addContentView(view, params);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "addContentView(View, ViewGroup.LayoutParams)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .addContentView(this, (View) args[0], (ViewGroup.LayoutParams) args[1]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_addContentView((View) args[0], (ViewGroup.LayoutParams) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(view, params);
     }
 
     public void applyOverrideConfiguration(final Configuration overrideConfiguration) {
-        callHook("applyOverrideConfiguration(Configuration)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_applyOverrideConfiguration(overrideConfiguration);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "applyOverrideConfiguration(Configuration)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.applyOverrideConfiguration(superCall, (Configuration) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().applyOverrideConfiguration(this, (Configuration) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_applyOverrideConfiguration((Configuration) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_applyOverrideConfiguration((Configuration) args[0]);
-            }
-        }, overrideConfiguration);
+        };
+        superCall.call(overrideConfiguration);
     }
 
     public void attachBaseContext(final Context newBase) {
-        callHook("attachBaseContext(Context)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_attachBaseContext(newBase);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "attachBaseContext(Context)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.attachBaseContext(superCall, (Context) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().attachBaseContext(this, (Context) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_attachBaseContext((Context) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_attachBaseContext((Context) args[0]);
-            }
-        }, newBase);
+        };
+        superCall.call(newBase);
     }
 
     public boolean bindService(final Intent service, final ServiceConnection conn,
             final int flags) {
-        return callFunction("bindService(Intent, ServiceConnection, int)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_bindService(service, conn, flags);
+        }
 
-                        return plugin.bindService(superCall, (Intent) args[0],
-                                (ServiceConnection) args[1], (int) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_bindService((Intent) args[0], (ServiceConnection) args[1],
-                                        (int) args[2]);
-                    }
-                }, service, conn, flags);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "bindService(Intent, ServiceConnection, int)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .bindService(this, (Intent) args[0], (ServiceConnection) args[1],
+                                    (int) args[2]);
+                } else {
+                    return getOriginal()
+                            .super_bindService((Intent) args[0], (ServiceConnection) args[1],
+                                    (int) args[2]);
+                }
+            }
+        };
+        return superCall.call(service, conn, flags);
     }
 
     public int checkCallingOrSelfPermission(final String permission) {
-        return callFunction("checkCallingOrSelfPermission(String)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_checkCallingOrSelfPermission(permission);
+        }
 
-                        return plugin.checkCallingOrSelfPermission(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_checkCallingOrSelfPermission((String) args[0]);
-                    }
-                }, permission);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkCallingOrSelfPermission(String)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().checkCallingOrSelfPermission(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_checkCallingOrSelfPermission((String) args[0]);
+                }
+            }
+        };
+        return superCall.call(permission);
     }
 
     public int checkCallingOrSelfUriPermission(final Uri uri, final int modeFlags) {
-        return callFunction("checkCallingOrSelfUriPermission(Uri, int)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_checkCallingOrSelfUriPermission(uri, modeFlags);
+        }
 
-                        return plugin.checkCallingOrSelfUriPermission(superCall, (Uri) args[0],
-                                (int) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_checkCallingOrSelfUriPermission((Uri) args[0],
-                                (int) args[1]);
-                    }
-                }, uri, modeFlags);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkCallingOrSelfUriPermission(Uri, int)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .checkCallingOrSelfUriPermission(this, (Uri) args[0], (int) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_checkCallingOrSelfUriPermission((Uri) args[0], (int) args[1]);
+                }
+            }
+        };
+        return superCall.call(uri, modeFlags);
     }
 
     public int checkCallingPermission(final String permission) {
-        return callFunction("checkCallingPermission(String)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_checkCallingPermission(permission);
+        }
 
-                        return plugin.checkCallingPermission(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_checkCallingPermission((String) args[0]);
-                    }
-                }, permission);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkCallingPermission(String)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().checkCallingPermission(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_checkCallingPermission((String) args[0]);
+                }
+            }
+        };
+        return superCall.call(permission);
     }
 
     public int checkCallingUriPermission(final Uri uri, final int modeFlags) {
-        return callFunction("checkCallingUriPermission(Uri, int)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_checkCallingUriPermission(uri, modeFlags);
+        }
 
-                        return plugin
-                                .checkCallingUriPermission(superCall, (Uri) args[0], (int) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal()
-                                .super_checkCallingUriPermission((Uri) args[0], (int) args[1]);
-                    }
-                }, uri, modeFlags);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkCallingUriPermission(Uri, int)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .checkCallingUriPermission(this, (Uri) args[0], (int) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_checkCallingUriPermission((Uri) args[0], (int) args[1]);
+                }
+            }
+        };
+        return superCall.call(uri, modeFlags);
     }
 
     public int checkPermission(final String permission, final int pid, final int uid) {
-        return callFunction("checkPermission(String, int, int)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_checkPermission(permission, pid, uid);
+        }
 
-                        return plugin.checkPermission(superCall, (String) args[0], (int) args[1],
-                                (int) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_checkPermission((String) args[0], (int) args[1],
-                                (int) args[2]);
-                    }
-                }, permission, pid, uid);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkPermission(String, int, int)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .checkPermission(this, (String) args[0], (int) args[1], (int) args[2]);
+                } else {
+                    return getOriginal()
+                            .super_checkPermission((String) args[0], (int) args[1], (int) args[2]);
+                }
+            }
+        };
+        return superCall.call(permission, pid, uid);
     }
 
     public int checkSelfPermission(final String permission) {
-        return callFunction("checkSelfPermission(String)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_checkSelfPermission(permission);
+        }
 
-                        return plugin.checkSelfPermission(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_checkSelfPermission((String) args[0]);
-                    }
-                }, permission);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkSelfPermission(String)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().checkSelfPermission(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_checkSelfPermission((String) args[0]);
+                }
+            }
+        };
+        return superCall.call(permission);
     }
 
     public int checkUriPermission(final Uri uri, final int pid, final int uid,
             final int modeFlags) {
-        return callFunction("checkUriPermission(Uri, int, int, int)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_checkUriPermission(uri, pid, uid, modeFlags);
+        }
 
-                        return plugin.checkUriPermission(superCall, (Uri) args[0], (int) args[1],
-                                (int) args[2], (int) args[3]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_checkUriPermission((Uri) args[0], (int) args[1],
-                                (int) args[2], (int) args[3]);
-                    }
-                }, uri, pid, uid, modeFlags);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkUriPermission(Uri, int, int, int)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .checkUriPermission(this, (Uri) args[0], (int) args[1], (int) args[2],
+                                    (int) args[3]);
+                } else {
+                    return getOriginal()
+                            .super_checkUriPermission((Uri) args[0], (int) args[1], (int) args[2],
+                                    (int) args[3]);
+                }
+            }
+        };
+        return superCall.call(uri, pid, uid, modeFlags);
     }
 
     public int checkUriPermission(final Uri uri, final String readPermission,
             final String writePermission, final int pid, final int uid, final int modeFlags) {
-        return callFunction("checkUriPermission(Uri, String, String, int, int, int)",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal()
+                    .super_checkUriPermission(uri, readPermission, writePermission, pid, uid,
+                            modeFlags);
+        }
 
-                        return plugin.checkUriPermission(superCall, (Uri) args[0], (String) args[1],
-                                (String) args[2], (int) args[3], (int) args[4], (int) args[5]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal()
-                                .super_checkUriPermission((Uri) args[0], (String) args[1],
-                                        (String) args[2], (int) args[3], (int) args[4],
-                                        (int) args[5]);
-                    }
-                }, uri, readPermission, writePermission, pid, uid, modeFlags);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "checkUriPermission(Uri, String, String, int, int, int)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .checkUriPermission(this, (Uri) args[0], (String) args[1],
+                                    (String) args[2], (int) args[3], (int) args[4], (int) args[5]);
+                } else {
+                    return getOriginal().super_checkUriPermission((Uri) args[0], (String) args[1],
+                            (String) args[2], (int) args[3], (int) args[4], (int) args[5]);
+                }
+            }
+        };
+        return superCall.call(uri, readPermission, writePermission, pid, uid, modeFlags);
     }
 
     public void clearWallpaper() throws IOException {
-        callHook("clearWallpaper()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal().super_clearWallpaper();
+            } catch (IOException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("clearWallpaper()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                try {
-                    plugin.clearWallpaper(superCall);
-                } catch (IOException e) {
-                    throw new SuppressedException(e);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous().clearWallpaper(this);
+                        return null;
+                    } catch (IOException e) {
+                        throw new SuppressedException(e);
+                    }
+                } else {
+                    try {
+                        getOriginal().super_clearWallpaper();
+                        return null;
+                    } catch (IOException e) {
+                        throw new SuppressedException(e);
+                    }
                 }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                try {
-                    getOriginal().super_clearWallpaper();
-                } catch (IOException e) {
-                    throw new SuppressedException(e);
-                }
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void closeContextMenu() {
-        callHook("closeContextMenu()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_closeContextMenu();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("closeContextMenu()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.closeContextMenu(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().closeContextMenu(this);
+                    return null;
+                } else {
+                    getOriginal().super_closeContextMenu();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_closeContextMenu();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void closeOptionsMenu() {
-        callHook("closeOptionsMenu()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_closeOptionsMenu();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("closeOptionsMenu()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.closeOptionsMenu(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().closeOptionsMenu(this);
+                    return null;
+                } else {
+                    getOriginal().super_closeOptionsMenu();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_closeOptionsMenu();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public Context createConfigurationContext(final Configuration overrideConfiguration) {
-        return callFunction("createConfigurationContext(Configuration)",
-                new PluginCall<ActivityPlugin, Context>() {
-                    @Override
-                    public Context call(final NamedSuperCall<Context> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_createConfigurationContext(overrideConfiguration);
+        }
 
-                        return plugin
-                                .createConfigurationContext(superCall, (Configuration) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Context>() {
-                    @Override
-                    public Context call(final Object... args) {
-                        return getOriginal()
-                                .super_createConfigurationContext((Configuration) args[0]);
-                    }
-                }, overrideConfiguration);
+        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
+                "createConfigurationContext(Configuration)") {
+
+            @Override
+            public Context call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .createConfigurationContext(this, (Configuration) args[0]);
+                } else {
+                    return getOriginal().super_createConfigurationContext((Configuration) args[0]);
+                }
+            }
+        };
+        return superCall.call(overrideConfiguration);
     }
 
     public Context createDisplayContext(final Display display) {
-        return callFunction("createDisplayContext(Display)",
-                new PluginCall<ActivityPlugin, Context>() {
-                    @Override
-                    public Context call(final NamedSuperCall<Context> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_createDisplayContext(display);
+        }
 
-                        return plugin.createDisplayContext(superCall, (Display) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Context>() {
-                    @Override
-                    public Context call(final Object... args) {
-                        return getOriginal().super_createDisplayContext((Display) args[0]);
-                    }
-                }, display);
+        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
+                "createDisplayContext(Display)") {
+
+            @Override
+            public Context call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().createDisplayContext(this, (Display) args[0]);
+                } else {
+                    return getOriginal().super_createDisplayContext((Display) args[0]);
+                }
+            }
+        };
+        return superCall.call(display);
     }
 
-    public Context createPackageContext(final String packageName, final int flags) {
-        return callFunction("createPackageContext(String, int)",
-                new PluginCall<ActivityPlugin, Context>() {
-                    @Override
-                    public Context call(final NamedSuperCall<Context> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            return plugin.createPackageContext(superCall, (String) args[0],
-                                    (int) args[1]);
-                        } catch (PackageManager.NameNotFoundException e) {
-                            throw new SuppressedException(e);
-                        }
+    public Context createPackageContext(final String packageName, final int flags)
+            throws PackageManager.NameNotFoundException {
+        if (mPlugins.isEmpty()) {
+            try {
+                return getOriginal().super_createPackageContext(packageName, flags);
+            } catch (PackageManager.NameNotFoundException e) {
+                throw new SuppressedException(e);
+            }
+        }
 
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
+                "createPackageContext(String, int)") {
+
+            @Override
+            public Context call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        return iterator.previous()
+                                .createPackageContext(this, (String) args[0], (int) args[1]);
+                    } catch (PackageManager.NameNotFoundException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCall<Context>() {
-                    @Override
-                    public Context call(final Object... args) {
-                        try {
-                            return getOriginal()
-                                    .super_createPackageContext((String) args[0], (int) args[1]);
-                        } catch (PackageManager.NameNotFoundException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        return getOriginal()
+                                .super_createPackageContext((String) args[0], (int) args[1]);
+                    } catch (PackageManager.NameNotFoundException e) {
+                        throw new SuppressedException(e);
                     }
-                }, packageName, flags);
+                }
+            }
+        };
+        return superCall.call(packageName, flags);
     }
 
     public PendingIntent createPendingResult(final int requestCode, final Intent data,
             final int flags) {
-        return callFunction("createPendingResult(int, Intent, int)",
-                new PluginCall<ActivityPlugin, PendingIntent>() {
-                    @Override
-                    public PendingIntent call(final NamedSuperCall<PendingIntent> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_createPendingResult(requestCode, data, flags);
+        }
 
-                        return plugin
-                                .createPendingResult(superCall, (int) args[0], (Intent) args[1],
-                                        (int) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<PendingIntent>() {
-                    @Override
-                    public PendingIntent call(final Object... args) {
-                        return getOriginal()
-                                .super_createPendingResult((int) args[0], (Intent) args[1],
-                                        (int) args[2]);
-                    }
-                }, requestCode, data, flags);
+        final NamedSuperCall<PendingIntent> superCall = new NamedSuperCall<PendingIntent>(
+                "createPendingResult(int, Intent, int)") {
+
+            @Override
+            public PendingIntent call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .createPendingResult(this, (int) args[0], (Intent) args[1],
+                                    (int) args[2]);
+                } else {
+                    return getOriginal().super_createPendingResult((int) args[0], (Intent) args[1],
+                            (int) args[2]);
+                }
+            }
+        };
+        return superCall.call(requestCode, data, flags);
     }
 
     public String[] databaseList() {
-        return callFunction("databaseList()", new PluginCall<ActivityPlugin, String[]>() {
-            @Override
-            public String[] call(final NamedSuperCall<String[]> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_databaseList();
+        }
 
-                return plugin.databaseList(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String[]>() {
+        final NamedSuperCall<String[]> superCall = new NamedSuperCall<String[]>("databaseList()") {
+
             @Override
             public String[] call(final Object... args) {
-                return getOriginal().super_databaseList();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().databaseList(this);
+                } else {
+                    return getOriginal().super_databaseList();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean deleteDatabase(final String name) {
-        return callFunction("deleteDatabase(String)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_deleteDatabase(name);
+        }
 
-                return plugin.deleteDatabase(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "deleteDatabase(String)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_deleteDatabase((String) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().deleteDatabase(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_deleteDatabase((String) args[0]);
+                }
             }
-        }, name);
+        };
+        return superCall.call(name);
     }
 
     public boolean deleteFile(final String name) {
-        return callFunction("deleteFile(String)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_deleteFile(name);
+        }
 
-                return plugin.deleteFile(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "deleteFile(String)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_deleteFile((String) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().deleteFile(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_deleteFile((String) args[0]);
+                }
             }
-        }, name);
+        };
+        return superCall.call(name);
     }
 
     public boolean dispatchGenericMotionEvent(final MotionEvent ev) {
-        return callFunction("dispatchGenericMotionEvent(MotionEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_dispatchGenericMotionEvent(ev);
+        }
 
-                        return plugin.dispatchGenericMotionEvent(superCall, (MotionEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_dispatchGenericMotionEvent((MotionEvent) args[0]);
-                    }
-                }, ev);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "dispatchGenericMotionEvent(MotionEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .dispatchGenericMotionEvent(this, (MotionEvent) args[0]);
+                } else {
+                    return getOriginal().super_dispatchGenericMotionEvent((MotionEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(ev);
     }
 
     public boolean dispatchKeyEvent(final KeyEvent event) {
-        return callFunction("dispatchKeyEvent(KeyEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_dispatchKeyEvent(event);
+        }
 
-                        return plugin.dispatchKeyEvent(superCall, (KeyEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_dispatchKeyEvent((KeyEvent) args[0]);
-                    }
-                }, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "dispatchKeyEvent(KeyEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().dispatchKeyEvent(this, (KeyEvent) args[0]);
+                } else {
+                    return getOriginal().super_dispatchKeyEvent((KeyEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(event);
     }
 
     public boolean dispatchKeyShortcutEvent(final KeyEvent event) {
-        return callFunction("dispatchKeyShortcutEvent(KeyEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_dispatchKeyShortcutEvent(event);
+        }
 
-                        return plugin.dispatchKeyShortcutEvent(superCall, (KeyEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_dispatchKeyShortcutEvent((KeyEvent) args[0]);
-                    }
-                }, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "dispatchKeyShortcutEvent(KeyEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().dispatchKeyShortcutEvent(this, (KeyEvent) args[0]);
+                } else {
+                    return getOriginal().super_dispatchKeyShortcutEvent((KeyEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(event);
     }
 
     public boolean dispatchPopulateAccessibilityEvent(final AccessibilityEvent event) {
-        return callFunction("dispatchPopulateAccessibilityEvent(AccessibilityEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_dispatchPopulateAccessibilityEvent(event);
+        }
 
-                        return plugin.dispatchPopulateAccessibilityEvent(superCall,
-                                (AccessibilityEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_dispatchPopulateAccessibilityEvent(
-                                (AccessibilityEvent) args[0]);
-                    }
-                }, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "dispatchPopulateAccessibilityEvent(AccessibilityEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .dispatchPopulateAccessibilityEvent(this, (AccessibilityEvent) args[0]);
+                } else {
+                    return getOriginal()
+                            .super_dispatchPopulateAccessibilityEvent((AccessibilityEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(event);
     }
 
     public boolean dispatchTouchEvent(final MotionEvent ev) {
-        return callFunction("dispatchTouchEvent(MotionEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_dispatchTouchEvent(ev);
+        }
 
-                        return plugin.dispatchTouchEvent(superCall, (MotionEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_dispatchTouchEvent((MotionEvent) args[0]);
-                    }
-                }, ev);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "dispatchTouchEvent(MotionEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().dispatchTouchEvent(this, (MotionEvent) args[0]);
+                } else {
+                    return getOriginal().super_dispatchTouchEvent((MotionEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(ev);
     }
 
     public boolean dispatchTrackballEvent(final MotionEvent ev) {
-        return callFunction("dispatchTrackballEvent(MotionEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_dispatchTrackballEvent(ev);
+        }
 
-                        return plugin.dispatchTrackballEvent(superCall, (MotionEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_dispatchTrackballEvent((MotionEvent) args[0]);
-                    }
-                }, ev);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "dispatchTrackballEvent(MotionEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().dispatchTrackballEvent(this, (MotionEvent) args[0]);
+                } else {
+                    return getOriginal().super_dispatchTrackballEvent((MotionEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(ev);
     }
 
     public void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args) {
-        callHook("dump(String, FileDescriptor, PrintWriter, String[])",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.dump(superCall, (String) args[0], (FileDescriptor) args[1],
-                                (PrintWriter) args[2], (String[]) args[3]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
-                                (PrintWriter) args[2], (String[]) args[3]);
-                    }
-                }, prefix, fd, writer, args);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_dump(prefix, fd, writer, args);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "dump(String, FileDescriptor, PrintWriter, String[])") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().dump(this, (String) args[0], (FileDescriptor) args[1],
+                            (PrintWriter) args[2], (String[]) args[3]);
+                    return null;
+                } else {
+                    getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
+                            (PrintWriter) args[2], (String[]) args[3]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(prefix, fd, writer, args);
     }
 
     public void enforceCallingOrSelfPermission(final String permission, final String message) {
-        callHook("enforceCallingOrSelfPermission(String, String)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.enforceCallingOrSelfPermission(superCall, (String) args[0],
-                                (String) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_enforceCallingOrSelfPermission((String) args[0],
-                                (String) args[1]);
-                    }
-                }, permission, message);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_enforceCallingOrSelfPermission(permission, message);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "enforceCallingOrSelfPermission(String, String)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().enforceCallingOrSelfPermission(this, (String) args[0],
+                            (String) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_enforceCallingOrSelfPermission((String) args[0],
+                            (String) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(permission, message);
     }
 
     public void enforceCallingOrSelfUriPermission(final Uri uri, final int modeFlags,
             final String message) {
-        callHook("enforceCallingOrSelfUriPermission(Uri, int, String)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.enforceCallingOrSelfUriPermission(superCall, (Uri) args[0],
-                                (int) args[1], (String) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_enforceCallingOrSelfUriPermission((Uri) args[0],
-                                (int) args[1], (String) args[2]);
-                    }
-                }, uri, modeFlags, message);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_enforceCallingOrSelfUriPermission(uri, modeFlags, message);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "enforceCallingOrSelfUriPermission(Uri, int, String)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .enforceCallingOrSelfUriPermission(this, (Uri) args[0], (int) args[1],
+                                    (String) args[2]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_enforceCallingOrSelfUriPermission((Uri) args[0], (int) args[1],
+                                    (String) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(uri, modeFlags, message);
     }
 
     public void enforceCallingPermission(final String permission, final String message) {
-        callHook("enforceCallingPermission(String, String)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_enforceCallingPermission(permission, message);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "enforceCallingPermission(String, String)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.enforceCallingPermission(superCall, (String) args[0], (String) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .enforceCallingPermission(this, (String) args[0], (String) args[1]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_enforceCallingPermission((String) args[0], (String) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_enforceCallingPermission((String) args[0], (String) args[1]);
-            }
-        }, permission, message);
+        };
+        superCall.call(permission, message);
     }
 
     public void enforceCallingUriPermission(final Uri uri, final int modeFlags,
             final String message) {
-        callHook("enforceCallingUriPermission(Uri, int, String)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.enforceCallingUriPermission(superCall, (Uri) args[0], (int) args[1],
-                                (String) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_enforceCallingUriPermission((Uri) args[0], (int) args[1],
-                                        (String) args[2]);
-                    }
-                }, uri, modeFlags, message);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_enforceCallingUriPermission(uri, modeFlags, message);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "enforceCallingUriPermission(Uri, int, String)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .enforceCallingUriPermission(this, (Uri) args[0], (int) args[1],
+                                    (String) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_enforceCallingUriPermission((Uri) args[0], (int) args[1],
+                            (String) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(uri, modeFlags, message);
     }
 
     public void enforcePermission(final String permission, final int pid, final int uid,
             final String message) {
-        callHook("enforcePermission(String, int, int, String)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.enforcePermission(superCall, (String) args[0], (int) args[1],
-                                (int) args[2], (String) args[3]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_enforcePermission((String) args[0], (int) args[1],
-                                (int) args[2], (String) args[3]);
-                    }
-                }, permission, pid, uid, message);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_enforcePermission(permission, pid, uid, message);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "enforcePermission(String, int, int, String)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .enforcePermission(this, (String) args[0], (int) args[1], (int) args[2],
+                                    (String) args[3]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_enforcePermission((String) args[0], (int) args[1], (int) args[2],
+                                    (String) args[3]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(permission, pid, uid, message);
     }
 
     public void enforceUriPermission(final Uri uri, final int pid, final int uid,
             final int modeFlags, final String message) {
-        callHook("enforceUriPermission(Uri, int, int, int, String)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.enforceUriPermission(superCall, (Uri) args[0], (int) args[1],
-                                (int) args[2], (int) args[3], (String) args[4]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_enforceUriPermission((Uri) args[0], (int) args[1],
-                                (int) args[2], (int) args[3], (String) args[4]);
-                    }
-                }, uri, pid, uid, modeFlags, message);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_enforceUriPermission(uri, pid, uid, modeFlags, message);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "enforceUriPermission(Uri, int, int, int, String)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .enforceUriPermission(this, (Uri) args[0], (int) args[1], (int) args[2],
+                                    (int) args[3], (String) args[4]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_enforceUriPermission((Uri) args[0], (int) args[1], (int) args[2],
+                                    (int) args[3], (String) args[4]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(uri, pid, uid, modeFlags, message);
     }
 
     public void enforceUriPermission(final Uri uri, final String readPermission,
             final String writePermission, final int pid, final int uid, final int modeFlags,
             final String message) {
-        callHook("enforceUriPermission(Uri, String, String, int, int, int, String)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.enforceUriPermission(superCall, (Uri) args[0], (String) args[1],
-                                (String) args[2], (int) args[3], (int) args[4], (int) args[5],
-                                (String) args[6]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_enforceUriPermission((Uri) args[0], (String) args[1],
-                                (String) args[2], (int) args[3], (int) args[4], (int) args[5],
-                                (String) args[6]);
-                    }
-                }, uri, readPermission, writePermission, pid, uid, modeFlags, message);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_enforceUriPermission(uri, readPermission, writePermission, pid, uid,
+                    modeFlags, message);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "enforceUriPermission(Uri, String, String, int, int, int, String)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().enforceUriPermission(this, (Uri) args[0], (String) args[1],
+                            (String) args[2], (int) args[3], (int) args[4], (int) args[5],
+                            (String) args[6]);
+                    return null;
+                } else {
+                    getOriginal().super_enforceUriPermission((Uri) args[0], (String) args[1],
+                            (String) args[2], (int) args[3], (int) args[4], (int) args[5],
+                            (String) args[6]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(uri, readPermission, writePermission, pid, uid, modeFlags, message);
     }
 
     public String[] fileList() {
-        return callFunction("fileList()", new PluginCall<ActivityPlugin, String[]>() {
-            @Override
-            public String[] call(final NamedSuperCall<String[]> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_fileList();
+        }
 
-                return plugin.fileList(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String[]>() {
+        final NamedSuperCall<String[]> superCall = new NamedSuperCall<String[]>("fileList()") {
+
             @Override
             public String[] call(final Object... args) {
-                return getOriginal().super_fileList();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().fileList(this);
+                } else {
+                    return getOriginal().super_fileList();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public View findViewById(@IdRes final int id) {
-        return callFunction("findViewById(int)", new PluginCall<ActivityPlugin, View>() {
-            @Override
-            public View call(final NamedSuperCall<View> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_findViewById(id);
+        }
 
-                return plugin.findViewById(superCall, (int) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<View>() {
+        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("findViewById(int)") {
+
             @Override
             public View call(final Object... args) {
-                return getOriginal().super_findViewById((int) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().findViewById(this, (int) args[0]);
+                } else {
+                    return getOriginal().super_findViewById((int) args[0]);
+                }
             }
-        }, id);
+        };
+        return superCall.call(id);
     }
 
     public void finish() {
-        callHook("finish()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_finish();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finish()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.finish(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().finish(this);
+                    return null;
+                } else {
+                    getOriginal().super_finish();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_finish();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void finishActivity(final int requestCode) {
-        callHook("finishActivity(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_finishActivity(requestCode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishActivity(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.finishActivity(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().finishActivity(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_finishActivity((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_finishActivity((int) args[0]);
-            }
-        }, requestCode);
+        };
+        superCall.call(requestCode);
     }
 
     public void finishActivityFromChild(final Activity child, final int requestCode) {
-        callHook("finishActivityFromChild(Activity, int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_finishActivityFromChild(child, requestCode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "finishActivityFromChild(Activity, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.finishActivityFromChild(superCall, (Activity) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .finishActivityFromChild(this, (Activity) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_finishActivityFromChild((Activity) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_finishActivityFromChild((Activity) args[0], (int) args[1]);
-            }
-        }, child, requestCode);
+        };
+        superCall.call(child, requestCode);
     }
 
     public void finishAffinity() {
-        callHook("finishAffinity()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_finishAffinity();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishAffinity()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.finishAffinity(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().finishAffinity(this);
+                    return null;
+                } else {
+                    getOriginal().super_finishAffinity();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_finishAffinity();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void finishAfterTransition() {
-        callHook("finishAfterTransition()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_finishAfterTransition();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishAfterTransition()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.finishAfterTransition(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().finishAfterTransition(this);
+                    return null;
+                } else {
+                    getOriginal().super_finishAfterTransition();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_finishAfterTransition();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void finishAndRemoveTask() {
-        callHook("finishAndRemoveTask()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_finishAndRemoveTask();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishAndRemoveTask()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.finishAndRemoveTask(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().finishAndRemoveTask(this);
+                    return null;
+                } else {
+                    getOriginal().super_finishAndRemoveTask();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_finishAndRemoveTask();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void finishFromChild(final Activity child) {
-        callHook("finishFromChild(Activity)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_finishFromChild(child);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "finishFromChild(Activity)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.finishFromChild(superCall, (Activity) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().finishFromChild(this, (Activity) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_finishFromChild((Activity) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_finishFromChild((Activity) args[0]);
-            }
-        }, child);
+        };
+        superCall.call(child);
     }
 
     public android.app.ActionBar getActionBar() {
-        return callFunction("getActionBar()",
-                new PluginCall<ActivityPlugin, android.app.ActionBar>() {
-                    @Override
-                    public android.app.ActionBar call(
-                            final NamedSuperCall<android.app.ActionBar> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getActionBar();
+        }
 
-                        return plugin.getActionBar(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<android.app.ActionBar>() {
-                    @Override
-                    public android.app.ActionBar call(final Object... args) {
-                        return getOriginal().super_getActionBar();
-                    }
-                });
+        final NamedSuperCall<android.app.ActionBar> superCall
+                = new NamedSuperCall<android.app.ActionBar>("getActionBar()") {
+
+            @Override
+            public android.app.ActionBar call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getActionBar(this);
+                } else {
+                    return getOriginal().super_getActionBar();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Context getApplicationContext() {
-        return callFunction("getApplicationContext()", new PluginCall<ActivityPlugin, Context>() {
-            @Override
-            public Context call(final NamedSuperCall<Context> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getApplicationContext();
+        }
 
-                return plugin.getApplicationContext(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Context>() {
+        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
+                "getApplicationContext()") {
+
             @Override
             public Context call(final Object... args) {
-                return getOriginal().super_getApplicationContext();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getApplicationContext(this);
+                } else {
+                    return getOriginal().super_getApplicationContext();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public ApplicationInfo getApplicationInfo() {
-        return callFunction("getApplicationInfo()",
-                new PluginCall<ActivityPlugin, ApplicationInfo>() {
-                    @Override
-                    public ApplicationInfo call(final NamedSuperCall<ApplicationInfo> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getApplicationInfo();
+        }
 
-                        return plugin.getApplicationInfo(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<ApplicationInfo>() {
-                    @Override
-                    public ApplicationInfo call(final Object... args) {
-                        return getOriginal().super_getApplicationInfo();
-                    }
-                });
+        final NamedSuperCall<ApplicationInfo> superCall = new NamedSuperCall<ApplicationInfo>(
+                "getApplicationInfo()") {
+
+            @Override
+            public ApplicationInfo call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getApplicationInfo(this);
+                } else {
+                    return getOriginal().super_getApplicationInfo();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public AssetManager getAssets() {
-        return callFunction("getAssets()", new PluginCall<ActivityPlugin, AssetManager>() {
-            @Override
-            public AssetManager call(final NamedSuperCall<AssetManager> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getAssets();
+        }
 
-                return plugin.getAssets(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<AssetManager>() {
+        final NamedSuperCall<AssetManager> superCall = new NamedSuperCall<AssetManager>(
+                "getAssets()") {
+
             @Override
             public AssetManager call(final Object... args) {
-                return getOriginal().super_getAssets();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getAssets(this);
+                } else {
+                    return getOriginal().super_getAssets();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public Context getBaseContext() {
-        return callFunction("getBaseContext()", new PluginCall<ActivityPlugin, Context>() {
-            @Override
-            public Context call(final NamedSuperCall<Context> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getBaseContext();
+        }
 
-                return plugin.getBaseContext(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Context>() {
+        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>("getBaseContext()") {
+
             @Override
             public Context call(final Object... args) {
-                return getOriginal().super_getBaseContext();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getBaseContext(this);
+                } else {
+                    return getOriginal().super_getBaseContext();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File getCacheDir() {
-        return callFunction("getCacheDir()", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getCacheDir();
+        }
 
-                return plugin.getCacheDir(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getCacheDir()") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getCacheDir();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getCacheDir(this);
+                } else {
+                    return getOriginal().super_getCacheDir();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public ComponentName getCallingActivity() {
-        return callFunction("getCallingActivity()",
-                new PluginCall<ActivityPlugin, ComponentName>() {
-                    @Override
-                    public ComponentName call(final NamedSuperCall<ComponentName> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getCallingActivity();
+        }
 
-                        return plugin.getCallingActivity(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<ComponentName>() {
-                    @Override
-                    public ComponentName call(final Object... args) {
-                        return getOriginal().super_getCallingActivity();
-                    }
-                });
+        final NamedSuperCall<ComponentName> superCall = new NamedSuperCall<ComponentName>(
+                "getCallingActivity()") {
+
+            @Override
+            public ComponentName call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getCallingActivity(this);
+                } else {
+                    return getOriginal().super_getCallingActivity();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public String getCallingPackage() {
-        return callFunction("getCallingPackage()", new PluginCall<ActivityPlugin, String>() {
-            @Override
-            public String call(final NamedSuperCall<String> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getCallingPackage();
+        }
 
-                return plugin.getCallingPackage(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String>() {
+        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("getCallingPackage()") {
+
             @Override
             public String call(final Object... args) {
-                return getOriginal().super_getCallingPackage();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getCallingPackage(this);
+                } else {
+                    return getOriginal().super_getCallingPackage();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public int getChangingConfigurations() {
-        return callFunction("getChangingConfigurations()",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getChangingConfigurations();
+        }
 
-                        return plugin.getChangingConfigurations(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_getChangingConfigurations();
-                    }
-                });
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "getChangingConfigurations()") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getChangingConfigurations(this);
+                } else {
+                    return getOriginal().super_getChangingConfigurations();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public ClassLoader getClassLoader() {
-        return callFunction("getClassLoader()", new PluginCall<ActivityPlugin, ClassLoader>() {
-            @Override
-            public ClassLoader call(final NamedSuperCall<ClassLoader> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getClassLoader();
+        }
 
-                return plugin.getClassLoader(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<ClassLoader>() {
+        final NamedSuperCall<ClassLoader> superCall = new NamedSuperCall<ClassLoader>(
+                "getClassLoader()") {
+
             @Override
             public ClassLoader call(final Object... args) {
-                return getOriginal().super_getClassLoader();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getClassLoader(this);
+                } else {
+                    return getOriginal().super_getClassLoader();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File getCodeCacheDir() {
-        return callFunction("getCodeCacheDir()", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getCodeCacheDir();
+        }
 
-                return plugin.getCodeCacheDir(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getCodeCacheDir()") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getCodeCacheDir();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getCodeCacheDir(this);
+                } else {
+                    return getOriginal().super_getCodeCacheDir();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public ComponentName getComponentName() {
-        return callFunction("getComponentName()", new PluginCall<ActivityPlugin, ComponentName>() {
-            @Override
-            public ComponentName call(final NamedSuperCall<ComponentName> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getComponentName();
+        }
 
-                return plugin.getComponentName(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<ComponentName>() {
+        final NamedSuperCall<ComponentName> superCall = new NamedSuperCall<ComponentName>(
+                "getComponentName()") {
+
             @Override
             public ComponentName call(final Object... args) {
-                return getOriginal().super_getComponentName();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getComponentName(this);
+                } else {
+                    return getOriginal().super_getComponentName();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public ContentResolver getContentResolver() {
-        return callFunction("getContentResolver()",
-                new PluginCall<ActivityPlugin, ContentResolver>() {
-                    @Override
-                    public ContentResolver call(final NamedSuperCall<ContentResolver> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getContentResolver();
+        }
 
-                        return plugin.getContentResolver(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<ContentResolver>() {
-                    @Override
-                    public ContentResolver call(final Object... args) {
-                        return getOriginal().super_getContentResolver();
-                    }
-                });
+        final NamedSuperCall<ContentResolver> superCall = new NamedSuperCall<ContentResolver>(
+                "getContentResolver()") {
+
+            @Override
+            public ContentResolver call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getContentResolver(this);
+                } else {
+                    return getOriginal().super_getContentResolver();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Scene getContentScene() {
-        return callFunction("getContentScene()", new PluginCall<ActivityPlugin, Scene>() {
-            @Override
-            public Scene call(final NamedSuperCall<Scene> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getContentScene();
+        }
 
-                return plugin.getContentScene(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Scene>() {
+        final NamedSuperCall<Scene> superCall = new NamedSuperCall<Scene>("getContentScene()") {
+
             @Override
             public Scene call(final Object... args) {
-                return getOriginal().super_getContentScene();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getContentScene(this);
+                } else {
+                    return getOriginal().super_getContentScene();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public TransitionManager getContentTransitionManager() {
-        return callFunction("getContentTransitionManager()",
-                new PluginCall<ActivityPlugin, TransitionManager>() {
-                    @Override
-                    public TransitionManager call(final NamedSuperCall<TransitionManager> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getContentTransitionManager();
+        }
 
-                        return plugin.getContentTransitionManager(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<TransitionManager>() {
-                    @Override
-                    public TransitionManager call(final Object... args) {
-                        return getOriginal().super_getContentTransitionManager();
-                    }
-                });
+        final NamedSuperCall<TransitionManager> superCall = new NamedSuperCall<TransitionManager>(
+                "getContentTransitionManager()") {
+
+            @Override
+            public TransitionManager call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getContentTransitionManager(this);
+                } else {
+                    return getOriginal().super_getContentTransitionManager();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public View getCurrentFocus() {
-        return callFunction("getCurrentFocus()", new PluginCall<ActivityPlugin, View>() {
-            @Override
-            public View call(final NamedSuperCall<View> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getCurrentFocus();
+        }
 
-                return plugin.getCurrentFocus(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<View>() {
+        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("getCurrentFocus()") {
+
             @Override
             public View call(final Object... args) {
-                return getOriginal().super_getCurrentFocus();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getCurrentFocus(this);
+                } else {
+                    return getOriginal().super_getCurrentFocus();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File getDatabasePath(final String name) {
-        return callFunction("getDatabasePath(String)", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getDatabasePath(name);
+        }
 
-                return plugin.getDatabasePath(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getDatabasePath(String)") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getDatabasePath((String) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getDatabasePath(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_getDatabasePath((String) args[0]);
+                }
             }
-        }, name);
+        };
+        return superCall.call(name);
     }
 
-    final PluginCall<ActivityPlugin, AppCompatDelegate> fiudsojf
-            = new PluginCall<ActivityPlugin, AppCompatDelegate>() {
-        @Override
-        public AppCompatDelegate call(final NamedSuperCall<AppCompatDelegate> superCall,
-                final ActivityPlugin plugin, final Object... args) {
-
-            return plugin.getDelegate(superCall);
-
-        }
-    };
-    final SuperCall<AppCompatDelegate> diso = new SuperCall<AppCompatDelegate>() {
-        @Override
-        public AppCompatDelegate call(final Object... args) {
+    public AppCompatDelegate getDelegate() {
+        if (mPlugins.isEmpty()) {
             return getOriginal().super_getDelegate();
         }
-    };
 
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-    public AppCompatDelegate getDelegate() {
-        return callFunction("getDelegate()", fiudsojf, diso);
+        final NamedSuperCall<AppCompatDelegate> superCall = new NamedSuperCall<AppCompatDelegate>(
+                "getDelegate()") {
+
+            @Override
+            public AppCompatDelegate call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getDelegate(this);
+                } else {
+                    return getOriginal().super_getDelegate();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public File getDir(final String name, final int mode) {
-        return callFunction("getDir(String, int)", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getDir(name, mode);
+        }
 
-                return plugin.getDir(superCall, (String) args[0], (int) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getDir(String, int)") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getDir((String) args[0], (int) args[1]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getDir(this, (String) args[0], (int) args[1]);
+                } else {
+                    return getOriginal().super_getDir((String) args[0], (int) args[1]);
+                }
             }
-        }, name, mode);
+        };
+        return superCall.call(name, mode);
     }
 
     public ActionBarDrawerToggle.Delegate getDrawerToggleDelegate() {
-        return callFunction("getDrawerToggleDelegate()",
-                new PluginCall<ActivityPlugin, ActionBarDrawerToggle.Delegate>() {
-                    @Override
-                    public ActionBarDrawerToggle.Delegate call(
-                            final NamedSuperCall<ActionBarDrawerToggle.Delegate> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getDrawerToggleDelegate();
+        }
 
-                        return plugin.getDrawerToggleDelegate(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<ActionBarDrawerToggle.Delegate>() {
-                    @Override
-                    public ActionBarDrawerToggle.Delegate call(final Object... args) {
-                        return getOriginal().super_getDrawerToggleDelegate();
-                    }
-                });
+        final NamedSuperCall<ActionBarDrawerToggle.Delegate> superCall
+                = new NamedSuperCall<ActionBarDrawerToggle.Delegate>("getDrawerToggleDelegate()") {
+
+            @Override
+            public ActionBarDrawerToggle.Delegate call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getDrawerToggleDelegate(this);
+                } else {
+                    return getOriginal().super_getDrawerToggleDelegate();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public File getExternalCacheDir() {
-        return callFunction("getExternalCacheDir()", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getExternalCacheDir();
+        }
 
-                return plugin.getExternalCacheDir(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getExternalCacheDir()") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getExternalCacheDir();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getExternalCacheDir(this);
+                } else {
+                    return getOriginal().super_getExternalCacheDir();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File[] getExternalCacheDirs() {
-        return callFunction("getExternalCacheDirs()", new PluginCall<ActivityPlugin, File[]>() {
-            @Override
-            public File[] call(final NamedSuperCall<File[]> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getExternalCacheDirs();
+        }
 
-                return plugin.getExternalCacheDirs(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File[]>() {
+        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>(
+                "getExternalCacheDirs()") {
+
             @Override
             public File[] call(final Object... args) {
-                return getOriginal().super_getExternalCacheDirs();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getExternalCacheDirs(this);
+                } else {
+                    return getOriginal().super_getExternalCacheDirs();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File getExternalFilesDir(final String type) {
-        return callFunction("getExternalFilesDir(String)", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getExternalFilesDir(type);
+        }
 
-                return plugin.getExternalFilesDir(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>(
+                "getExternalFilesDir(String)") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getExternalFilesDir((String) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getExternalFilesDir(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_getExternalFilesDir((String) args[0]);
+                }
             }
-        }, type);
+        };
+        return superCall.call(type);
     }
 
     public File[] getExternalFilesDirs(final String type) {
-        return callFunction("getExternalFilesDirs(String)",
-                new PluginCall<ActivityPlugin, File[]>() {
-                    @Override
-                    public File[] call(final NamedSuperCall<File[]> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getExternalFilesDirs(type);
+        }
 
-                        return plugin.getExternalFilesDirs(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<File[]>() {
-                    @Override
-                    public File[] call(final Object... args) {
-                        return getOriginal().super_getExternalFilesDirs((String) args[0]);
-                    }
-                }, type);
+        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>(
+                "getExternalFilesDirs(String)") {
+
+            @Override
+            public File[] call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getExternalFilesDirs(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_getExternalFilesDirs((String) args[0]);
+                }
+            }
+        };
+        return superCall.call(type);
     }
 
     public File[] getExternalMediaDirs() {
-        return callFunction("getExternalMediaDirs()", new PluginCall<ActivityPlugin, File[]>() {
-            @Override
-            public File[] call(final NamedSuperCall<File[]> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getExternalMediaDirs();
+        }
 
-                return plugin.getExternalMediaDirs(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File[]>() {
+        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>(
+                "getExternalMediaDirs()") {
+
             @Override
             public File[] call(final Object... args) {
-                return getOriginal().super_getExternalMediaDirs();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getExternalMediaDirs(this);
+                } else {
+                    return getOriginal().super_getExternalMediaDirs();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File getFileStreamPath(final String name) {
-        return callFunction("getFileStreamPath(String)", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getFileStreamPath(name);
+        }
 
-                return plugin.getFileStreamPath(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>(
+                "getFileStreamPath(String)") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getFileStreamPath((String) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getFileStreamPath(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_getFileStreamPath((String) args[0]);
+                }
             }
-        }, name);
+        };
+        return superCall.call(name);
     }
 
     public File getFilesDir() {
-        return callFunction("getFilesDir()", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getFilesDir();
+        }
 
-                return plugin.getFilesDir(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getFilesDir()") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getFilesDir();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getFilesDir(this);
+                } else {
+                    return getOriginal().super_getFilesDir();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public android.app.FragmentManager getFragmentManager() {
-        return callFunction("getFragmentManager()",
-                new PluginCall<ActivityPlugin, android.app.FragmentManager>() {
-                    @Override
-                    public android.app.FragmentManager call(
-                            final NamedSuperCall<android.app.FragmentManager> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getFragmentManager();
+        }
 
-                        return plugin.getFragmentManager(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<android.app.FragmentManager>() {
-                    @Override
-                    public android.app.FragmentManager call(final Object... args) {
-                        return getOriginal().super_getFragmentManager();
-                    }
-                });
+        final NamedSuperCall<android.app.FragmentManager> superCall
+                = new NamedSuperCall<android.app.FragmentManager>("getFragmentManager()") {
+
+            @Override
+            public android.app.FragmentManager call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getFragmentManager(this);
+                } else {
+                    return getOriginal().super_getFragmentManager();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Intent getIntent() {
-        return callFunction("getIntent()", new PluginCall<ActivityPlugin, Intent>() {
-            @Override
-            public Intent call(final NamedSuperCall<Intent> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getIntent();
+        }
 
-                return plugin.getIntent(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Intent>() {
+        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>("getIntent()") {
+
             @Override
             public Intent call(final Object... args) {
-                return getOriginal().super_getIntent();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getIntent(this);
+                } else {
+                    return getOriginal().super_getIntent();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public Object getLastCompositeCustomNonConfigurationInstance() {
@@ -1443,284 +1869,349 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public LayoutInflater getLayoutInflater() {
-        return callFunction("getLayoutInflater()",
-                new PluginCall<ActivityPlugin, LayoutInflater>() {
-                    @Override
-                    public LayoutInflater call(final NamedSuperCall<LayoutInflater> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getLayoutInflater();
+        }
 
-                        return plugin.getLayoutInflater(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<LayoutInflater>() {
-                    @Override
-                    public LayoutInflater call(final Object... args) {
-                        return getOriginal().super_getLayoutInflater();
-                    }
-                });
+        final NamedSuperCall<LayoutInflater> superCall = new NamedSuperCall<LayoutInflater>(
+                "getLayoutInflater()") {
+
+            @Override
+            public LayoutInflater call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getLayoutInflater(this);
+                } else {
+                    return getOriginal().super_getLayoutInflater();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public android.app.LoaderManager getLoaderManager() {
-        return callFunction("getLoaderManager()",
-                new PluginCall<ActivityPlugin, android.app.LoaderManager>() {
-                    @Override
-                    public android.app.LoaderManager call(
-                            final NamedSuperCall<android.app.LoaderManager> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getLoaderManager();
+        }
 
-                        return plugin.getLoaderManager(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<android.app.LoaderManager>() {
-                    @Override
-                    public android.app.LoaderManager call(final Object... args) {
-                        return getOriginal().super_getLoaderManager();
-                    }
-                });
+        final NamedSuperCall<android.app.LoaderManager> superCall
+                = new NamedSuperCall<android.app.LoaderManager>("getLoaderManager()") {
+
+            @Override
+            public android.app.LoaderManager call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getLoaderManager(this);
+                } else {
+                    return getOriginal().super_getLoaderManager();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public String getLocalClassName() {
-        return callFunction("getLocalClassName()", new PluginCall<ActivityPlugin, String>() {
-            @Override
-            public String call(final NamedSuperCall<String> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getLocalClassName();
+        }
 
-                return plugin.getLocalClassName(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String>() {
+        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("getLocalClassName()") {
+
             @Override
             public String call(final Object... args) {
-                return getOriginal().super_getLocalClassName();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getLocalClassName(this);
+                } else {
+                    return getOriginal().super_getLocalClassName();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public Looper getMainLooper() {
-        return callFunction("getMainLooper()", new PluginCall<ActivityPlugin, Looper>() {
-            @Override
-            public Looper call(final NamedSuperCall<Looper> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getMainLooper();
+        }
 
-                return plugin.getMainLooper(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Looper>() {
+        final NamedSuperCall<Looper> superCall = new NamedSuperCall<Looper>("getMainLooper()") {
+
             @Override
             public Looper call(final Object... args) {
-                return getOriginal().super_getMainLooper();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getMainLooper(this);
+                } else {
+                    return getOriginal().super_getMainLooper();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public MenuInflater getMenuInflater() {
-        return callFunction("getMenuInflater()", new PluginCall<ActivityPlugin, MenuInflater>() {
-            @Override
-            public MenuInflater call(final NamedSuperCall<MenuInflater> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getMenuInflater();
+        }
 
-                return plugin.getMenuInflater(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<MenuInflater>() {
+        final NamedSuperCall<MenuInflater> superCall = new NamedSuperCall<MenuInflater>(
+                "getMenuInflater()") {
+
             @Override
             public MenuInflater call(final Object... args) {
-                return getOriginal().super_getMenuInflater();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getMenuInflater(this);
+                } else {
+                    return getOriginal().super_getMenuInflater();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File getNoBackupFilesDir() {
-        return callFunction("getNoBackupFilesDir()", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getNoBackupFilesDir();
+        }
 
-                return plugin.getNoBackupFilesDir(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getNoBackupFilesDir()") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getNoBackupFilesDir();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getNoBackupFilesDir(this);
+                } else {
+                    return getOriginal().super_getNoBackupFilesDir();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File getObbDir() {
-        return callFunction("getObbDir()", new PluginCall<ActivityPlugin, File>() {
-            @Override
-            public File call(final NamedSuperCall<File> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getObbDir();
+        }
 
-                return plugin.getObbDir(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File>() {
+        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getObbDir()") {
+
             @Override
             public File call(final Object... args) {
-                return getOriginal().super_getObbDir();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getObbDir(this);
+                } else {
+                    return getOriginal().super_getObbDir();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public File[] getObbDirs() {
-        return callFunction("getObbDirs()", new PluginCall<ActivityPlugin, File[]>() {
-            @Override
-            public File[] call(final NamedSuperCall<File[]> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getObbDirs();
+        }
 
-                return plugin.getObbDirs(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<File[]>() {
+        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>("getObbDirs()") {
+
             @Override
             public File[] call(final Object... args) {
-                return getOriginal().super_getObbDirs();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getObbDirs(this);
+                } else {
+                    return getOriginal().super_getObbDirs();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public String getPackageCodePath() {
-        return callFunction("getPackageCodePath()", new PluginCall<ActivityPlugin, String>() {
-            @Override
-            public String call(final NamedSuperCall<String> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getPackageCodePath();
+        }
 
-                return plugin.getPackageCodePath(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String>() {
+        final NamedSuperCall<String> superCall = new NamedSuperCall<String>(
+                "getPackageCodePath()") {
+
             @Override
             public String call(final Object... args) {
-                return getOriginal().super_getPackageCodePath();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getPackageCodePath(this);
+                } else {
+                    return getOriginal().super_getPackageCodePath();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public PackageManager getPackageManager() {
-        return callFunction("getPackageManager()",
-                new PluginCall<ActivityPlugin, PackageManager>() {
-                    @Override
-                    public PackageManager call(final NamedSuperCall<PackageManager> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getPackageManager();
+        }
 
-                        return plugin.getPackageManager(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<PackageManager>() {
-                    @Override
-                    public PackageManager call(final Object... args) {
-                        return getOriginal().super_getPackageManager();
-                    }
-                });
+        final NamedSuperCall<PackageManager> superCall = new NamedSuperCall<PackageManager>(
+                "getPackageManager()") {
+
+            @Override
+            public PackageManager call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getPackageManager(this);
+                } else {
+                    return getOriginal().super_getPackageManager();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public String getPackageName() {
-        return callFunction("getPackageName()", new PluginCall<ActivityPlugin, String>() {
-            @Override
-            public String call(final NamedSuperCall<String> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getPackageName();
+        }
 
-                return plugin.getPackageName(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String>() {
+        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("getPackageName()") {
+
             @Override
             public String call(final Object... args) {
-                return getOriginal().super_getPackageName();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getPackageName(this);
+                } else {
+                    return getOriginal().super_getPackageName();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public String getPackageResourcePath() {
-        return callFunction("getPackageResourcePath()", new PluginCall<ActivityPlugin, String>() {
-            @Override
-            public String call(final NamedSuperCall<String> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getPackageResourcePath();
+        }
 
-                return plugin.getPackageResourcePath(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String>() {
+        final NamedSuperCall<String> superCall = new NamedSuperCall<String>(
+                "getPackageResourcePath()") {
+
             @Override
             public String call(final Object... args) {
-                return getOriginal().super_getPackageResourcePath();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getPackageResourcePath(this);
+                } else {
+                    return getOriginal().super_getPackageResourcePath();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public Intent getParentActivityIntent() {
-        return callFunction("getParentActivityIntent()", new PluginCall<ActivityPlugin, Intent>() {
-            @Override
-            public Intent call(final NamedSuperCall<Intent> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getParentActivityIntent();
+        }
 
-                return plugin.getParentActivityIntent(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Intent>() {
+        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
+                "getParentActivityIntent()") {
+
             @Override
             public Intent call(final Object... args) {
-                return getOriginal().super_getParentActivityIntent();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getParentActivityIntent(this);
+                } else {
+                    return getOriginal().super_getParentActivityIntent();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public SharedPreferences getPreferences(final int mode) {
-        return callFunction("getPreferences(int)",
-                new PluginCall<ActivityPlugin, SharedPreferences>() {
-                    @Override
-                    public SharedPreferences call(final NamedSuperCall<SharedPreferences> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getPreferences(mode);
+        }
 
-                        return plugin.getPreferences(superCall, (int) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<SharedPreferences>() {
-                    @Override
-                    public SharedPreferences call(final Object... args) {
-                        return getOriginal().super_getPreferences((int) args[0]);
-                    }
-                }, mode);
+        final NamedSuperCall<SharedPreferences> superCall = new NamedSuperCall<SharedPreferences>(
+                "getPreferences(int)") {
+
+            @Override
+            public SharedPreferences call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getPreferences(this, (int) args[0]);
+                } else {
+                    return getOriginal().super_getPreferences((int) args[0]);
+                }
+            }
+        };
+        return superCall.call(mode);
     }
 
     public Uri getReferrer() {
-        return callFunction("getReferrer()", new PluginCall<ActivityPlugin, Uri>() {
-            @Override
-            public Uri call(final NamedSuperCall<Uri> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getReferrer();
+        }
 
-                return plugin.getReferrer(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Uri>() {
+        final NamedSuperCall<Uri> superCall = new NamedSuperCall<Uri>("getReferrer()") {
+
             @Override
             public Uri call(final Object... args) {
-                return getOriginal().super_getReferrer();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getReferrer(this);
+                } else {
+                    return getOriginal().super_getReferrer();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public int getRequestedOrientation() {
-        return callFunction("getRequestedOrientation()", new PluginCall<ActivityPlugin, Integer>() {
-            @Override
-            public Integer call(final NamedSuperCall<Integer> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getRequestedOrientation();
+        }
 
-                return plugin.getRequestedOrientation(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Integer>() {
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "getRequestedOrientation()") {
+
             @Override
             public Integer call(final Object... args) {
-                return getOriginal().super_getRequestedOrientation();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getRequestedOrientation(this);
+                } else {
+                    return getOriginal().super_getRequestedOrientation();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
-
-
-    //private GetResourcesSuperCall mGetResourcesSuperCall = new GetResourcesSuperCall();
 
     public Resources getResources() {
         if (mPlugins.isEmpty()) {
@@ -1729,8 +2220,8 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Resources> superCall =
-                new NamedSuperCall<Resources>("getResources()") {
+        final NamedSuperCall<Resources> superCall = new NamedSuperCall<Resources>(
+                "getResources()") {
 
             @Override
             public Resources call(final Object... args) {
@@ -1744,1620 +2235,2235 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         return superCall.call();
     }
 
-/*    private class GetResourcesSuperCall extends NamedSuperCall<Resources> {
-
-        private ListIterator<ActivityPlugin> iterator;
-
-        public GetResourcesSuperCall() {
-            super("getResources()");
-        }
-
-        @Override
-        public Resources call(final Object... args) {
-            if (iterator.hasPrevious()) {
-                ActivityPlugin plugin = iterator.previous();
-                return plugin.getResources(this);
-            } else {
-                return getOriginal().super_getResources();
-            }
-        }
-    }*/
-
-
     public SharedPreferences getSharedPreferences(final String name, final int mode) {
-        return callFunction("getSharedPreferences(String, int)",
-                new PluginCall<ActivityPlugin, SharedPreferences>() {
-                    @Override
-                    public SharedPreferences call(final NamedSuperCall<SharedPreferences> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSharedPreferences(name, mode);
+        }
 
-                        return plugin
-                                .getSharedPreferences(superCall, (String) args[0], (int) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<SharedPreferences>() {
-                    @Override
-                    public SharedPreferences call(final Object... args) {
-                        return getOriginal()
-                                .super_getSharedPreferences((String) args[0], (int) args[1]);
-                    }
-                }, name, mode);
+        final NamedSuperCall<SharedPreferences> superCall = new NamedSuperCall<SharedPreferences>(
+                "getSharedPreferences(String, int)") {
+
+            @Override
+            public SharedPreferences call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .getSharedPreferences(this, (String) args[0], (int) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_getSharedPreferences((String) args[0], (int) args[1]);
+                }
+            }
+        };
+        return superCall.call(name, mode);
     }
 
     public ActionBar getSupportActionBar() {
-        return callFunction("getSupportActionBar()", new PluginCall<ActivityPlugin, ActionBar>() {
-            @Override
-            public ActionBar call(final NamedSuperCall<ActionBar> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSupportActionBar();
+        }
 
-                return plugin.getSupportActionBar(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<ActionBar>() {
+        final NamedSuperCall<ActionBar> superCall = new NamedSuperCall<ActionBar>(
+                "getSupportActionBar()") {
+
             @Override
             public ActionBar call(final Object... args) {
-                return getOriginal().super_getSupportActionBar();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSupportActionBar(this);
+                } else {
+                    return getOriginal().super_getSupportActionBar();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public FragmentManager getSupportFragmentManager() {
-        return callFunction("getSupportFragmentManager()",
-                new PluginCall<ActivityPlugin, FragmentManager>() {
-                    @Override
-                    public FragmentManager call(final NamedSuperCall<FragmentManager> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSupportFragmentManager();
+        }
 
-                        return plugin.getSupportFragmentManager(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<FragmentManager>() {
-                    @Override
-                    public FragmentManager call(final Object... args) {
-                        return getOriginal().super_getSupportFragmentManager();
-                    }
-                });
+        final NamedSuperCall<FragmentManager> superCall = new NamedSuperCall<FragmentManager>(
+                "getSupportFragmentManager()") {
+
+            @Override
+            public FragmentManager call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSupportFragmentManager(this);
+                } else {
+                    return getOriginal().super_getSupportFragmentManager();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public LoaderManager getSupportLoaderManager() {
-        return callFunction("getSupportLoaderManager()",
-                new PluginCall<ActivityPlugin, LoaderManager>() {
-                    @Override
-                    public LoaderManager call(final NamedSuperCall<LoaderManager> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSupportLoaderManager();
+        }
 
-                        return plugin.getSupportLoaderManager(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<LoaderManager>() {
-                    @Override
-                    public LoaderManager call(final Object... args) {
-                        return getOriginal().super_getSupportLoaderManager();
-                    }
-                });
+        final NamedSuperCall<LoaderManager> superCall = new NamedSuperCall<LoaderManager>(
+                "getSupportLoaderManager()") {
+
+            @Override
+            public LoaderManager call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSupportLoaderManager(this);
+                } else {
+                    return getOriginal().super_getSupportLoaderManager();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Intent getSupportParentActivityIntent() {
-        return callFunction("getSupportParentActivityIntent()",
-                new PluginCall<ActivityPlugin, Intent>() {
-                    @Override
-                    public Intent call(final NamedSuperCall<Intent> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSupportParentActivityIntent();
+        }
 
-                        return plugin.getSupportParentActivityIntent(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Intent>() {
-                    @Override
-                    public Intent call(final Object... args) {
-                        return getOriginal().super_getSupportParentActivityIntent();
-                    }
-                });
+        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
+                "getSupportParentActivityIntent()") {
+
+            @Override
+            public Intent call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSupportParentActivityIntent(this);
+                } else {
+                    return getOriginal().super_getSupportParentActivityIntent();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Object getSystemService(final String name) {
-        return callFunction("getSystemService(String)", new PluginCall<ActivityPlugin, Object>() {
-            @Override
-            public Object call(final NamedSuperCall<Object> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSystemService(name);
+        }
 
-                return plugin.getSystemService(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Object>() {
+        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+                "getSystemService(String)") {
+
             @Override
             public Object call(final Object... args) {
-                return getOriginal().super_getSystemService((String) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSystemService(this, (String) args[0]);
+                } else {
+                    return getOriginal().super_getSystemService((String) args[0]);
+                }
             }
-        }, name);
+        };
+        return superCall.call(name);
     }
 
     public String getSystemServiceName(final Class<?> serviceClass) {
-        return callFunction("getSystemServiceName(Class<?>)",
-                new PluginCall<ActivityPlugin, String>() {
-                    @Override
-                    public String call(final NamedSuperCall<String> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSystemServiceName(serviceClass);
+        }
 
-                        return plugin.getSystemServiceName(superCall, (Class<?>) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<String>() {
-                    @Override
-                    public String call(final Object... args) {
-                        return getOriginal().super_getSystemServiceName((Class<?>) args[0]);
-                    }
-                }, serviceClass);
+        final NamedSuperCall<String> superCall = new NamedSuperCall<String>(
+                "getSystemServiceName(Class<?>)") {
+
+            @Override
+            public String call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSystemServiceName(this, (Class<?>) args[0]);
+                } else {
+                    return getOriginal().super_getSystemServiceName((Class<?>) args[0]);
+                }
+            }
+        };
+        return superCall.call(serviceClass);
     }
 
     public int getTaskId() {
-        return callFunction("getTaskId()", new PluginCall<ActivityPlugin, Integer>() {
-            @Override
-            public Integer call(final NamedSuperCall<Integer> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getTaskId();
+        }
 
-                return plugin.getTaskId(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Integer>() {
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>("getTaskId()") {
+
             @Override
             public Integer call(final Object... args) {
-                return getOriginal().super_getTaskId();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getTaskId(this);
+                } else {
+                    return getOriginal().super_getTaskId();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public Resources.Theme getTheme() {
-        return callFunction("getTheme()", new PluginCall<ActivityPlugin, Resources.Theme>() {
-            @Override
-            public Resources.Theme call(final NamedSuperCall<Resources.Theme> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getTheme();
+        }
 
-                return plugin.getTheme(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Resources.Theme>() {
+        final NamedSuperCall<Resources.Theme> superCall = new NamedSuperCall<Resources.Theme>(
+                "getTheme()") {
+
             @Override
             public Resources.Theme call(final Object... args) {
-                return getOriginal().super_getTheme();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getTheme(this);
+                } else {
+                    return getOriginal().super_getTheme();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public VoiceInteractor getVoiceInteractor() {
-        return callFunction("getVoiceInteractor()",
-                new PluginCall<ActivityPlugin, VoiceInteractor>() {
-                    @Override
-                    public VoiceInteractor call(final NamedSuperCall<VoiceInteractor> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getVoiceInteractor();
+        }
 
-                        return plugin.getVoiceInteractor(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<VoiceInteractor>() {
-                    @Override
-                    public VoiceInteractor call(final Object... args) {
-                        return getOriginal().super_getVoiceInteractor();
-                    }
-                });
+        final NamedSuperCall<VoiceInteractor> superCall = new NamedSuperCall<VoiceInteractor>(
+                "getVoiceInteractor()") {
+
+            @Override
+            public VoiceInteractor call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getVoiceInteractor(this);
+                } else {
+                    return getOriginal().super_getVoiceInteractor();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Drawable getWallpaper() {
-        return callFunction("getWallpaper()", new PluginCall<ActivityPlugin, Drawable>() {
-            @Override
-            public Drawable call(final NamedSuperCall<Drawable> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getWallpaper();
+        }
 
-                return plugin.getWallpaper(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Drawable>() {
+        final NamedSuperCall<Drawable> superCall = new NamedSuperCall<Drawable>("getWallpaper()") {
+
             @Override
             public Drawable call(final Object... args) {
-                return getOriginal().super_getWallpaper();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getWallpaper(this);
+                } else {
+                    return getOriginal().super_getWallpaper();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public int getWallpaperDesiredMinimumHeight() {
-        return callFunction("getWallpaperDesiredMinimumHeight()",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getWallpaperDesiredMinimumHeight();
+        }
 
-                        return plugin.getWallpaperDesiredMinimumHeight(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_getWallpaperDesiredMinimumHeight();
-                    }
-                });
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "getWallpaperDesiredMinimumHeight()") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getWallpaperDesiredMinimumHeight(this);
+                } else {
+                    return getOriginal().super_getWallpaperDesiredMinimumHeight();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public int getWallpaperDesiredMinimumWidth() {
-        return callFunction("getWallpaperDesiredMinimumWidth()",
-                new PluginCall<ActivityPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getWallpaperDesiredMinimumWidth();
+        }
 
-                        return plugin.getWallpaperDesiredMinimumWidth(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal().super_getWallpaperDesiredMinimumWidth();
-                    }
-                });
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "getWallpaperDesiredMinimumWidth()") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getWallpaperDesiredMinimumWidth(this);
+                } else {
+                    return getOriginal().super_getWallpaperDesiredMinimumWidth();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Window getWindow() {
-        return callFunction("getWindow()", new PluginCall<ActivityPlugin, Window>() {
-            @Override
-            public Window call(final NamedSuperCall<Window> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getWindow();
+        }
 
-                return plugin.getWindow(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Window>() {
+        final NamedSuperCall<Window> superCall = new NamedSuperCall<Window>("getWindow()") {
+
             @Override
             public Window call(final Object... args) {
-                return getOriginal().super_getWindow();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getWindow(this);
+                } else {
+                    return getOriginal().super_getWindow();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public WindowManager getWindowManager() {
-        return callFunction("getWindowManager()", new PluginCall<ActivityPlugin, WindowManager>() {
-            @Override
-            public WindowManager call(final NamedSuperCall<WindowManager> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getWindowManager();
+        }
 
-                return plugin.getWindowManager(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<WindowManager>() {
+        final NamedSuperCall<WindowManager> superCall = new NamedSuperCall<WindowManager>(
+                "getWindowManager()") {
+
             @Override
             public WindowManager call(final Object... args) {
-                return getOriginal().super_getWindowManager();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getWindowManager(this);
+                } else {
+                    return getOriginal().super_getWindowManager();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void grantUriPermission(final String toPackage, final Uri uri, final int modeFlags) {
-        callHook("grantUriPermission(String, Uri, int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_grantUriPermission(toPackage, uri, modeFlags);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "grantUriPermission(String, Uri, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.grantUriPermission(superCall, (String) args[0], (Uri) args[1],
-                        (int) args[2]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().grantUriPermission(this, (String) args[0], (Uri) args[1],
+                            (int) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_grantUriPermission((String) args[0], (Uri) args[1],
+                            (int) args[2]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal()
-                        .super_grantUriPermission((String) args[0], (Uri) args[1], (int) args[2]);
-            }
-        }, toPackage, uri, modeFlags);
+        };
+        superCall.call(toPackage, uri, modeFlags);
     }
 
     public boolean hasWindowFocus() {
-        return callFunction("hasWindowFocus()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_hasWindowFocus();
+        }
 
-                return plugin.hasWindowFocus(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("hasWindowFocus()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_hasWindowFocus();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().hasWindowFocus(this);
+                } else {
+                    return getOriginal().super_hasWindowFocus();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void invalidateOptionsMenu() {
-        callHook("invalidateOptionsMenu()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_invalidateOptionsMenu();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("invalidateOptionsMenu()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.invalidateOptionsMenu(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().invalidateOptionsMenu(this);
+                    return null;
+                } else {
+                    getOriginal().super_invalidateOptionsMenu();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_invalidateOptionsMenu();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public boolean isChangingConfigurations() {
-        return callFunction("isChangingConfigurations()",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isChangingConfigurations();
+        }
 
-                        return plugin.isChangingConfigurations(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_isChangingConfigurations();
-                    }
-                });
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "isChangingConfigurations()") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isChangingConfigurations(this);
+                } else {
+                    return getOriginal().super_isChangingConfigurations();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public boolean isDestroyed() {
-        return callFunction("isDestroyed()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isDestroyed();
+        }
 
-                return plugin.isDestroyed(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isDestroyed()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isDestroyed();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isDestroyed(this);
+                } else {
+                    return getOriginal().super_isDestroyed();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean isFinishing() {
-        return callFunction("isFinishing()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isFinishing();
+        }
 
-                return plugin.isFinishing(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isFinishing()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isFinishing();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isFinishing(this);
+                } else {
+                    return getOriginal().super_isFinishing();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean isImmersive() {
-        return callFunction("isImmersive()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isImmersive();
+        }
 
-                return plugin.isImmersive(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isImmersive()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isImmersive();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isImmersive(this);
+                } else {
+                    return getOriginal().super_isImmersive();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean isRestricted() {
-        return callFunction("isRestricted()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isRestricted();
+        }
 
-                return plugin.isRestricted(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isRestricted()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isRestricted();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isRestricted(this);
+                } else {
+                    return getOriginal().super_isRestricted();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean isTaskRoot() {
-        return callFunction("isTaskRoot()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isTaskRoot();
+        }
 
-                return plugin.isTaskRoot(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isTaskRoot()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isTaskRoot();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isTaskRoot(this);
+                } else {
+                    return getOriginal().super_isTaskRoot();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean isVoiceInteraction() {
-        return callFunction("isVoiceInteraction()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isVoiceInteraction();
+        }
 
-                return plugin.isVoiceInteraction(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "isVoiceInteraction()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isVoiceInteraction();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isVoiceInteraction(this);
+                } else {
+                    return getOriginal().super_isVoiceInteraction();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean isVoiceInteractionRoot() {
-        return callFunction("isVoiceInteractionRoot()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isVoiceInteractionRoot();
+        }
 
-                return plugin.isVoiceInteractionRoot(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "isVoiceInteractionRoot()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isVoiceInteractionRoot();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isVoiceInteractionRoot(this);
+                } else {
+                    return getOriginal().super_isVoiceInteractionRoot();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean moveTaskToBack(final boolean nonRoot) {
-        return callFunction("moveTaskToBack(boolean)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_moveTaskToBack(nonRoot);
+        }
 
-                return plugin.moveTaskToBack(superCall, (boolean) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "moveTaskToBack(boolean)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_moveTaskToBack((boolean) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().moveTaskToBack(this, (boolean) args[0]);
+                } else {
+                    return getOriginal().super_moveTaskToBack((boolean) args[0]);
+                }
             }
-        }, nonRoot);
+        };
+        return superCall.call(nonRoot);
     }
 
     public boolean navigateUpTo(final Intent upIntent) {
-        return callFunction("navigateUpTo(Intent)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_navigateUpTo(upIntent);
+        }
 
-                return plugin.navigateUpTo(superCall, (Intent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "navigateUpTo(Intent)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_navigateUpTo((Intent) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().navigateUpTo(this, (Intent) args[0]);
+                } else {
+                    return getOriginal().super_navigateUpTo((Intent) args[0]);
+                }
             }
-        }, upIntent);
+        };
+        return superCall.call(upIntent);
     }
 
     public boolean navigateUpToFromChild(final Activity child, final Intent upIntent) {
-        return callFunction("navigateUpToFromChild(Activity, Intent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_navigateUpToFromChild(child, upIntent);
+        }
 
-                        return plugin.navigateUpToFromChild(superCall, (Activity) args[0],
-                                (Intent) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_navigateUpToFromChild((Activity) args[0], (Intent) args[1]);
-                    }
-                }, child, upIntent);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "navigateUpToFromChild(Activity, Intent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .navigateUpToFromChild(this, (Activity) args[0], (Intent) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_navigateUpToFromChild((Activity) args[0], (Intent) args[1]);
+                }
+            }
+        };
+        return superCall.call(child, upIntent);
     }
 
     public void onActionModeFinished(final android.view.ActionMode mode) {
-        callHook("onActionModeFinished(android.view.ActionMode)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onActionModeFinished(superCall, (android.view.ActionMode) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onActionModeFinished((android.view.ActionMode) args[0]);
-                    }
-                }, mode);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onActionModeFinished(mode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onActionModeFinished(android.view.ActionMode)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onActionModeFinished(this, (android.view.ActionMode) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onActionModeFinished((android.view.ActionMode) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(mode);
     }
 
     public void onActionModeStarted(final android.view.ActionMode mode) {
-        callHook("onActionModeStarted(android.view.ActionMode)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onActionModeStarted(superCall, (android.view.ActionMode) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onActionModeStarted((android.view.ActionMode) args[0]);
-                    }
-                }, mode);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onActionModeStarted(mode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onActionModeStarted(android.view.ActionMode)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onActionModeStarted(this, (android.view.ActionMode) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onActionModeStarted((android.view.ActionMode) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(mode);
     }
 
     public void onActivityReenter(final int resultCode, final Intent data) {
-        callHook("onActivityReenter(int, Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onActivityReenter(resultCode, data);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onActivityReenter(int, Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onActivityReenter(superCall, (int) args[0], (Intent) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onActivityReenter(this, (int) args[0], (Intent) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onActivityReenter((int) args[0], (Intent) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onActivityReenter((int) args[0], (Intent) args[1]);
-            }
-        }, resultCode, data);
+        };
+        superCall.call(resultCode, data);
     }
 
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        callHook("onActivityResult(int, int, Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onActivityResult(requestCode, resultCode, data);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onActivityResult(int, int, Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onActivityResult(superCall, (int) args[0], (int) args[1], (Intent) args[2]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onActivityResult(this, (int) args[0], (int) args[1], (Intent) args[2]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal()
-                        .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
-            }
-        }, requestCode, resultCode, data);
+        };
+        superCall.call(requestCode, resultCode, data);
     }
 
     public void onApplyThemeResource(final Resources.Theme theme, final int resid,
             final boolean first) {
-        callHook("onApplyThemeResource(Resources.Theme, int, boolean)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onApplyThemeResource(superCall, (Resources.Theme) args[0],
-                                (int) args[1], (boolean) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onApplyThemeResource((Resources.Theme) args[0],
-                                (int) args[1], (boolean) args[2]);
-                    }
-                }, theme, resid, first);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onApplyThemeResource(theme, resid, first);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onApplyThemeResource(Resources.Theme, int, boolean)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onApplyThemeResource(this, (Resources.Theme) args[0], (int) args[1],
+                                    (boolean) args[2]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_onApplyThemeResource((Resources.Theme) args[0], (int) args[1],
+                                    (boolean) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(theme, resid, first);
     }
 
     public void onAttachFragment(final Fragment fragment) {
-        callHook("onAttachFragment(Fragment)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onAttachFragment(fragment);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onAttachFragment(Fragment)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onAttachFragment(superCall, (Fragment) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onAttachFragment(this, (Fragment) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onAttachFragment((Fragment) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onAttachFragment((Fragment) args[0]);
-            }
-        }, fragment);
+        };
+        superCall.call(fragment);
     }
 
     public void onAttachFragment(final android.app.Fragment fragment) {
-        callHook("onAttachFragment(android.app.Fragment)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onAttachFragment(fragment);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onAttachFragment(android.app.Fragment)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onAttachFragment(superCall, (android.app.Fragment) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onAttachFragment(this, (android.app.Fragment) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onAttachFragment((android.app.Fragment) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onAttachFragment((android.app.Fragment) args[0]);
-            }
-        }, fragment);
+        };
+        superCall.call(fragment);
     }
 
     public void onAttachedToWindow() {
-        callHook("onAttachedToWindow()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onAttachedToWindow();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onAttachedToWindow()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onAttachedToWindow(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onAttachedToWindow(this);
+                    return null;
+                } else {
+                    getOriginal().super_onAttachedToWindow();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onAttachedToWindow();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onBackPressed() {
-        callHook("onBackPressed()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onBackPressed();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onBackPressed()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onBackPressed(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onBackPressed(this);
+                    return null;
+                } else {
+                    getOriginal().super_onBackPressed();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onBackPressed();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onChildTitleChanged(final Activity childActivity, final CharSequence title) {
-        callHook("onChildTitleChanged(Activity, CharSequence)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onChildTitleChanged(superCall, (Activity) args[0],
-                                (CharSequence) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onChildTitleChanged((Activity) args[0],
-                                (CharSequence) args[1]);
-                    }
-                }, childActivity, title);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onChildTitleChanged(childActivity, title);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onChildTitleChanged(Activity, CharSequence)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onChildTitleChanged(this, (Activity) args[0], (CharSequence) args[1]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_onChildTitleChanged((Activity) args[0], (CharSequence) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(childActivity, title);
     }
 
     public void onConfigurationChanged(final Configuration newConfig) {
-        callHook("onConfigurationChanged(Configuration)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onConfigurationChanged(newConfig);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onConfigurationChanged(Configuration)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onConfigurationChanged(superCall, (Configuration) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onConfigurationChanged(this, (Configuration) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onConfigurationChanged((Configuration) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onConfigurationChanged((Configuration) args[0]);
-            }
-        }, newConfig);
+        };
+        superCall.call(newConfig);
     }
 
     public void onContentChanged() {
-        callHook("onContentChanged()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onContentChanged();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onContentChanged()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onContentChanged(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onContentChanged(this);
+                    return null;
+                } else {
+                    getOriginal().super_onContentChanged();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onContentChanged();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public boolean onContextItemSelected(final MenuItem item) {
-        return callFunction("onContextItemSelected(MenuItem)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onContextItemSelected(item);
+        }
 
-                        return plugin.onContextItemSelected(superCall, (MenuItem) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
-                    }
-                }, item);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onContextItemSelected(MenuItem)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onContextItemSelected(this, (MenuItem) args[0]);
+                } else {
+                    return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
+                }
+            }
+        };
+        return superCall.call(item);
     }
 
     public void onContextMenuClosed(final Menu menu) {
-        callHook("onContextMenuClosed(Menu)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onContextMenuClosed(menu);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onContextMenuClosed(Menu)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onContextMenuClosed(superCall, (Menu) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onContextMenuClosed(this, (Menu) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onContextMenuClosed((Menu) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onContextMenuClosed((Menu) args[0]);
-            }
-        }, menu);
+        };
+        superCall.call(menu);
     }
 
     public void onCreate(final Bundle savedInstanceState, final PersistableBundle persistentState) {
-        callHook("onCreate(Bundle, PersistableBundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreate(savedInstanceState, persistentState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onCreate(Bundle, PersistableBundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onCreate(superCall, (Bundle) args[0], (PersistableBundle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onCreate(this, (Bundle) args[0], (PersistableBundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreate((Bundle) args[0], (PersistableBundle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onCreate((Bundle) args[0], (PersistableBundle) args[1]);
-            }
-        }, savedInstanceState, persistentState);
+        };
+        superCall.call(savedInstanceState, persistentState);
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
-        callHook("onCreate(Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreate(savedInstanceState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onCreate(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onCreate(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onCreate(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreate((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onCreate((Bundle) args[0]);
-            }
-        }, savedInstanceState);
+        };
+        superCall.call(savedInstanceState);
     }
 
     public void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo) {
-        callHook("onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onCreateContextMenu(superCall, (ContextMenu) args[0], (View) args[1],
-                                (ContextMenu.ContextMenuInfo) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
-                                        (ContextMenu.ContextMenuInfo) args[2]);
-                    }
-                }, menu, v, menuInfo);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreateContextMenu(menu, v, menuInfo);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onCreateContextMenu(this, (ContextMenu) args[0], (View) args[1],
+                                    (ContextMenu.ContextMenuInfo) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
+                            (ContextMenu.ContextMenuInfo) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(menu, v, menuInfo);
     }
 
     public CharSequence onCreateDescription() {
-        return callFunction("onCreateDescription()",
-                new PluginCall<ActivityPlugin, CharSequence>() {
-                    @Override
-                    public CharSequence call(final NamedSuperCall<CharSequence> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateDescription();
+        }
 
-                        return plugin.onCreateDescription(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<CharSequence>() {
-                    @Override
-                    public CharSequence call(final Object... args) {
-                        return getOriginal().super_onCreateDescription();
-                    }
-                });
+        final NamedSuperCall<CharSequence> superCall = new NamedSuperCall<CharSequence>(
+                "onCreateDescription()") {
+
+            @Override
+            public CharSequence call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onCreateDescription(this);
+                } else {
+                    return getOriginal().super_onCreateDescription();
+                }
+            }
+        };
+        return superCall.call();
     }
 
     public Dialog onCreateDialog(final int id) {
-        return callFunction("onCreateDialog(int)", new PluginCall<ActivityPlugin, Dialog>() {
-            @Override
-            public Dialog call(final NamedSuperCall<Dialog> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateDialog(id);
+        }
 
-                return plugin.onCreateDialog(superCall, (int) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Dialog>() {
+        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>("onCreateDialog(int)") {
+
             @Override
             public Dialog call(final Object... args) {
-                return getOriginal().super_onCreateDialog((int) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onCreateDialog(this, (int) args[0]);
+                } else {
+                    return getOriginal().super_onCreateDialog((int) args[0]);
+                }
             }
-        }, id);
+        };
+        return superCall.call(id);
     }
 
     public Dialog onCreateDialog(final int id, final Bundle args) {
-        return callFunction("onCreateDialog(int, Bundle)",
-                new PluginCall<ActivityPlugin, Dialog>() {
-                    @Override
-                    public Dialog call(final NamedSuperCall<Dialog> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateDialog(id, args);
+        }
 
-                        return plugin.onCreateDialog(superCall, (int) args[0], (Bundle) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Dialog>() {
-                    @Override
-                    public Dialog call(final Object... args) {
-                        return getOriginal().super_onCreateDialog((int) args[0], (Bundle) args[1]);
-                    }
-                }, id, args);
+        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>(
+                "onCreateDialog(int, Bundle)") {
+
+            @Override
+            public Dialog call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onCreateDialog(this, (int) args[0], (Bundle) args[1]);
+                } else {
+                    return getOriginal().super_onCreateDialog((int) args[0], (Bundle) args[1]);
+                }
+            }
+        };
+        return superCall.call(id, args);
     }
 
     public void onCreateNavigateUpTaskStack(final TaskStackBuilder builder) {
-        callHook("onCreateNavigateUpTaskStack(TaskStackBuilder)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onCreateNavigateUpTaskStack(superCall, (TaskStackBuilder) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onCreateNavigateUpTaskStack((TaskStackBuilder) args[0]);
-                    }
-                }, builder);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreateNavigateUpTaskStack(builder);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onCreateNavigateUpTaskStack(TaskStackBuilder)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onCreateNavigateUpTaskStack(this, (TaskStackBuilder) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreateNavigateUpTaskStack((TaskStackBuilder) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(builder);
     }
 
     public boolean onCreateOptionsMenu(final Menu menu) {
-        return callFunction("onCreateOptionsMenu(Menu)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateOptionsMenu(menu);
+        }
 
-                return plugin.onCreateOptionsMenu(superCall, (Menu) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onCreateOptionsMenu(Menu)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onCreateOptionsMenu((Menu) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onCreateOptionsMenu(this, (Menu) args[0]);
+                } else {
+                    return getOriginal().super_onCreateOptionsMenu((Menu) args[0]);
+                }
             }
-        }, menu);
+        };
+        return superCall.call(menu);
     }
 
     public boolean onCreatePanelMenu(final int featureId, final Menu menu) {
-        return callFunction("onCreatePanelMenu(int, Menu)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreatePanelMenu(featureId, menu);
+        }
 
-                        return plugin.onCreatePanelMenu(superCall, (int) args[0], (Menu) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onCreatePanelMenu((int) args[0], (Menu) args[1]);
-                    }
-                }, featureId, menu);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onCreatePanelMenu(int, Menu)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onCreatePanelMenu(this, (int) args[0], (Menu) args[1]);
+                } else {
+                    return getOriginal().super_onCreatePanelMenu((int) args[0], (Menu) args[1]);
+                }
+            }
+        };
+        return superCall.call(featureId, menu);
     }
 
     public View onCreatePanelView(final int featureId) {
-        return callFunction("onCreatePanelView(int)", new PluginCall<ActivityPlugin, View>() {
-            @Override
-            public View call(final NamedSuperCall<View> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreatePanelView(featureId);
+        }
 
-                return plugin.onCreatePanelView(superCall, (int) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<View>() {
+        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("onCreatePanelView(int)") {
+
             @Override
             public View call(final Object... args) {
-                return getOriginal().super_onCreatePanelView((int) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onCreatePanelView(this, (int) args[0]);
+                } else {
+                    return getOriginal().super_onCreatePanelView((int) args[0]);
+                }
             }
-        }, featureId);
+        };
+        return superCall.call(featureId);
     }
 
     public void onCreateSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
-        callHook("onCreateSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onCreateSupportNavigateUpTaskStack(superCall,
-                                (android.support.v4.app.TaskStackBuilder) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onCreateSupportNavigateUpTaskStack(
-                                (android.support.v4.app.TaskStackBuilder) args[0]);
-                    }
-                }, builder);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreateSupportNavigateUpTaskStack(builder);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onCreateSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onCreateSupportNavigateUpTaskStack(this,
+                            (android.support.v4.app.TaskStackBuilder) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreateSupportNavigateUpTaskStack(
+                            (android.support.v4.app.TaskStackBuilder) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(builder);
     }
 
     public boolean onCreateThumbnail(final Bitmap outBitmap, final Canvas canvas) {
-        return callFunction("onCreateThumbnail(Bitmap, Canvas)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateThumbnail(outBitmap, canvas);
+        }
 
-                        return plugin
-                                .onCreateThumbnail(superCall, (Bitmap) args[0], (Canvas) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_onCreateThumbnail((Bitmap) args[0], (Canvas) args[1]);
-                    }
-                }, outBitmap, canvas);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onCreateThumbnail(Bitmap, Canvas)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onCreateThumbnail(this, (Bitmap) args[0], (Canvas) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_onCreateThumbnail((Bitmap) args[0], (Canvas) args[1]);
+                }
+            }
+        };
+        return superCall.call(outBitmap, canvas);
     }
 
     public View onCreateView(final View parent, final String name, final Context context,
             final AttributeSet attrs) {
-        return callFunction("onCreateView(View, String, Context, AttributeSet)",
-                new PluginCall<ActivityPlugin, View>() {
-                    @Override
-                    public View call(final NamedSuperCall<View> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateView(parent, name, context, attrs);
+        }
 
-                        return plugin.onCreateView(superCall, (View) args[0], (String) args[1],
-                                (Context) args[2], (AttributeSet) args[3]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<View>() {
-                    @Override
-                    public View call(final Object... args) {
-                        return getOriginal().super_onCreateView((View) args[0], (String) args[1],
-                                (Context) args[2], (AttributeSet) args[3]);
-                    }
-                }, parent, name, context, attrs);
+        final NamedSuperCall<View> superCall = new NamedSuperCall<View>(
+                "onCreateView(View, String, Context, AttributeSet)") {
+
+            @Override
+            public View call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onCreateView(this, (View) args[0], (String) args[1], (Context) args[2],
+                                    (AttributeSet) args[3]);
+                } else {
+                    return getOriginal()
+                            .super_onCreateView((View) args[0], (String) args[1], (Context) args[2],
+                                    (AttributeSet) args[3]);
+                }
+            }
+        };
+        return superCall.call(parent, name, context, attrs);
     }
 
     public View onCreateView(final String name, final Context context, final AttributeSet attrs) {
-        return callFunction("onCreateView(String, Context, AttributeSet)",
-                new PluginCall<ActivityPlugin, View>() {
-                    @Override
-                    public View call(final NamedSuperCall<View> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateView(name, context, attrs);
+        }
 
-                        return plugin.onCreateView(superCall, (String) args[0], (Context) args[1],
-                                (AttributeSet) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<View>() {
-                    @Override
-                    public View call(final Object... args) {
-                        return getOriginal().super_onCreateView((String) args[0], (Context) args[1],
-                                (AttributeSet) args[2]);
-                    }
-                }, name, context, attrs);
+        final NamedSuperCall<View> superCall = new NamedSuperCall<View>(
+                "onCreateView(String, Context, AttributeSet)") {
+
+            @Override
+            public View call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onCreateView(this, (String) args[0], (Context) args[1],
+                                    (AttributeSet) args[2]);
+                } else {
+                    return getOriginal().super_onCreateView((String) args[0], (Context) args[1],
+                            (AttributeSet) args[2]);
+                }
+            }
+        };
+        return superCall.call(name, context, attrs);
     }
 
     public void onDestroy() {
-        callHook("onDestroy()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onDestroy();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroy()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onDestroy(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onDestroy(this);
+                    return null;
+                } else {
+                    getOriginal().super_onDestroy();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onDestroy();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onDetachedFromWindow() {
-        callHook("onDetachedFromWindow()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onDetachedFromWindow();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDetachedFromWindow()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onDetachedFromWindow(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onDetachedFromWindow(this);
+                    return null;
+                } else {
+                    getOriginal().super_onDetachedFromWindow();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onDetachedFromWindow();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onEnterAnimationComplete() {
-        callHook("onEnterAnimationComplete()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onEnterAnimationComplete();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onEnterAnimationComplete()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onEnterAnimationComplete(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onEnterAnimationComplete(this);
+                    return null;
+                } else {
+                    getOriginal().super_onEnterAnimationComplete();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onEnterAnimationComplete();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public boolean onGenericMotionEvent(final MotionEvent event) {
-        return callFunction("onGenericMotionEvent(MotionEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onGenericMotionEvent(event);
+        }
 
-                        return plugin.onGenericMotionEvent(superCall, (MotionEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onGenericMotionEvent((MotionEvent) args[0]);
-                    }
-                }, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onGenericMotionEvent(MotionEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onGenericMotionEvent(this, (MotionEvent) args[0]);
+                } else {
+                    return getOriginal().super_onGenericMotionEvent((MotionEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(event);
     }
 
     public boolean onKeyDown(final int keyCode, final KeyEvent event) {
-        return callFunction("onKeyDown(int, KeyEvent)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onKeyDown(keyCode, event);
+        }
 
-                return plugin.onKeyDown(superCall, (int) args[0], (KeyEvent) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onKeyDown(int, KeyEvent)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onKeyDown((int) args[0], (KeyEvent) args[1]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onKeyDown(this, (int) args[0], (KeyEvent) args[1]);
+                } else {
+                    return getOriginal().super_onKeyDown((int) args[0], (KeyEvent) args[1]);
+                }
             }
-        }, keyCode, event);
+        };
+        return superCall.call(keyCode, event);
     }
 
     public boolean onKeyLongPress(final int keyCode, final KeyEvent event) {
-        return callFunction("onKeyLongPress(int, KeyEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onKeyLongPress(keyCode, event);
+        }
 
-                        return plugin.onKeyLongPress(superCall, (int) args[0], (KeyEvent) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_onKeyLongPress((int) args[0], (KeyEvent) args[1]);
-                    }
-                }, keyCode, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onKeyLongPress(int, KeyEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onKeyLongPress(this, (int) args[0], (KeyEvent) args[1]);
+                } else {
+                    return getOriginal().super_onKeyLongPress((int) args[0], (KeyEvent) args[1]);
+                }
+            }
+        };
+        return superCall.call(keyCode, event);
     }
 
     public boolean onKeyMultiple(final int keyCode, final int repeatCount, final KeyEvent event) {
-        return callFunction("onKeyMultiple(int, int, KeyEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onKeyMultiple(keyCode, repeatCount, event);
+        }
 
-                        return plugin.onKeyMultiple(superCall, (int) args[0], (int) args[1],
-                                (KeyEvent) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onKeyMultiple((int) args[0], (int) args[1],
-                                (KeyEvent) args[2]);
-                    }
-                }, keyCode, repeatCount, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onKeyMultiple(int, int, KeyEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onKeyMultiple(this, (int) args[0], (int) args[1], (KeyEvent) args[2]);
+                } else {
+                    return getOriginal()
+                            .super_onKeyMultiple((int) args[0], (int) args[1], (KeyEvent) args[2]);
+                }
+            }
+        };
+        return superCall.call(keyCode, repeatCount, event);
     }
 
     public boolean onKeyShortcut(final int keyCode, final KeyEvent event) {
-        return callFunction("onKeyShortcut(int, KeyEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onKeyShortcut(keyCode, event);
+        }
 
-                        return plugin.onKeyShortcut(superCall, (int) args[0], (KeyEvent) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onKeyShortcut((int) args[0], (KeyEvent) args[1]);
-                    }
-                }, keyCode, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onKeyShortcut(int, KeyEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onKeyShortcut(this, (int) args[0], (KeyEvent) args[1]);
+                } else {
+                    return getOriginal().super_onKeyShortcut((int) args[0], (KeyEvent) args[1]);
+                }
+            }
+        };
+        return superCall.call(keyCode, event);
     }
 
     public boolean onKeyUp(final int keyCode, final KeyEvent event) {
-        return callFunction("onKeyUp(int, KeyEvent)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onKeyUp(keyCode, event);
+        }
 
-                return plugin.onKeyUp(superCall, (int) args[0], (KeyEvent) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onKeyUp(int, KeyEvent)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onKeyUp((int) args[0], (KeyEvent) args[1]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onKeyUp(this, (int) args[0], (KeyEvent) args[1]);
+                } else {
+                    return getOriginal().super_onKeyUp((int) args[0], (KeyEvent) args[1]);
+                }
             }
-        }, keyCode, event);
+        };
+        return superCall.call(keyCode, event);
     }
 
     public void onLowMemory() {
-        callHook("onLowMemory()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onLowMemory();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onLowMemory()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onLowMemory(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onLowMemory(this);
+                    return null;
+                } else {
+                    getOriginal().super_onLowMemory();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onLowMemory();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public boolean onMenuOpened(final int featureId, final Menu menu) {
-        return callFunction("onMenuOpened(int, Menu)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onMenuOpened(featureId, menu);
+        }
 
-                return plugin.onMenuOpened(superCall, (int) args[0], (Menu) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onMenuOpened(int, Menu)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onMenuOpened((int) args[0], (Menu) args[1]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onMenuOpened(this, (int) args[0], (Menu) args[1]);
+                } else {
+                    return getOriginal().super_onMenuOpened((int) args[0], (Menu) args[1]);
+                }
             }
-        }, featureId, menu);
+        };
+        return superCall.call(featureId, menu);
     }
 
     public boolean onNavigateUp() {
-        return callFunction("onNavigateUp()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onNavigateUp();
+        }
 
-                return plugin.onNavigateUp(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("onNavigateUp()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onNavigateUp();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onNavigateUp(this);
+                } else {
+                    return getOriginal().super_onNavigateUp();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean onNavigateUpFromChild(final Activity child) {
-        return callFunction("onNavigateUpFromChild(Activity)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onNavigateUpFromChild(child);
+        }
 
-                        return plugin.onNavigateUpFromChild(superCall, (Activity) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onNavigateUpFromChild((Activity) args[0]);
-                    }
-                }, child);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onNavigateUpFromChild(Activity)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onNavigateUpFromChild(this, (Activity) args[0]);
+                } else {
+                    return getOriginal().super_onNavigateUpFromChild((Activity) args[0]);
+                }
+            }
+        };
+        return superCall.call(child);
     }
 
     public void onNewIntent(final Intent intent) {
-        callHook("onNewIntent(Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onNewIntent(intent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onNewIntent(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onNewIntent(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onNewIntent(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onNewIntent((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onNewIntent((Intent) args[0]);
-            }
-        }, intent);
+        };
+        superCall.call(intent);
     }
 
     public boolean onOptionsItemSelected(final MenuItem item) {
-        return callFunction("onOptionsItemSelected(MenuItem)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onOptionsItemSelected(item);
+        }
 
-                        return plugin.onOptionsItemSelected(superCall, (MenuItem) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
-                    }
-                }, item);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onOptionsItemSelected(MenuItem)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onOptionsItemSelected(this, (MenuItem) args[0]);
+                } else {
+                    return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
+                }
+            }
+        };
+        return superCall.call(item);
     }
 
     public void onOptionsMenuClosed(final Menu menu) {
-        callHook("onOptionsMenuClosed(Menu)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onOptionsMenuClosed(menu);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onOptionsMenuClosed(Menu)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onOptionsMenuClosed(superCall, (Menu) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onOptionsMenuClosed(this, (Menu) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
-            }
-        }, menu);
+        };
+        superCall.call(menu);
     }
 
     public void onPanelClosed(final int featureId, final Menu menu) {
-        callHook("onPanelClosed(int, Menu)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPanelClosed(featureId, menu);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onPanelClosed(int, Menu)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onPanelClosed(superCall, (int) args[0], (Menu) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPanelClosed(this, (int) args[0], (Menu) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onPanelClosed((int) args[0], (Menu) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPanelClosed((int) args[0], (Menu) args[1]);
-            }
-        }, featureId, menu);
+        };
+        superCall.call(featureId, menu);
     }
 
     public void onPause() {
-        callHook("onPause()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPause();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPause()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onPause(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPause(this);
+                    return null;
+                } else {
+                    getOriginal().super_onPause();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPause();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onPostCreate(final Bundle savedInstanceState,
             final PersistableBundle persistentState) {
-        callHook("onPostCreate(Bundle, PersistableBundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPostCreate(savedInstanceState, persistentState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onPostCreate(Bundle, PersistableBundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onPostCreate(superCall, (Bundle) args[0], (PersistableBundle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onPostCreate(this, (Bundle) args[0], (PersistableBundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onPostCreate((Bundle) args[0], (PersistableBundle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPostCreate((Bundle) args[0], (PersistableBundle) args[1]);
-            }
-        }, savedInstanceState, persistentState);
+        };
+        superCall.call(savedInstanceState, persistentState);
     }
 
     public void onPostCreate(@Nullable final Bundle savedInstanceState) {
-        callHook("onPostCreate(Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPostCreate(savedInstanceState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPostCreate(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onPostCreate(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPostCreate(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onPostCreate((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPostCreate((Bundle) args[0]);
-            }
-        }, savedInstanceState);
+        };
+        superCall.call(savedInstanceState);
     }
 
     public void onPostResume() {
-        callHook("onPostResume()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPostResume();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPostResume()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onPostResume(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPostResume(this);
+                    return null;
+                } else {
+                    getOriginal().super_onPostResume();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPostResume();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onPrepareDialog(final int id, final Dialog dialog) {
-        callHook("onPrepareDialog(int, Dialog)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPrepareDialog(id, dialog);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onPrepareDialog(int, Dialog)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onPrepareDialog(superCall, (int) args[0], (Dialog) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPrepareDialog(this, (int) args[0], (Dialog) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onPrepareDialog((int) args[0], (Dialog) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPrepareDialog((int) args[0], (Dialog) args[1]);
-            }
-        }, id, dialog);
+        };
+        superCall.call(id, dialog);
     }
 
     public void onPrepareDialog(final int id, final Dialog dialog, final Bundle args) {
-        callHook("onPrepareDialog(int, Dialog, Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPrepareDialog(id, dialog, args);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onPrepareDialog(int, Dialog, Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onPrepareDialog(superCall, (int) args[0], (Dialog) args[1],
-                        (Bundle) args[2]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPrepareDialog(this, (int) args[0], (Dialog) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_onPrepareDialog((int) args[0], (Dialog) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal()
-                        .super_onPrepareDialog((int) args[0], (Dialog) args[1], (Bundle) args[2]);
-            }
-        }, id, dialog, args);
+        };
+        superCall.call(id, dialog, args);
     }
 
     public void onPrepareNavigateUpTaskStack(final TaskStackBuilder builder) {
-        callHook("onPrepareNavigateUpTaskStack(TaskStackBuilder)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onPrepareNavigateUpTaskStack(superCall, (TaskStackBuilder) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_onPrepareNavigateUpTaskStack((TaskStackBuilder) args[0]);
-                    }
-                }, builder);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPrepareNavigateUpTaskStack(builder);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onPrepareNavigateUpTaskStack(TaskStackBuilder)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onPrepareNavigateUpTaskStack(this, (TaskStackBuilder) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onPrepareNavigateUpTaskStack((TaskStackBuilder) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(builder);
     }
 
     public boolean onPrepareOptionsMenu(final Menu menu) {
-        return callFunction("onPrepareOptionsMenu(Menu)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onPrepareOptionsMenu(menu);
+        }
 
-                        return plugin.onPrepareOptionsMenu(superCall, (Menu) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
-                    }
-                }, menu);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onPrepareOptionsMenu(Menu)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onPrepareOptionsMenu(this, (Menu) args[0]);
+                } else {
+                    return getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
+                }
+            }
+        };
+        return superCall.call(menu);
     }
 
     public boolean onPrepareOptionsPanel(final View view, final Menu menu) {
-        return callFunction("onPrepareOptionsPanel(View, Menu)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onPrepareOptionsPanel(view, menu);
+        }
 
-                        return plugin
-                                .onPrepareOptionsPanel(superCall, (View) args[0], (Menu) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_onPrepareOptionsPanel((View) args[0], (Menu) args[1]);
-                    }
-                }, view, menu);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onPrepareOptionsPanel(View, Menu)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onPrepareOptionsPanel(this, (View) args[0], (Menu) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_onPrepareOptionsPanel((View) args[0], (Menu) args[1]);
+                }
+            }
+        };
+        return superCall.call(view, menu);
     }
 
     public boolean onPreparePanel(final int featureId, final View view, final Menu menu) {
-        return callFunction("onPreparePanel(int, View, Menu)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onPreparePanel(featureId, view, menu);
+        }
 
-                        return plugin.onPreparePanel(superCall, (int) args[0], (View) args[1],
-                                (Menu) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onPreparePanel((int) args[0], (View) args[1],
-                                (Menu) args[2]);
-                    }
-                }, featureId, view, menu);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onPreparePanel(int, View, Menu)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onPreparePanel(this, (int) args[0], (View) args[1], (Menu) args[2]);
+                } else {
+                    return getOriginal()
+                            .super_onPreparePanel((int) args[0], (View) args[1], (Menu) args[2]);
+                }
+            }
+        };
+        return superCall.call(featureId, view, menu);
     }
 
     public void onPrepareSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
-        callHook("onPrepareSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onPrepareSupportNavigateUpTaskStack(superCall,
-                                (android.support.v4.app.TaskStackBuilder) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onPrepareSupportNavigateUpTaskStack(
-                                (android.support.v4.app.TaskStackBuilder) args[0]);
-                    }
-                }, builder);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPrepareSupportNavigateUpTaskStack(builder);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onPrepareSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPrepareSupportNavigateUpTaskStack(this,
+                            (android.support.v4.app.TaskStackBuilder) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onPrepareSupportNavigateUpTaskStack(
+                            (android.support.v4.app.TaskStackBuilder) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(builder);
     }
 
     public void onProvideAssistContent(final AssistContent outContent) {
-        callHook("onProvideAssistContent(AssistContent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onProvideAssistContent(outContent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onProvideAssistContent(AssistContent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onProvideAssistContent(superCall, (AssistContent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onProvideAssistContent(this, (AssistContent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onProvideAssistContent((AssistContent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onProvideAssistContent((AssistContent) args[0]);
-            }
-        }, outContent);
+        };
+        superCall.call(outContent);
     }
 
     public void onProvideAssistData(final Bundle data) {
-        callHook("onProvideAssistData(Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onProvideAssistData(data);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onProvideAssistData(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onProvideAssistData(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onProvideAssistData(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onProvideAssistData((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onProvideAssistData((Bundle) args[0]);
-            }
-        }, data);
+        };
+        superCall.call(data);
     }
 
     public Uri onProvideReferrer() {
-        return callFunction("onProvideReferrer()", new PluginCall<ActivityPlugin, Uri>() {
-            @Override
-            public Uri call(final NamedSuperCall<Uri> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onProvideReferrer();
+        }
 
-                return plugin.onProvideReferrer(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Uri>() {
+        final NamedSuperCall<Uri> superCall = new NamedSuperCall<Uri>("onProvideReferrer()") {
+
             @Override
             public Uri call(final Object... args) {
-                return getOriginal().super_onProvideReferrer();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onProvideReferrer(this);
+                } else {
+                    return getOriginal().super_onProvideReferrer();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        callHook("onRequestPermissionsResult(int, String[], int[])",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onRequestPermissionsResult(superCall, (int) args[0],
-                                (String[]) args[1], (int[]) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
-                                        (int[]) args[2]);
-                    }
-                }, requestCode, permissions, grantResults);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onRequestPermissionsResult(requestCode, permissions, grantResults);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onRequestPermissionsResult(int, String[], int[])") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onRequestPermissionsResult(this, (int) args[0], (String[]) args[1],
+                                    (int[]) args[2]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
+                                    (int[]) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(requestCode, permissions, grantResults);
     }
 
     public void onRestart() {
-        callHook("onRestart()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onRestart();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onRestart()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onRestart(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onRestart(this);
+                    return null;
+                } else {
+                    getOriginal().super_onRestart();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onRestart();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onRestoreInstanceState(final Bundle savedInstanceState,
             final PersistableBundle persistentState) {
-        callHook("onRestoreInstanceState(Bundle, PersistableBundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onRestoreInstanceState(superCall, (Bundle) args[0],
-                                (PersistableBundle) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onRestoreInstanceState((Bundle) args[0],
-                                (PersistableBundle) args[1]);
-                    }
-                }, savedInstanceState, persistentState);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onRestoreInstanceState(savedInstanceState, persistentState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onRestoreInstanceState(Bundle, PersistableBundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onRestoreInstanceState(this, (Bundle) args[0],
+                            (PersistableBundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onRestoreInstanceState((Bundle) args[0],
+                            (PersistableBundle) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(savedInstanceState, persistentState);
     }
 
     public void onRestoreInstanceState(final Bundle savedInstanceState) {
-        callHook("onRestoreInstanceState(Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onRestoreInstanceState(savedInstanceState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onRestoreInstanceState(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onRestoreInstanceState(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onRestoreInstanceState(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onRestoreInstanceState((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onRestoreInstanceState((Bundle) args[0]);
-            }
-        }, savedInstanceState);
+        };
+        superCall.call(savedInstanceState);
     }
 
     public void onResume() {
-        callHook("onResume()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onResume();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onResume()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onResume(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onResume(this);
+                    return null;
+                } else {
+                    getOriginal().super_onResume();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onResume();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onResumeFragments() {
-        callHook("onResumeFragments()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onResumeFragments();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onResumeFragments()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onResumeFragments(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onResumeFragments(this);
+                    return null;
+                } else {
+                    getOriginal().super_onResumeFragments();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onResumeFragments();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public Object onRetainNonConfigurationInstance() {
@@ -3373,2365 +4479,3484 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
         return all;
     }
 
-    final PluginCallVoid<ActivityPlugin> onSaveInstanceStatemethodCall = new PluginCallVoid<ActivityPlugin>() {
-        @Override
-        public void call(final NamedSuperCall<Void> superCall,
-                final ActivityPlugin plugin, final Object... args) {
-            plugin.onSaveInstanceState(superCall, (Bundle) args[0],
-                    (PersistableBundle) args[1]);
-        }
-    };
-    final SuperCallVoid onSaveInstantstateactivitySuper = new SuperCallVoid() {
-        @Override
-        public void call(final Object... args) {
-            getOriginal().super_onSaveInstanceState((Bundle) args[0],
-                    (PersistableBundle) args[1]);
-        }
-    };
     public void onSaveInstanceState(final Bundle outState,
             final PersistableBundle outPersistentState) {
-        callHook("onSaveInstanceState(Bundle, PersistableBundle)",
-                onSaveInstanceStatemethodCall, onSaveInstantstateactivitySuper, outState, outPersistentState);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onSaveInstanceState(outState, outPersistentState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onSaveInstanceState(Bundle, PersistableBundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onSaveInstanceState(this, (Bundle) args[0],
+                            (PersistableBundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onSaveInstanceState((Bundle) args[0],
+                            (PersistableBundle) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(outState, outPersistentState);
     }
 
-    final PluginCallVoid<ActivityPlugin> aslkfjawer = new PluginCallVoid<ActivityPlugin>() {
-        @Override
-        public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                final Object... args) {
-            plugin.onSaveInstanceState(superCall, (Bundle) args[0]);
-        }
-    };
-    final SuperCallVoid oisanfs = new SuperCallVoid() {
-        @Override
-        public void call(final Object... args) {
-            getOriginal().super_onSaveInstanceState((Bundle) args[0]);
-        }
-    };
     public void onSaveInstanceState(final Bundle outState) {
-        callHook("onSaveInstanceState(Bundle)", aslkfjawer, oisanfs, outState);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onSaveInstanceState(outState);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onSaveInstanceState(Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onSaveInstanceState(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onSaveInstanceState((Bundle) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(outState);
     }
 
     public boolean onSearchRequested(final SearchEvent searchEvent) {
-        return callFunction("onSearchRequested(SearchEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onSearchRequested(searchEvent);
+        }
 
-                        return plugin.onSearchRequested(superCall, (SearchEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onSearchRequested((SearchEvent) args[0]);
-                    }
-                }, searchEvent);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onSearchRequested(SearchEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onSearchRequested(this, (SearchEvent) args[0]);
+                } else {
+                    return getOriginal().super_onSearchRequested((SearchEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(searchEvent);
     }
 
     public boolean onSearchRequested() {
-        return callFunction("onSearchRequested()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onSearchRequested();
+        }
 
-                return plugin.onSearchRequested(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onSearchRequested()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onSearchRequested();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onSearchRequested(this);
+                } else {
+                    return getOriginal().super_onSearchRequested();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void onStart() {
-        callHook("onStart()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onStart();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStart()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onStart(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onStart(this);
+                    return null;
+                } else {
+                    getOriginal().super_onStart();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onStart();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onStateNotSaved() {
-        callHook("onStateNotSaved()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onStateNotSaved();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStateNotSaved()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onStateNotSaved(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onStateNotSaved(this);
+                    return null;
+                } else {
+                    getOriginal().super_onStateNotSaved();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onStateNotSaved();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onStop() {
-        callHook("onStop()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onStop();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStop()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onStop(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onStop(this);
+                    return null;
+                } else {
+                    getOriginal().super_onStop();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onStop();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onSupportActionModeFinished(@NonNull final ActionMode mode) {
-        callHook("onSupportActionModeFinished(ActionMode)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onSupportActionModeFinished(mode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onSupportActionModeFinished(ActionMode)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onSupportActionModeFinished(superCall, (ActionMode) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onSupportActionModeFinished(this, (ActionMode) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onSupportActionModeFinished((ActionMode) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onSupportActionModeFinished((ActionMode) args[0]);
-            }
-        }, mode);
+        };
+        superCall.call(mode);
     }
 
     public void onSupportActionModeStarted(@NonNull final ActionMode mode) {
-        callHook("onSupportActionModeStarted(ActionMode)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onSupportActionModeStarted(mode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onSupportActionModeStarted(ActionMode)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onSupportActionModeStarted(superCall, (ActionMode) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onSupportActionModeStarted(this, (ActionMode) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onSupportActionModeStarted((ActionMode) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onSupportActionModeStarted((ActionMode) args[0]);
-            }
-        }, mode);
+        };
+        superCall.call(mode);
     }
 
     public void onSupportContentChanged() {
-        callHook("onSupportContentChanged()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onSupportContentChanged();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onSupportContentChanged()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onSupportContentChanged(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onSupportContentChanged(this);
+                    return null;
+                } else {
+                    getOriginal().super_onSupportContentChanged();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onSupportContentChanged();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public boolean onSupportNavigateUp() {
-        return callFunction("onSupportNavigateUp()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onSupportNavigateUp();
+        }
 
-                return plugin.onSupportNavigateUp(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onSupportNavigateUp()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onSupportNavigateUp();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onSupportNavigateUp(this);
+                } else {
+                    return getOriginal().super_onSupportNavigateUp();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void onTitleChanged(final CharSequence title, final int color) {
-        callHook("onTitleChanged(CharSequence, int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onTitleChanged(title, color);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onTitleChanged(CharSequence, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onTitleChanged(superCall, (CharSequence) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onTitleChanged(this, (CharSequence) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onTitleChanged((CharSequence) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onTitleChanged((CharSequence) args[0], (int) args[1]);
-            }
-        }, title, color);
+        };
+        superCall.call(title, color);
     }
 
     public boolean onTouchEvent(final MotionEvent event) {
-        return callFunction("onTouchEvent(MotionEvent)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onTouchEvent(event);
+        }
 
-                return plugin.onTouchEvent(superCall, (MotionEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onTouchEvent(MotionEvent)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_onTouchEvent((MotionEvent) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onTouchEvent(this, (MotionEvent) args[0]);
+                } else {
+                    return getOriginal().super_onTouchEvent((MotionEvent) args[0]);
+                }
             }
-        }, event);
+        };
+        return superCall.call(event);
     }
 
     public boolean onTrackballEvent(final MotionEvent event) {
-        return callFunction("onTrackballEvent(MotionEvent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onTrackballEvent(event);
+        }
 
-                        return plugin.onTrackballEvent(superCall, (MotionEvent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onTrackballEvent((MotionEvent) args[0]);
-                    }
-                }, event);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onTrackballEvent(MotionEvent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onTrackballEvent(this, (MotionEvent) args[0]);
+                } else {
+                    return getOriginal().super_onTrackballEvent((MotionEvent) args[0]);
+                }
+            }
+        };
+        return superCall.call(event);
     }
 
     public void onTrimMemory(final int level) {
-        callHook("onTrimMemory(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onTrimMemory(level);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onTrimMemory(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onTrimMemory(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onTrimMemory(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onTrimMemory((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onTrimMemory((int) args[0]);
-            }
-        }, level);
+        };
+        superCall.call(level);
     }
 
     public void onUserInteraction() {
-        callHook("onUserInteraction()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onUserInteraction();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onUserInteraction()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onUserInteraction(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onUserInteraction(this);
+                    return null;
+                } else {
+                    getOriginal().super_onUserInteraction();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onUserInteraction();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onUserLeaveHint() {
-        callHook("onUserLeaveHint()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onUserLeaveHint();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onUserLeaveHint()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onUserLeaveHint(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onUserLeaveHint(this);
+                    return null;
+                } else {
+                    getOriginal().super_onUserLeaveHint();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onUserLeaveHint();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onVisibleBehindCanceled() {
-        callHook("onVisibleBehindCanceled()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onVisibleBehindCanceled();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onVisibleBehindCanceled()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onVisibleBehindCanceled(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onVisibleBehindCanceled(this);
+                    return null;
+                } else {
+                    getOriginal().super_onVisibleBehindCanceled();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onVisibleBehindCanceled();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onWindowAttributesChanged(final WindowManager.LayoutParams params) {
-        callHook("onWindowAttributesChanged(WindowManager.LayoutParams)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.onWindowAttributesChanged(superCall,
-                                (WindowManager.LayoutParams) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_onWindowAttributesChanged(
-                                (WindowManager.LayoutParams) args[0]);
-                    }
-                }, params);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onWindowAttributesChanged(params);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onWindowAttributesChanged(WindowManager.LayoutParams)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onWindowAttributesChanged(this, (WindowManager.LayoutParams) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_onWindowAttributesChanged((WindowManager.LayoutParams) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(params);
     }
 
     public void onWindowFocusChanged(final boolean hasFocus) {
-        callHook("onWindowFocusChanged(boolean)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onWindowFocusChanged(hasFocus);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onWindowFocusChanged(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.onWindowFocusChanged(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onWindowFocusChanged(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onWindowFocusChanged((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onWindowFocusChanged((boolean) args[0]);
-            }
-        }, hasFocus);
+        };
+        superCall.call(hasFocus);
     }
 
     public android.view.ActionMode onWindowStartingActionMode(
             final android.view.ActionMode.Callback callback) {
-        return callFunction("onWindowStartingActionMode(android.view.ActionMode.Callback)",
-                new PluginCall<ActivityPlugin, android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(
-                            final NamedSuperCall<android.view.ActionMode> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onWindowStartingActionMode(callback);
+        }
 
-                        return plugin.onWindowStartingActionMode(superCall,
-                                (android.view.ActionMode.Callback) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(final Object... args) {
-                        return getOriginal().super_onWindowStartingActionMode(
-                                (android.view.ActionMode.Callback) args[0]);
-                    }
-                }, callback);
+        final NamedSuperCall<android.view.ActionMode> superCall
+                = new NamedSuperCall<android.view.ActionMode>(
+                "onWindowStartingActionMode(android.view.ActionMode.Callback)") {
+
+            @Override
+            public android.view.ActionMode call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onWindowStartingActionMode(this,
+                            (android.view.ActionMode.Callback) args[0]);
+                } else {
+                    return getOriginal().super_onWindowStartingActionMode(
+                            (android.view.ActionMode.Callback) args[0]);
+                }
+            }
+        };
+        return superCall.call(callback);
     }
 
     public android.view.ActionMode onWindowStartingActionMode(
             final android.view.ActionMode.Callback callback, final int type) {
-        return callFunction("onWindowStartingActionMode(android.view.ActionMode.Callback, int)",
-                new PluginCall<ActivityPlugin, android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(
-                            final NamedSuperCall<android.view.ActionMode> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onWindowStartingActionMode(callback, type);
+        }
 
-                        return plugin.onWindowStartingActionMode(superCall,
-                                (android.view.ActionMode.Callback) args[0], (int) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(final Object... args) {
-                        return getOriginal().super_onWindowStartingActionMode(
-                                (android.view.ActionMode.Callback) args[0], (int) args[1]);
-                    }
-                }, callback, type);
+        final NamedSuperCall<android.view.ActionMode> superCall
+                = new NamedSuperCall<android.view.ActionMode>(
+                "onWindowStartingActionMode(android.view.ActionMode.Callback, int)") {
+
+            @Override
+            public android.view.ActionMode call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onWindowStartingActionMode(this,
+                            (android.view.ActionMode.Callback) args[0], (int) args[1]);
+                } else {
+                    return getOriginal().super_onWindowStartingActionMode(
+                            (android.view.ActionMode.Callback) args[0], (int) args[1]);
+                }
+            }
+        };
+        return superCall.call(callback, type);
     }
 
     public ActionMode onWindowStartingSupportActionMode(
             @NonNull final ActionMode.Callback callback) {
-        return callFunction("onWindowStartingSupportActionMode(ActionMode.Callback)",
-                new PluginCall<ActivityPlugin, ActionMode>() {
-                    @Override
-                    public ActionMode call(final NamedSuperCall<ActionMode> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onWindowStartingSupportActionMode(callback);
+        }
 
-                        return plugin.onWindowStartingSupportActionMode(superCall,
-                                (ActionMode.Callback) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<ActionMode>() {
-                    @Override
-                    public ActionMode call(final Object... args) {
-                        return getOriginal().super_onWindowStartingSupportActionMode(
-                                (ActionMode.Callback) args[0]);
-                    }
-                }, callback);
+        final NamedSuperCall<ActionMode> superCall = new NamedSuperCall<ActionMode>(
+                "onWindowStartingSupportActionMode(ActionMode.Callback)") {
+
+            @Override
+            public ActionMode call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onWindowStartingSupportActionMode(this, (ActionMode.Callback) args[0]);
+                } else {
+                    return getOriginal()
+                            .super_onWindowStartingSupportActionMode((ActionMode.Callback) args[0]);
+                }
+            }
+        };
+        return superCall.call(callback);
     }
 
     public void openContextMenu(final View view) {
-        callHook("openContextMenu(View)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_openContextMenu(view);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("openContextMenu(View)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.openContextMenu(superCall, (View) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().openContextMenu(this, (View) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_openContextMenu((View) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_openContextMenu((View) args[0]);
-            }
-        }, view);
+        };
+        superCall.call(view);
     }
 
-    public FileInputStream openFileInput(final String name) {
-        return callFunction("openFileInput(String)",
-                new PluginCall<ActivityPlugin, FileInputStream>() {
-                    @Override
-                    public FileInputStream call(final NamedSuperCall<FileInputStream> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            return plugin.openFileInput(superCall, (String) args[0]);
-                        } catch (FileNotFoundException e) {
-                            throw new SuppressedException(e);
-                        }
+    public FileInputStream openFileInput(final String name) throws FileNotFoundException {
+        if (mPlugins.isEmpty()) {
+            try {
+                return getOriginal().super_openFileInput(name);
+            } catch (FileNotFoundException e) {
+                throw new SuppressedException(e);
+            }
+        }
 
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<FileInputStream> superCall = new NamedSuperCall<FileInputStream>(
+                "openFileInput(String)") {
+
+            @Override
+            public FileInputStream call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        return iterator.previous().openFileInput(this, (String) args[0]);
+                    } catch (FileNotFoundException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCall<FileInputStream>() {
-                    @Override
-                    public FileInputStream call(final Object... args) {
-                        try {
-                            return getOriginal().super_openFileInput((String) args[0]);
-                        } catch (FileNotFoundException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        return getOriginal().super_openFileInput((String) args[0]);
+                    } catch (FileNotFoundException e) {
+                        throw new SuppressedException(e);
                     }
-                }, name);
+                }
+            }
+        };
+        return superCall.call(name);
     }
 
-    public FileOutputStream openFileOutput(final String name, final int mode) {
-        return callFunction("openFileOutput(String, int)",
-                new PluginCall<ActivityPlugin, FileOutputStream>() {
-                    @Override
-                    public FileOutputStream call(final NamedSuperCall<FileOutputStream> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            return plugin
-                                    .openFileOutput(superCall, (String) args[0], (int) args[1]);
-                        } catch (FileNotFoundException e) {
-                            throw new SuppressedException(e);
-                        }
+    public FileOutputStream openFileOutput(final String name, final int mode)
+            throws FileNotFoundException {
+        if (mPlugins.isEmpty()) {
+            try {
+                return getOriginal().super_openFileOutput(name, mode);
+            } catch (FileNotFoundException e) {
+                throw new SuppressedException(e);
+            }
+        }
 
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<FileOutputStream> superCall = new NamedSuperCall<FileOutputStream>(
+                "openFileOutput(String, int)") {
+
+            @Override
+            public FileOutputStream call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        return iterator.previous()
+                                .openFileOutput(this, (String) args[0], (int) args[1]);
+                    } catch (FileNotFoundException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCall<FileOutputStream>() {
-                    @Override
-                    public FileOutputStream call(final Object... args) {
-                        try {
-                            return getOriginal()
-                                    .super_openFileOutput((String) args[0], (int) args[1]);
-                        } catch (FileNotFoundException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        return getOriginal().super_openFileOutput((String) args[0], (int) args[1]);
+                    } catch (FileNotFoundException e) {
+                        throw new SuppressedException(e);
                     }
-                }, name, mode);
+                }
+            }
+        };
+        return superCall.call(name, mode);
     }
 
     public void openOptionsMenu() {
-        callHook("openOptionsMenu()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_openOptionsMenu();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("openOptionsMenu()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.openOptionsMenu(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().openOptionsMenu(this);
+                    return null;
+                } else {
+                    getOriginal().super_openOptionsMenu();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_openOptionsMenu();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory) {
-        return callFunction("openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory)",
-                new PluginCall<ActivityPlugin, SQLiteDatabase>() {
-                    @Override
-                    public SQLiteDatabase call(final NamedSuperCall<SQLiteDatabase> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_openOrCreateDatabase(name, mode, factory);
+        }
 
-                        return plugin
-                                .openOrCreateDatabase(superCall, (String) args[0], (int) args[1],
-                                        (SQLiteDatabase.CursorFactory) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<SQLiteDatabase>() {
-                    @Override
-                    public SQLiteDatabase call(final Object... args) {
-                        return getOriginal()
-                                .super_openOrCreateDatabase((String) args[0], (int) args[1],
-                                        (SQLiteDatabase.CursorFactory) args[2]);
-                    }
-                }, name, mode, factory);
+        final NamedSuperCall<SQLiteDatabase> superCall = new NamedSuperCall<SQLiteDatabase>(
+                "openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory)") {
+
+            @Override
+            public SQLiteDatabase call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .openOrCreateDatabase(this, (String) args[0], (int) args[1],
+                                    (SQLiteDatabase.CursorFactory) args[2]);
+                } else {
+                    return getOriginal().super_openOrCreateDatabase((String) args[0], (int) args[1],
+                            (SQLiteDatabase.CursorFactory) args[2]);
+                }
+            }
+        };
+        return superCall.call(name, mode, factory);
     }
 
     public SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler) {
-        return callFunction(
-                "openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)",
-                new PluginCall<ActivityPlugin, SQLiteDatabase>() {
-                    @Override
-                    public SQLiteDatabase call(final NamedSuperCall<SQLiteDatabase> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_openOrCreateDatabase(name, mode, factory, errorHandler);
+        }
 
-                        return plugin
-                                .openOrCreateDatabase(superCall, (String) args[0], (int) args[1],
-                                        (SQLiteDatabase.CursorFactory) args[2],
-                                        (DatabaseErrorHandler) args[3]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<SQLiteDatabase>() {
-                    @Override
-                    public SQLiteDatabase call(final Object... args) {
-                        return getOriginal()
-                                .super_openOrCreateDatabase((String) args[0], (int) args[1],
-                                        (SQLiteDatabase.CursorFactory) args[2],
-                                        (DatabaseErrorHandler) args[3]);
-                    }
-                }, name, mode, factory, errorHandler);
+        final NamedSuperCall<SQLiteDatabase> superCall = new NamedSuperCall<SQLiteDatabase>(
+                "openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)") {
+
+            @Override
+            public SQLiteDatabase call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .openOrCreateDatabase(this, (String) args[0], (int) args[1],
+                                    (SQLiteDatabase.CursorFactory) args[2],
+                                    (DatabaseErrorHandler) args[3]);
+                } else {
+                    return getOriginal().super_openOrCreateDatabase((String) args[0], (int) args[1],
+                            (SQLiteDatabase.CursorFactory) args[2], (DatabaseErrorHandler) args[3]);
+                }
+            }
+        };
+        return superCall.call(name, mode, factory, errorHandler);
     }
 
     public void overridePendingTransition(final int enterAnim, final int exitAnim) {
-        callHook("overridePendingTransition(int, int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_overridePendingTransition(enterAnim, exitAnim);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "overridePendingTransition(int, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.overridePendingTransition(superCall, (int) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .overridePendingTransition(this, (int) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_overridePendingTransition((int) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_overridePendingTransition((int) args[0], (int) args[1]);
-            }
-        }, enterAnim, exitAnim);
+        };
+        superCall.call(enterAnim, exitAnim);
     }
 
     public Drawable peekWallpaper() {
-        return callFunction("peekWallpaper()", new PluginCall<ActivityPlugin, Drawable>() {
-            @Override
-            public Drawable call(final NamedSuperCall<Drawable> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_peekWallpaper();
+        }
 
-                return plugin.peekWallpaper(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Drawable>() {
+        final NamedSuperCall<Drawable> superCall = new NamedSuperCall<Drawable>("peekWallpaper()") {
+
             @Override
             public Drawable call(final Object... args) {
-                return getOriginal().super_peekWallpaper();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().peekWallpaper(this);
+                } else {
+                    return getOriginal().super_peekWallpaper();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void postponeEnterTransition() {
-        callHook("postponeEnterTransition()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_postponeEnterTransition();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "postponeEnterTransition()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.postponeEnterTransition(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().postponeEnterTransition(this);
+                    return null;
+                } else {
+                    getOriginal().super_postponeEnterTransition();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_postponeEnterTransition();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void recreate() {
-        callHook("recreate()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_recreate();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("recreate()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.recreate(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().recreate(this);
+                    return null;
+                } else {
+                    getOriginal().super_recreate();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_recreate();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void registerComponentCallbacks(final ComponentCallbacks callback) {
-        callHook("registerComponentCallbacks(ComponentCallbacks)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.registerComponentCallbacks(superCall, (ComponentCallbacks) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_registerComponentCallbacks((ComponentCallbacks) args[0]);
-                    }
-                }, callback);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_registerComponentCallbacks(callback);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "registerComponentCallbacks(ComponentCallbacks)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .registerComponentCallbacks(this, (ComponentCallbacks) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_registerComponentCallbacks((ComponentCallbacks) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(callback);
     }
 
     public void registerForContextMenu(final View view) {
-        callHook("registerForContextMenu(View)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_registerForContextMenu(view);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "registerForContextMenu(View)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.registerForContextMenu(superCall, (View) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().registerForContextMenu(this, (View) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_registerForContextMenu((View) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_registerForContextMenu((View) args[0]);
-            }
-        }, view);
+        };
+        superCall.call(view);
     }
 
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter) {
-        return callFunction("registerReceiver(BroadcastReceiver, IntentFilter)",
-                new PluginCall<ActivityPlugin, Intent>() {
-                    @Override
-                    public Intent call(final NamedSuperCall<Intent> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_registerReceiver(receiver, filter);
+        }
 
-                        return plugin.registerReceiver(superCall, (BroadcastReceiver) args[0],
-                                (IntentFilter) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Intent>() {
-                    @Override
-                    public Intent call(final Object... args) {
-                        return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
-                                (IntentFilter) args[1]);
-                    }
-                }, receiver, filter);
+        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
+                "registerReceiver(BroadcastReceiver, IntentFilter)") {
+
+            @Override
+            public Intent call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().registerReceiver(this, (BroadcastReceiver) args[0],
+                            (IntentFilter) args[1]);
+                } else {
+                    return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
+                            (IntentFilter) args[1]);
+                }
+            }
+        };
+        return superCall.call(receiver, filter);
     }
 
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter,
             final String broadcastPermission, final Handler scheduler) {
-        return callFunction("registerReceiver(BroadcastReceiver, IntentFilter, String, Handler)",
-                new PluginCall<ActivityPlugin, Intent>() {
-                    @Override
-                    public Intent call(final NamedSuperCall<Intent> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal()
+                    .super_registerReceiver(receiver, filter, broadcastPermission, scheduler);
+        }
 
-                        return plugin.registerReceiver(superCall, (BroadcastReceiver) args[0],
-                                (IntentFilter) args[1], (String) args[2], (Handler) args[3]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Intent>() {
-                    @Override
-                    public Intent call(final Object... args) {
-                        return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
-                                (IntentFilter) args[1], (String) args[2], (Handler) args[3]);
-                    }
-                }, receiver, filter, broadcastPermission, scheduler);
+        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
+                "registerReceiver(BroadcastReceiver, IntentFilter, String, Handler)") {
+
+            @Override
+            public Intent call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().registerReceiver(this, (BroadcastReceiver) args[0],
+                            (IntentFilter) args[1], (String) args[2], (Handler) args[3]);
+                } else {
+                    return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
+                            (IntentFilter) args[1], (String) args[2], (Handler) args[3]);
+                }
+            }
+        };
+        return superCall.call(receiver, filter, broadcastPermission, scheduler);
     }
 
     public boolean releaseInstance() {
-        return callFunction("releaseInstance()", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_releaseInstance();
+        }
 
-                return plugin.releaseInstance(superCall);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("releaseInstance()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_releaseInstance();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().releaseInstance(this);
+                } else {
+                    return getOriginal().super_releaseInstance();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void removeStickyBroadcast(final Intent intent) {
-        callHook("removeStickyBroadcast(Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_removeStickyBroadcast(intent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "removeStickyBroadcast(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.removeStickyBroadcast(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().removeStickyBroadcast(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_removeStickyBroadcast((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_removeStickyBroadcast((Intent) args[0]);
-            }
-        }, intent);
+        };
+        superCall.call(intent);
     }
 
     public void removeStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
-        callHook("removeStickyBroadcastAsUser(Intent, UserHandle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.removeStickyBroadcastAsUser(superCall, (Intent) args[0],
-                                (UserHandle) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_removeStickyBroadcastAsUser((Intent) args[0],
-                                (UserHandle) args[1]);
-                    }
-                }, intent, user);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_removeStickyBroadcastAsUser(intent, user);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "removeStickyBroadcastAsUser(Intent, UserHandle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().removeStickyBroadcastAsUser(this, (Intent) args[0],
+                            (UserHandle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_removeStickyBroadcastAsUser((Intent) args[0],
+                            (UserHandle) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, user);
     }
 
     public void reportFullyDrawn() {
-        callHook("reportFullyDrawn()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_reportFullyDrawn();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("reportFullyDrawn()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.reportFullyDrawn(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().reportFullyDrawn(this);
+                    return null;
+                } else {
+                    getOriginal().super_reportFullyDrawn();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_reportFullyDrawn();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public boolean requestVisibleBehind(final boolean visible) {
-        return callFunction("requestVisibleBehind(boolean)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_requestVisibleBehind(visible);
+        }
 
-                        return plugin.requestVisibleBehind(superCall, (boolean) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_requestVisibleBehind((boolean) args[0]);
-                    }
-                }, visible);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "requestVisibleBehind(boolean)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().requestVisibleBehind(this, (boolean) args[0]);
+                } else {
+                    return getOriginal().super_requestVisibleBehind((boolean) args[0]);
+                }
+            }
+        };
+        return superCall.call(visible);
     }
 
     public void revokeUriPermission(final Uri uri, final int modeFlags) {
-        callHook("revokeUriPermission(Uri, int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_revokeUriPermission(uri, modeFlags);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "revokeUriPermission(Uri, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.revokeUriPermission(superCall, (Uri) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().revokeUriPermission(this, (Uri) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_revokeUriPermission((Uri) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_revokeUriPermission((Uri) args[0], (int) args[1]);
-            }
-        }, uri, modeFlags);
+        };
+        superCall.call(uri, modeFlags);
     }
 
     public void sendBroadcast(final Intent intent) {
-        callHook("sendBroadcast(Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendBroadcast(intent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("sendBroadcast(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.sendBroadcast(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().sendBroadcast(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_sendBroadcast((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_sendBroadcast((Intent) args[0]);
-            }
-        }, intent);
+        };
+        superCall.call(intent);
     }
 
     public void sendBroadcast(final Intent intent, final String receiverPermission) {
-        callHook("sendBroadcast(Intent, String)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendBroadcast(intent, receiverPermission);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendBroadcast(Intent, String)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.sendBroadcast(superCall, (Intent) args[0], (String) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().sendBroadcast(this, (Intent) args[0], (String) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_sendBroadcast((Intent) args[0], (String) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_sendBroadcast((Intent) args[0], (String) args[1]);
-            }
-        }, intent, receiverPermission);
+        };
+        superCall.call(intent, receiverPermission);
     }
 
     public void sendBroadcastAsUser(final Intent intent, final UserHandle user) {
-        callHook("sendBroadcastAsUser(Intent, UserHandle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendBroadcastAsUser(intent, user);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendBroadcastAsUser(Intent, UserHandle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.sendBroadcastAsUser(superCall, (Intent) args[0], (UserHandle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .sendBroadcastAsUser(this, (Intent) args[0], (UserHandle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1]);
-            }
-        }, intent, user);
+        };
+        superCall.call(intent, user);
     }
 
     public void sendBroadcastAsUser(final Intent intent, final UserHandle user,
             final String receiverPermission) {
-        callHook("sendBroadcastAsUser(Intent, UserHandle, String)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.sendBroadcastAsUser(superCall, (Intent) args[0],
-                                (UserHandle) args[1], (String) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1],
-                                        (String) args[2]);
-                    }
-                }, intent, user, receiverPermission);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendBroadcastAsUser(intent, user, receiverPermission);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendBroadcastAsUser(Intent, UserHandle, String)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .sendBroadcastAsUser(this, (Intent) args[0], (UserHandle) args[1],
+                                    (String) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1],
+                            (String) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, user, receiverPermission);
     }
 
     public void sendOrderedBroadcast(final Intent intent, final String receiverPermission) {
-        callHook("sendOrderedBroadcast(Intent, String)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendOrderedBroadcast(intent, receiverPermission);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendOrderedBroadcast(Intent, String)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.sendOrderedBroadcast(superCall, (Intent) args[0], (String) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .sendOrderedBroadcast(this, (Intent) args[0], (String) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1]);
-            }
-        }, intent, receiverPermission);
+        };
+        superCall.call(intent, receiverPermission);
     }
 
     public void sendOrderedBroadcast(final Intent intent, final String receiverPermission,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
-        callHook(
-                "sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, int, String, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.sendOrderedBroadcast(superCall, (Intent) args[0], (String) args[1],
-                                (BroadcastReceiver) args[2], (Handler) args[3], (int) args[4],
-                                (String) args[5], (Bundle) args[6]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1],
-                                (BroadcastReceiver) args[2], (Handler) args[3], (int) args[4],
-                                (String) args[5], (Bundle) args[6]);
-                    }
-                }, intent, receiverPermission, resultReceiver, scheduler, initialCode, initialData,
-                initialExtras);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendOrderedBroadcast(intent, receiverPermission, resultReceiver,
+                    scheduler, initialCode, initialData, initialExtras);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, int, String, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .sendOrderedBroadcast(this, (Intent) args[0], (String) args[1],
+                                    (BroadcastReceiver) args[2], (Handler) args[3], (int) args[4],
+                                    (String) args[5], (Bundle) args[6]);
+                    return null;
+                } else {
+                    getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1],
+                            (BroadcastReceiver) args[2], (Handler) args[3], (int) args[4],
+                            (String) args[5], (Bundle) args[6]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, receiverPermission, resultReceiver, scheduler, initialCode,
+                initialData, initialExtras);
     }
 
     public void sendOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
             final String receiverPermission, final BroadcastReceiver resultReceiver,
             final Handler scheduler, final int initialCode, final String initialData,
             final Bundle initialExtras) {
-        callHook(
-                "sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, int, String, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.sendOrderedBroadcastAsUser(superCall, (Intent) args[0],
-                                (UserHandle) args[1], (String) args[2], (BroadcastReceiver) args[3],
-                                (Handler) args[4], (int) args[5], (String) args[6],
-                                (Bundle) args[7]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_sendOrderedBroadcastAsUser((Intent) args[0],
-                                (UserHandle) args[1], (String) args[2], (BroadcastReceiver) args[3],
-                                (Handler) args[4], (int) args[5], (String) args[6],
-                                (Bundle) args[7]);
-                    }
-                }, intent, user, receiverPermission, resultReceiver, scheduler, initialCode,
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendOrderedBroadcastAsUser(intent, user, receiverPermission,
+                    resultReceiver, scheduler, initialCode, initialData, initialExtras);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, int, String, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().sendOrderedBroadcastAsUser(this, (Intent) args[0],
+                            (UserHandle) args[1], (String) args[2], (BroadcastReceiver) args[3],
+                            (Handler) args[4], (int) args[5], (String) args[6], (Bundle) args[7]);
+                    return null;
+                } else {
+                    getOriginal().super_sendOrderedBroadcastAsUser((Intent) args[0],
+                            (UserHandle) args[1], (String) args[2], (BroadcastReceiver) args[3],
+                            (Handler) args[4], (int) args[5], (String) args[6], (Bundle) args[7]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, user, receiverPermission, resultReceiver, scheduler, initialCode,
                 initialData, initialExtras);
     }
 
     public void sendStickyBroadcast(final Intent intent) {
-        callHook("sendStickyBroadcast(Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendStickyBroadcast(intent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendStickyBroadcast(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.sendStickyBroadcast(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().sendStickyBroadcast(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_sendStickyBroadcast((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_sendStickyBroadcast((Intent) args[0]);
-            }
-        }, intent);
+        };
+        superCall.call(intent);
     }
 
     public void sendStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
-        callHook("sendStickyBroadcastAsUser(Intent, UserHandle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.sendStickyBroadcastAsUser(superCall, (Intent) args[0],
-                                (UserHandle) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_sendStickyBroadcastAsUser((Intent) args[0],
-                                (UserHandle) args[1]);
-                    }
-                }, intent, user);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendStickyBroadcastAsUser(intent, user);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendStickyBroadcastAsUser(Intent, UserHandle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().sendStickyBroadcastAsUser(this, (Intent) args[0],
+                            (UserHandle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_sendStickyBroadcastAsUser((Intent) args[0],
+                            (UserHandle) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, user);
     }
 
     public void sendStickyOrderedBroadcast(final Intent intent,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
-        callHook(
-                "sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, int, String, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.sendStickyOrderedBroadcast(superCall, (Intent) args[0],
-                                (BroadcastReceiver) args[1], (Handler) args[2], (int) args[3],
-                                (String) args[4], (Bundle) args[5]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_sendStickyOrderedBroadcast((Intent) args[0],
-                                (BroadcastReceiver) args[1], (Handler) args[2], (int) args[3],
-                                (String) args[4], (Bundle) args[5]);
-                    }
-                }, intent, resultReceiver, scheduler, initialCode, initialData, initialExtras);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_sendStickyOrderedBroadcast(intent, resultReceiver, scheduler,
+                    initialCode, initialData, initialExtras);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, int, String, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().sendStickyOrderedBroadcast(this, (Intent) args[0],
+                            (BroadcastReceiver) args[1], (Handler) args[2], (int) args[3],
+                            (String) args[4], (Bundle) args[5]);
+                    return null;
+                } else {
+                    getOriginal().super_sendStickyOrderedBroadcast((Intent) args[0],
+                            (BroadcastReceiver) args[1], (Handler) args[2], (int) args[3],
+                            (String) args[4], (Bundle) args[5]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, resultReceiver, scheduler, initialCode, initialData, initialExtras);
     }
 
     public void sendStickyOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
-        callHook(
-                "sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, int, String, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.sendStickyOrderedBroadcastAsUser(superCall, (Intent) args[0],
-                                (UserHandle) args[1], (BroadcastReceiver) args[2],
-                                (Handler) args[3], (int) args[4], (String) args[5],
-                                (Bundle) args[6]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_sendStickyOrderedBroadcastAsUser((Intent) args[0],
-                                (UserHandle) args[1], (BroadcastReceiver) args[2],
-                                (Handler) args[3], (int) args[4], (String) args[5],
-                                (Bundle) args[6]);
-                    }
-                }, intent, user, resultReceiver, scheduler, initialCode, initialData,
+        if (mPlugins.isEmpty()) {
+            getOriginal()
+                    .super_sendStickyOrderedBroadcastAsUser(intent, user, resultReceiver, scheduler,
+                            initialCode, initialData, initialExtras);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, int, String, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().sendStickyOrderedBroadcastAsUser(this, (Intent) args[0],
+                            (UserHandle) args[1], (BroadcastReceiver) args[2], (Handler) args[3],
+                            (int) args[4], (String) args[5], (Bundle) args[6]);
+                    return null;
+                } else {
+                    getOriginal().super_sendStickyOrderedBroadcastAsUser((Intent) args[0],
+                            (UserHandle) args[1], (BroadcastReceiver) args[2], (Handler) args[3],
+                            (int) args[4], (String) args[5], (Bundle) args[6]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, user, resultReceiver, scheduler, initialCode, initialData,
                 initialExtras);
     }
 
     public void setActionBar(final Toolbar toolbar) {
-        callHook("setActionBar(Toolbar)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setActionBar(toolbar);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setActionBar(Toolbar)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setActionBar(superCall, (Toolbar) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setActionBar(this, (Toolbar) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setActionBar((Toolbar) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setActionBar((Toolbar) args[0]);
-            }
-        }, toolbar);
+        };
+        superCall.call(toolbar);
     }
 
     public void setContentTransitionManager(final TransitionManager tm) {
-        callHook("setContentTransitionManager(TransitionManager)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setContentTransitionManager(superCall, (TransitionManager) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_setContentTransitionManager((TransitionManager) args[0]);
-                    }
-                }, tm);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setContentTransitionManager(tm);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setContentTransitionManager(TransitionManager)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setContentTransitionManager(this, (TransitionManager) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setContentTransitionManager((TransitionManager) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(tm);
     }
 
     public void setContentView(@LayoutRes final int layoutResID) {
-        callHook("setContentView(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setContentView(layoutResID);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setContentView(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setContentView(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setContentView(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setContentView((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setContentView((int) args[0]);
-            }
-        }, layoutResID);
+        };
+        superCall.call(layoutResID);
     }
 
     public void setContentView(final View view) {
-        callHook("setContentView(View)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setContentView(view);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setContentView(View)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setContentView(superCall, (View) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setContentView(this, (View) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setContentView((View) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setContentView((View) args[0]);
-            }
-        }, view);
+        };
+        superCall.call(view);
     }
 
     public void setContentView(final View view, final ViewGroup.LayoutParams params) {
-        callHook("setContentView(View, ViewGroup.LayoutParams)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setContentView(superCall, (View) args[0],
-                                (ViewGroup.LayoutParams) args[1]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setContentView((View) args[0],
-                                (ViewGroup.LayoutParams) args[1]);
-                    }
-                }, view, params);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setContentView(view, params);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setContentView(View, ViewGroup.LayoutParams)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setContentView(this, (View) args[0], (ViewGroup.LayoutParams) args[1]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setContentView((View) args[0], (ViewGroup.LayoutParams) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(view, params);
     }
 
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
-        callHook("setEnterSharedElementCallback(SharedElementCallback)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setEnterSharedElementCallback(superCall,
-                                (SharedElementCallback) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setEnterSharedElementCallback(
-                                (SharedElementCallback) args[0]);
-                    }
-                }, callback);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setEnterSharedElementCallback(callback);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setEnterSharedElementCallback(SharedElementCallback)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setEnterSharedElementCallback(this, (SharedElementCallback) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setEnterSharedElementCallback((SharedElementCallback) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(callback);
     }
 
     public void setEnterSharedElementCallback(final android.app.SharedElementCallback callback) {
-        callHook("setEnterSharedElementCallback(android.app.SharedElementCallback)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setEnterSharedElementCallback(superCall,
-                                (android.app.SharedElementCallback) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setEnterSharedElementCallback(
-                                (android.app.SharedElementCallback) args[0]);
-                    }
-                }, callback);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setEnterSharedElementCallback(callback);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setEnterSharedElementCallback(android.app.SharedElementCallback)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setEnterSharedElementCallback(this,
+                            (android.app.SharedElementCallback) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setEnterSharedElementCallback(
+                            (android.app.SharedElementCallback) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(callback);
     }
 
     public void setExitSharedElementCallback(final SharedElementCallback listener) {
-        callHook("setExitSharedElementCallback(SharedElementCallback)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setExitSharedElementCallback(superCall,
-                                (SharedElementCallback) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setExitSharedElementCallback(
-                                (SharedElementCallback) args[0]);
-                    }
-                }, listener);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setExitSharedElementCallback(listener);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setExitSharedElementCallback(SharedElementCallback)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setExitSharedElementCallback(this, (SharedElementCallback) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setExitSharedElementCallback((SharedElementCallback) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(listener);
     }
 
     public void setExitSharedElementCallback(final android.app.SharedElementCallback callback) {
-        callHook("setExitSharedElementCallback(android.app.SharedElementCallback)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setExitSharedElementCallback(superCall,
-                                (android.app.SharedElementCallback) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setExitSharedElementCallback(
-                                (android.app.SharedElementCallback) args[0]);
-                    }
-                }, callback);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setExitSharedElementCallback(callback);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setExitSharedElementCallback(android.app.SharedElementCallback)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setExitSharedElementCallback(this,
+                            (android.app.SharedElementCallback) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setExitSharedElementCallback(
+                            (android.app.SharedElementCallback) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(callback);
     }
 
     public void setFinishOnTouchOutside(final boolean finish) {
-        callHook("setFinishOnTouchOutside(boolean)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setFinishOnTouchOutside(finish);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setFinishOnTouchOutside(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setFinishOnTouchOutside(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setFinishOnTouchOutside(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setFinishOnTouchOutside((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setFinishOnTouchOutside((boolean) args[0]);
-            }
-        }, finish);
+        };
+        superCall.call(finish);
     }
 
     public void setImmersive(final boolean i) {
-        callHook("setImmersive(boolean)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setImmersive(i);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setImmersive(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setImmersive(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setImmersive(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setImmersive((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setImmersive((boolean) args[0]);
-            }
-        }, i);
+        };
+        superCall.call(i);
     }
 
     public void setIntent(final Intent newIntent) {
-        callHook("setIntent(Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setIntent(newIntent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setIntent(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setIntent(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setIntent(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setIntent((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setIntent((Intent) args[0]);
-            }
-        }, newIntent);
+        };
+        superCall.call(newIntent);
     }
 
     public void setRequestedOrientation(final int requestedOrientation) {
-        callHook("setRequestedOrientation(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setRequestedOrientation(requestedOrientation);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setRequestedOrientation(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setRequestedOrientation(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setRequestedOrientation(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setRequestedOrientation((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setRequestedOrientation((int) args[0]);
-            }
-        }, requestedOrientation);
+        };
+        superCall.call(requestedOrientation);
     }
 
     public void setSupportActionBar(@Nullable final android.support.v7.widget.Toolbar toolbar) {
-        callHook("setSupportActionBar(android.support.v7.widget.Toolbar)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setSupportActionBar(superCall,
-                                (android.support.v7.widget.Toolbar) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setSupportActionBar(
-                                (android.support.v7.widget.Toolbar) args[0]);
-                    }
-                }, toolbar);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setSupportActionBar(toolbar);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setSupportActionBar(android.support.v7.widget.Toolbar)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setSupportActionBar(this, (android.support.v7.widget.Toolbar) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setSupportActionBar((android.support.v7.widget.Toolbar) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(toolbar);
     }
 
     public void setSupportProgress(final int progress) {
-        callHook("setSupportProgress(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setSupportProgress(progress);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setSupportProgress(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setSupportProgress(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setSupportProgress(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setSupportProgress((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setSupportProgress((int) args[0]);
-            }
-        }, progress);
+        };
+        superCall.call(progress);
     }
 
     public void setSupportProgressBarIndeterminate(final boolean indeterminate) {
-        callHook("setSupportProgressBarIndeterminate(boolean)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setSupportProgressBarIndeterminate(superCall, (boolean) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setSupportProgressBarIndeterminate((boolean) args[0]);
-                    }
-                }, indeterminate);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setSupportProgressBarIndeterminate(indeterminate);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setSupportProgressBarIndeterminate(boolean)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setSupportProgressBarIndeterminate(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setSupportProgressBarIndeterminate((boolean) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(indeterminate);
     }
 
     public void setSupportProgressBarIndeterminateVisibility(final boolean visible) {
-        callHook("setSupportProgressBarIndeterminateVisibility(boolean)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setSupportProgressBarIndeterminateVisibility(superCall,
-                                (boolean) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setSupportProgressBarIndeterminateVisibility(
-                                (boolean) args[0]);
-                    }
-                }, visible);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setSupportProgressBarIndeterminateVisibility(visible);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setSupportProgressBarIndeterminateVisibility(boolean)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setSupportProgressBarIndeterminateVisibility(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setSupportProgressBarIndeterminateVisibility((boolean) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(visible);
     }
 
     public void setSupportProgressBarVisibility(final boolean visible) {
-        callHook("setSupportProgressBarVisibility(boolean)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setSupportProgressBarVisibility(visible);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setSupportProgressBarVisibility(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setSupportProgressBarVisibility(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setSupportProgressBarVisibility(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setSupportProgressBarVisibility((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setSupportProgressBarVisibility((boolean) args[0]);
-            }
-        }, visible);
+        };
+        superCall.call(visible);
     }
 
     public void setTaskDescription(final ActivityManager.TaskDescription taskDescription) {
-        callHook("setTaskDescription(ActivityManager.TaskDescription)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.setTaskDescription(superCall,
-                                (ActivityManager.TaskDescription) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setTaskDescription(
-                                (ActivityManager.TaskDescription) args[0]);
-                    }
-                }, taskDescription);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setTaskDescription(taskDescription);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setTaskDescription(ActivityManager.TaskDescription)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setTaskDescription(this, (ActivityManager.TaskDescription) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setTaskDescription((ActivityManager.TaskDescription) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(taskDescription);
     }
 
     public void setTheme(@StyleRes final int resid) {
-        callHook("setTheme(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setTheme(resid);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTheme(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setTheme(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setTheme(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setTheme((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setTheme((int) args[0]);
-            }
-        }, resid);
+        };
+        superCall.call(resid);
     }
 
     public void setTitle(final CharSequence title) {
-        callHook("setTitle(CharSequence)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setTitle(title);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTitle(CharSequence)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setTitle(superCall, (CharSequence) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setTitle(this, (CharSequence) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setTitle((CharSequence) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setTitle((CharSequence) args[0]);
-            }
-        }, title);
+        };
+        superCall.call(title);
     }
 
     public void setTitle(final int titleId) {
-        callHook("setTitle(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setTitle(titleId);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTitle(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setTitle(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setTitle(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setTitle((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setTitle((int) args[0]);
-            }
-        }, titleId);
+        };
+        superCall.call(titleId);
     }
 
     public void setTitleColor(final int textColor) {
-        callHook("setTitleColor(int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setTitleColor(textColor);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTitleColor(int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setTitleColor(superCall, (int) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setTitleColor(this, (int) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setTitleColor((int) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setTitleColor((int) args[0]);
-            }
-        }, textColor);
+        };
+        superCall.call(textColor);
     }
 
     public void setVisible(final boolean visible) {
-        callHook("setVisible(boolean)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setVisible(visible);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setVisible(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.setVisible(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setVisible(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setVisible((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setVisible((boolean) args[0]);
-            }
-        }, visible);
+        };
+        superCall.call(visible);
     }
 
     public void setWallpaper(final Bitmap bitmap) throws IOException {
-        callHook("setWallpaper(Bitmap)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal().super_setWallpaper(bitmap);
+            } catch (IOException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setWallpaper(Bitmap)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                try {
-                    plugin.setWallpaper(superCall, (Bitmap) args[0]);
-                } catch (IOException e) {
-                    throw new SuppressedException(e);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous().setWallpaper(this, (Bitmap) args[0]);
+                        return null;
+                    } catch (IOException e) {
+                        throw new SuppressedException(e);
+                    }
+                } else {
+                    try {
+                        getOriginal().super_setWallpaper((Bitmap) args[0]);
+                        return null;
+                    } catch (IOException e) {
+                        throw new SuppressedException(e);
+                    }
                 }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                try {
-                    getOriginal().super_setWallpaper((Bitmap) args[0]);
-                } catch (IOException e) {
-                    throw new SuppressedException(e);
-                }
-            }
-        }, bitmap);
+        };
+        superCall.call(bitmap);
     }
 
     public void setWallpaper(final InputStream data) throws IOException {
-        callHook("setWallpaper(InputStream)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal().super_setWallpaper(data);
+            } catch (IOException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setWallpaper(InputStream)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                try {
-                    plugin.setWallpaper(superCall, (InputStream) args[0]);
-                } catch (IOException e) {
-                    throw new SuppressedException(e);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous().setWallpaper(this, (InputStream) args[0]);
+                        return null;
+                    } catch (IOException e) {
+                        throw new SuppressedException(e);
+                    }
+                } else {
+                    try {
+                        getOriginal().super_setWallpaper((InputStream) args[0]);
+                        return null;
+                    } catch (IOException e) {
+                        throw new SuppressedException(e);
+                    }
                 }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                try {
-                    getOriginal().super_setWallpaper((InputStream) args[0]);
-                } catch (IOException e) {
-                    throw new SuppressedException(e);
-                }
-            }
-        }, data);
+        };
+        superCall.call(data);
     }
 
     public boolean shouldShowRequestPermissionRationale(final String permission) {
-        return callFunction("shouldShowRequestPermissionRationale(String)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_shouldShowRequestPermissionRationale(permission);
+        }
 
-                        return plugin
-                                .shouldShowRequestPermissionRationale(superCall, (String) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_shouldShowRequestPermissionRationale((String) args[0]);
-                    }
-                }, permission);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "shouldShowRequestPermissionRationale(String)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .shouldShowRequestPermissionRationale(this, (String) args[0]);
+                } else {
+                    return getOriginal()
+                            .super_shouldShowRequestPermissionRationale((String) args[0]);
+                }
+            }
+        };
+        return superCall.call(permission);
     }
 
     public boolean shouldUpRecreateTask(final Intent targetIntent) {
-        return callFunction("shouldUpRecreateTask(Intent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_shouldUpRecreateTask(targetIntent);
+        }
 
-                        return plugin.shouldUpRecreateTask(superCall, (Intent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_shouldUpRecreateTask((Intent) args[0]);
-                    }
-                }, targetIntent);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "shouldUpRecreateTask(Intent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().shouldUpRecreateTask(this, (Intent) args[0]);
+                } else {
+                    return getOriginal().super_shouldUpRecreateTask((Intent) args[0]);
+                }
+            }
+        };
+        return superCall.call(targetIntent);
     }
 
     public boolean showAssist(final Bundle args) {
-        return callFunction("showAssist(Bundle)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_showAssist(args);
+        }
 
-                return plugin.showAssist(superCall, (Bundle) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "showAssist(Bundle)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_showAssist((Bundle) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().showAssist(this, (Bundle) args[0]);
+                } else {
+                    return getOriginal().super_showAssist((Bundle) args[0]);
+                }
             }
-        }, args);
+        };
+        return superCall.call(args);
     }
 
     public void showLockTaskEscapeMessage() {
-        callHook("showLockTaskEscapeMessage()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_showLockTaskEscapeMessage();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "showLockTaskEscapeMessage()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.showLockTaskEscapeMessage(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().showLockTaskEscapeMessage(this);
+                    return null;
+                } else {
+                    getOriginal().super_showLockTaskEscapeMessage();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_showLockTaskEscapeMessage();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public android.view.ActionMode startActionMode(
             final android.view.ActionMode.Callback callback) {
-        return callFunction("startActionMode(android.view.ActionMode.Callback)",
-                new PluginCall<ActivityPlugin, android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(
-                            final NamedSuperCall<android.view.ActionMode> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startActionMode(callback);
+        }
 
-                        return plugin.startActionMode(superCall,
-                                (android.view.ActionMode.Callback) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(final Object... args) {
-                        return getOriginal()
-                                .super_startActionMode((android.view.ActionMode.Callback) args[0]);
-                    }
-                }, callback);
+        final NamedSuperCall<android.view.ActionMode> superCall
+                = new NamedSuperCall<android.view.ActionMode>(
+                "startActionMode(android.view.ActionMode.Callback)") {
+
+            @Override
+            public android.view.ActionMode call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .startActionMode(this, (android.view.ActionMode.Callback) args[0]);
+                } else {
+                    return getOriginal()
+                            .super_startActionMode((android.view.ActionMode.Callback) args[0]);
+                }
+            }
+        };
+        return superCall.call(callback);
     }
 
     public android.view.ActionMode startActionMode(final android.view.ActionMode.Callback callback,
             final int type) {
-        return callFunction("startActionMode(android.view.ActionMode.Callback, int)",
-                new PluginCall<ActivityPlugin, android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(
-                            final NamedSuperCall<android.view.ActionMode> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startActionMode(callback, type);
+        }
 
-                        return plugin.startActionMode(superCall,
-                                (android.view.ActionMode.Callback) args[0], (int) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<android.view.ActionMode>() {
-                    @Override
-                    public android.view.ActionMode call(final Object... args) {
-                        return getOriginal()
-                                .super_startActionMode((android.view.ActionMode.Callback) args[0],
-                                        (int) args[1]);
-                    }
-                }, callback, type);
+        final NamedSuperCall<android.view.ActionMode> superCall
+                = new NamedSuperCall<android.view.ActionMode>(
+                "startActionMode(android.view.ActionMode.Callback, int)") {
+
+            @Override
+            public android.view.ActionMode call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .startActionMode(this, (android.view.ActionMode.Callback) args[0],
+                                    (int) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_startActionMode((android.view.ActionMode.Callback) args[0],
+                                    (int) args[1]);
+                }
+            }
+        };
+        return superCall.call(callback, type);
     }
 
     public void startActivities(final Intent[] intents) {
-        callHook("startActivities(Intent[])", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivities(intents);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivities(Intent[])") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startActivities(superCall, (Intent[]) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startActivities(this, (Intent[]) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivities((Intent[]) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivities((Intent[]) args[0]);
-            }
-        }, new Object[]{intents});
+        };
+        superCall.call(intents);
     }
 
     public void startActivities(final Intent[] intents, final Bundle options) {
-        callHook("startActivities(Intent[], Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivities(intents, options);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivities(Intent[], Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startActivities(superCall, (Intent[]) args[0], (Bundle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startActivities(this, (Intent[]) args[0], (Bundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivities((Intent[]) args[0], (Bundle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivities((Intent[]) args[0], (Bundle) args[1]);
-            }
-        }, intents, options);
+        };
+        superCall.call(intents, options);
     }
 
     public void startActivity(final Intent intent) {
-        callHook("startActivity(Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivity(intent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("startActivity(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startActivity(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startActivity(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivity((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivity((Intent) args[0]);
-            }
-        }, intent);
+        };
+        superCall.call(intent);
     }
 
     public void startActivity(final Intent intent, final Bundle options) {
-        callHook("startActivity(Intent, Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivity(intent, options);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivity(Intent, Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startActivity(superCall, (Intent) args[0], (Bundle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startActivity(this, (Intent) args[0], (Bundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
-            }
-        }, intent, options);
+        };
+        superCall.call(intent, options);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode) {
-        callHook("startActivityForResult(Intent, int)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityForResult(intent, requestCode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityForResult(Intent, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startActivityForResult(superCall, (Intent) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityForResult(this, (Intent) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
-            }
-        }, intent, requestCode);
+        };
+        superCall.call(intent, requestCode);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode,
             final Bundle options) {
-        callHook("startActivityForResult(Intent, int, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startActivityForResult(superCall, (Intent) args[0], (int) args[1],
-                                (Bundle) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
-                                (Bundle) args[2]);
-                    }
-                }, intent, requestCode, options);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityForResult(intent, requestCode, options);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityForResult(Intent, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityForResult(this, (Intent) args[0], (int) args[1],
+                                    (Bundle) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, requestCode, options);
     }
 
     public void startActivityFromChild(final Activity child, final Intent intent,
             final int requestCode) {
-        callHook("startActivityFromChild(Activity, Intent, int)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startActivityFromChild(superCall, (Activity) args[0],
-                                (Intent) args[1], (int) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_startActivityFromChild((Activity) args[0], (Intent) args[1],
-                                        (int) args[2]);
-                    }
-                }, child, intent, requestCode);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityFromChild(child, intent, requestCode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityFromChild(Activity, Intent, int)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityFromChild(this, (Activity) args[0], (Intent) args[1],
+                                    (int) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityFromChild((Activity) args[0], (Intent) args[1],
+                            (int) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(child, intent, requestCode);
     }
 
     public void startActivityFromChild(final Activity child, final Intent intent,
             final int requestCode, final Bundle options) {
-        callHook("startActivityFromChild(Activity, Intent, int, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startActivityFromChild(superCall, (Activity) args[0],
-                                (Intent) args[1], (int) args[2], (Bundle) args[3]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_startActivityFromChild((Activity) args[0], (Intent) args[1],
-                                        (int) args[2], (Bundle) args[3]);
-                    }
-                }, child, intent, requestCode, options);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityFromChild(child, intent, requestCode, options);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityFromChild(Activity, Intent, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityFromChild(this, (Activity) args[0], (Intent) args[1],
+                                    (int) args[2], (Bundle) args[3]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityFromChild((Activity) args[0], (Intent) args[1],
+                            (int) args[2], (Bundle) args[3]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(child, intent, requestCode, options);
     }
 
     public void startActivityFromFragment(final Fragment fragment, final Intent intent,
             final int requestCode) {
-        callHook("startActivityFromFragment(Fragment, Intent, int)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startActivityFromFragment(superCall, (Fragment) args[0],
-                                (Intent) args[1], (int) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_startActivityFromFragment((Fragment) args[0],
-                                (Intent) args[1], (int) args[2]);
-                    }
-                }, fragment, intent, requestCode);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityFromFragment(fragment, intent, requestCode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityFromFragment(Fragment, Intent, int)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityFromFragment(this, (Fragment) args[0], (Intent) args[1],
+                                    (int) args[2]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_startActivityFromFragment((Fragment) args[0], (Intent) args[1],
+                                    (int) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(fragment, intent, requestCode);
     }
 
     public void startActivityFromFragment(final Fragment fragment, final Intent intent,
             final int requestCode, @Nullable final Bundle options) {
-        callHook("startActivityFromFragment(Fragment, Intent, int, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startActivityFromFragment(superCall, (Fragment) args[0],
-                                (Intent) args[1], (int) args[2], (Bundle) args[3]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_startActivityFromFragment((Fragment) args[0],
-                                (Intent) args[1], (int) args[2], (Bundle) args[3]);
-                    }
-                }, fragment, intent, requestCode, options);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityFromFragment(fragment, intent, requestCode, options);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityFromFragment(Fragment, Intent, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityFromFragment(this, (Fragment) args[0], (Intent) args[1],
+                                    (int) args[2], (Bundle) args[3]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_startActivityFromFragment((Fragment) args[0], (Intent) args[1],
+                                    (int) args[2], (Bundle) args[3]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(fragment, intent, requestCode, options);
     }
 
     public void startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
             final int requestCode) {
-        callHook("startActivityFromFragment(android.app.Fragment, Intent, int)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startActivityFromFragment(superCall, (android.app.Fragment) args[0],
-                                (Intent) args[1], (int) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_startActivityFromFragment((android.app.Fragment) args[0],
-                                        (Intent) args[1], (int) args[2]);
-                    }
-                }, fragment, intent, requestCode);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityFromFragment(fragment, intent, requestCode);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityFromFragment(android.app.Fragment, Intent, int)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityFromFragment(this, (android.app.Fragment) args[0],
+                                    (Intent) args[1], (int) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityFromFragment((android.app.Fragment) args[0],
+                            (Intent) args[1], (int) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(fragment, intent, requestCode);
     }
 
     public void startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
             final int requestCode, final Bundle options) {
-        callHook("startActivityFromFragment(android.app.Fragment, Intent, int, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startActivityFromFragment(superCall, (android.app.Fragment) args[0],
-                                (Intent) args[1], (int) args[2], (Bundle) args[3]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_startActivityFromFragment((android.app.Fragment) args[0],
-                                        (Intent) args[1], (int) args[2], (Bundle) args[3]);
-                    }
-                }, fragment, intent, requestCode, options);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityFromFragment(fragment, intent, requestCode, options);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityFromFragment(android.app.Fragment, Intent, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityFromFragment(this, (android.app.Fragment) args[0],
+                                    (Intent) args[1], (int) args[2], (Bundle) args[3]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityFromFragment((android.app.Fragment) args[0],
+                            (Intent) args[1], (int) args[2], (Bundle) args[3]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(fragment, intent, requestCode, options);
     }
 
     public boolean startActivityIfNeeded(final Intent intent, final int requestCode) {
-        return callFunction("startActivityIfNeeded(Intent, int)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startActivityIfNeeded(intent, requestCode);
+        }
 
-                        return plugin
-                                .startActivityIfNeeded(superCall, (Intent) args[0], (int) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_startActivityIfNeeded((Intent) args[0], (int) args[1]);
-                    }
-                }, intent, requestCode);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "startActivityIfNeeded(Intent, int)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .startActivityIfNeeded(this, (Intent) args[0], (int) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_startActivityIfNeeded((Intent) args[0], (int) args[1]);
+                }
+            }
+        };
+        return superCall.call(intent, requestCode);
     }
 
     public boolean startActivityIfNeeded(final Intent intent, final int requestCode,
             final Bundle options) {
-        return callFunction("startActivityIfNeeded(Intent, int, Bundle)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startActivityIfNeeded(intent, requestCode, options);
+        }
 
-                        return plugin
-                                .startActivityIfNeeded(superCall, (Intent) args[0], (int) args[1],
-                                        (Bundle) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_startActivityIfNeeded((Intent) args[0], (int) args[1],
-                                        (Bundle) args[2]);
-                    }
-                }, intent, requestCode, options);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "startActivityIfNeeded(Intent, int, Bundle)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .startActivityIfNeeded(this, (Intent) args[0], (int) args[1],
+                                    (Bundle) args[2]);
+                } else {
+                    return getOriginal()
+                            .super_startActivityIfNeeded((Intent) args[0], (int) args[1],
+                                    (Bundle) args[2]);
+                }
+            }
+        };
+        return superCall.call(intent, requestCode, options);
     }
 
     public boolean startInstrumentation(final ComponentName className, final String profileFile,
             final Bundle arguments) {
-        return callFunction("startInstrumentation(ComponentName, String, Bundle)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startInstrumentation(className, profileFile, arguments);
+        }
 
-                        return plugin.startInstrumentation(superCall, (ComponentName) args[0],
-                                (String) args[1], (Bundle) args[2]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_startInstrumentation((ComponentName) args[0],
-                                (String) args[1], (Bundle) args[2]);
-                    }
-                }, className, profileFile, arguments);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "startInstrumentation(ComponentName, String, Bundle)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .startInstrumentation(this, (ComponentName) args[0], (String) args[1],
+                                    (Bundle) args[2]);
+                } else {
+                    return getOriginal()
+                            .super_startInstrumentation((ComponentName) args[0], (String) args[1],
+                                    (Bundle) args[2]);
+                }
+            }
+        };
+        return superCall.call(className, profileFile, arguments);
     }
 
     public void startIntentSender(final IntentSender intent, final Intent fillInIntent,
             final int flagsMask, final int flagsValues, final int extraFlags)
             throws IntentSender.SendIntentException {
-        callHook("startIntentSender(IntentSender, Intent, int, int, int)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            plugin.startIntentSender(superCall, (IntentSender) args[0],
-                                    (Intent) args[1], (int) args[2], (int) args[3], (int) args[4]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask, flagsValues,
+                        extraFlags);
+            } catch (IntentSender.SendIntentException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startIntentSender(IntentSender, Intent, int, int, int)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous()
+                                .startIntentSender(this, (IntentSender) args[0], (Intent) args[1],
+                                        (int) args[2], (int) args[3], (int) args[4]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        try {
-                            getOriginal().super_startIntentSender((IntentSender) args[0],
-                                    (Intent) args[1], (int) args[2], (int) args[3], (int) args[4]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        getOriginal()
+                                .super_startIntentSender((IntentSender) args[0], (Intent) args[1],
+                                        (int) args[2], (int) args[3], (int) args[4]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, intent, fillInIntent, flagsMask, flagsValues, extraFlags);
+                }
+            }
+        };
+        superCall.call(intent, fillInIntent, flagsMask, flagsValues, extraFlags);
     }
 
     public void startIntentSender(final IntentSender intent, final Intent fillInIntent,
             final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException {
-        callHook("startIntentSender(IntentSender, Intent, int, int, int, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            plugin.startIntentSender(superCall, (IntentSender) args[0],
-                                    (Intent) args[1], (int) args[2], (int) args[3], (int) args[4],
-                                    (Bundle) args[5]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask, flagsValues,
+                        extraFlags, options);
+            } catch (IntentSender.SendIntentException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startIntentSender(IntentSender, Intent, int, int, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous()
+                                .startIntentSender(this, (IntentSender) args[0], (Intent) args[1],
+                                        (int) args[2], (int) args[3], (int) args[4],
+                                        (Bundle) args[5]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        try {
-                            getOriginal().super_startIntentSender((IntentSender) args[0],
-                                    (Intent) args[1], (int) args[2], (int) args[3], (int) args[4],
-                                    (Bundle) args[5]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        getOriginal()
+                                .super_startIntentSender((IntentSender) args[0], (Intent) args[1],
+                                        (int) args[2], (int) args[3], (int) args[4],
+                                        (Bundle) args[5]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, intent, fillInIntent, flagsMask, flagsValues, extraFlags, options);
+                }
+            }
+        };
+        superCall.call(intent, fillInIntent, flagsMask, flagsValues, extraFlags, options);
     }
 
     public void startIntentSenderForResult(final IntentSender intent, final int requestCode,
             final Intent fillInIntent, final int flagsMask, final int flagsValues,
             final int extraFlags) throws IntentSender.SendIntentException {
-        callHook("startIntentSenderForResult(IntentSender, int, Intent, int, int, int)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            plugin.startIntentSenderForResult(superCall, (IntentSender) args[0],
-                                    (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                    (int) args[5]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal().super_startIntentSenderForResult(intent, requestCode, fillInIntent,
+                        flagsMask, flagsValues, extraFlags);
+            } catch (IntentSender.SendIntentException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startIntentSenderForResult(IntentSender, int, Intent, int, int, int)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous().startIntentSenderForResult(this, (IntentSender) args[0],
+                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
+                                (int) args[5]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        try {
-                            getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
-                                    (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                    (int) args[5]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
+                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
+                                (int) args[5]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags);
+                }
+            }
+        };
+        superCall.call(intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags);
     }
 
     public void startIntentSenderForResult(final IntentSender intent, final int requestCode,
             final Intent fillInIntent, final int flagsMask, final int flagsValues,
             final int extraFlags, final Bundle options) throws IntentSender.SendIntentException {
-        callHook("startIntentSenderForResult(IntentSender, int, Intent, int, int, int, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            plugin.startIntentSenderForResult(superCall, (IntentSender) args[0],
-                                    (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                    (int) args[5], (Bundle) args[6]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal().super_startIntentSenderForResult(intent, requestCode, fillInIntent,
+                        flagsMask, flagsValues, extraFlags, options);
+            } catch (IntentSender.SendIntentException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startIntentSenderForResult(IntentSender, int, Intent, int, int, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous().startIntentSenderForResult(this, (IntentSender) args[0],
+                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
+                                (int) args[5], (Bundle) args[6]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        try {
-                            getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
-                                    (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                    (int) args[5], (Bundle) args[6]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
+                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
+                                (int) args[5], (Bundle) args[6]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags, options);
+                }
+            }
+        };
+        superCall.call(intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags,
+                options);
     }
 
     public void startIntentSenderFromChild(final Activity child, final IntentSender intent,
             final int requestCode, final Intent fillInIntent, final int flagsMask,
             final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException {
-        callHook("startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            plugin.startIntentSenderFromChild(superCall, (Activity) args[0],
-                                    (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                    (int) args[4], (int) args[5], (int) args[6]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal()
+                        .super_startIntentSenderFromChild(child, intent, requestCode, fillInIntent,
+                                flagsMask, flagsValues, extraFlags);
+            } catch (IntentSender.SendIntentException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous().startIntentSenderFromChild(this, (Activity) args[0],
+                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
+                                (int) args[4], (int) args[5], (int) args[6]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        try {
-                            getOriginal().super_startIntentSenderFromChild((Activity) args[0],
-                                    (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                    (int) args[4], (int) args[5], (int) args[6]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        getOriginal().super_startIntentSenderFromChild((Activity) args[0],
+                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
+                                (int) args[4], (int) args[5], (int) args[6]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, child, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags);
+                }
+            }
+        };
+        superCall
+                .call(child, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags);
     }
 
     public void startIntentSenderFromChild(final Activity child, final IntentSender intent,
             final int requestCode, final Intent fillInIntent, final int flagsMask,
             final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException {
-        callHook(
-                "startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int, Bundle)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        try {
-                            plugin.startIntentSenderFromChild(superCall, (Activity) args[0],
-                                    (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                    (int) args[4], (int) args[5], (int) args[6], (Bundle) args[7]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+        if (mPlugins.isEmpty()) {
+            try {
+                getOriginal()
+                        .super_startIntentSenderFromChild(child, intent, requestCode, fillInIntent,
+                                flagsMask, flagsValues, extraFlags, options);
+            } catch (IntentSender.SendIntentException e) {
+                throw new SuppressedException(e);
+            }
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    try {
+                        iterator.previous().startIntentSenderFromChild(this, (Activity) args[0],
+                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
+                                (int) args[4], (int) args[5], (int) args[6], (Bundle) args[7]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        try {
-                            getOriginal().super_startIntentSenderFromChild((Activity) args[0],
-                                    (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                    (int) args[4], (int) args[5], (int) args[6], (Bundle) args[7]);
-                        } catch (IntentSender.SendIntentException e) {
-                            throw new SuppressedException(e);
-                        }
+                } else {
+                    try {
+                        getOriginal().super_startIntentSenderFromChild((Activity) args[0],
+                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
+                                (int) args[4], (int) args[5], (int) args[6], (Bundle) args[7]);
+                        return null;
+                    } catch (IntentSender.SendIntentException e) {
+                        throw new SuppressedException(e);
                     }
-                }, child, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags,
+                }
+            }
+        };
+        superCall.call(child, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags,
                 options);
     }
 
     public void startLockTask() {
-        callHook("startLockTask()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startLockTask();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("startLockTask()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startLockTask(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startLockTask(this);
+                    return null;
+                } else {
+                    getOriginal().super_startLockTask();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startLockTask();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void startManagingCursor(final Cursor c) {
-        callHook("startManagingCursor(Cursor)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startManagingCursor(c);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startManagingCursor(Cursor)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startManagingCursor(superCall, (Cursor) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startManagingCursor(this, (Cursor) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_startManagingCursor((Cursor) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startManagingCursor((Cursor) args[0]);
-            }
-        }, c);
+        };
+        superCall.call(c);
     }
 
     public boolean startNextMatchingActivity(final Intent intent) {
-        return callFunction("startNextMatchingActivity(Intent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startNextMatchingActivity(intent);
+        }
 
-                        return plugin.startNextMatchingActivity(superCall, (Intent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_startNextMatchingActivity((Intent) args[0]);
-                    }
-                }, intent);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "startNextMatchingActivity(Intent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().startNextMatchingActivity(this, (Intent) args[0]);
+                } else {
+                    return getOriginal().super_startNextMatchingActivity((Intent) args[0]);
+                }
+            }
+        };
+        return superCall.call(intent);
     }
 
     public boolean startNextMatchingActivity(final Intent intent, final Bundle options) {
-        return callFunction("startNextMatchingActivity(Intent, Bundle)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startNextMatchingActivity(intent, options);
+        }
 
-                        return plugin.startNextMatchingActivity(superCall, (Intent) args[0],
-                                (Bundle) args[1]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_startNextMatchingActivity((Intent) args[0],
-                                (Bundle) args[1]);
-                    }
-                }, intent, options);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "startNextMatchingActivity(Intent, Bundle)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .startNextMatchingActivity(this, (Intent) args[0], (Bundle) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_startNextMatchingActivity((Intent) args[0], (Bundle) args[1]);
+                }
+            }
+        };
+        return superCall.call(intent, options);
     }
 
     public void startPostponedEnterTransition() {
-        callHook("startPostponedEnterTransition()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startPostponedEnterTransition();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startPostponedEnterTransition()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.startPostponedEnterTransition(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startPostponedEnterTransition(this);
+                    return null;
+                } else {
+                    getOriginal().super_startPostponedEnterTransition();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startPostponedEnterTransition();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void startSearch(final String initialQuery, final boolean selectInitialQuery,
             final Bundle appSearchData, final boolean globalSearch) {
-        callHook("startSearch(String, boolean, Bundle, boolean)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.startSearch(superCall, (String) args[0], (boolean) args[1],
-                                (Bundle) args[2], (boolean) args[3]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_startSearch((String) args[0], (boolean) args[1],
-                                (Bundle) args[2], (boolean) args[3]);
-                    }
-                }, initialQuery, selectInitialQuery, appSearchData, globalSearch);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startSearch(initialQuery, selectInitialQuery, appSearchData,
+                    globalSearch);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startSearch(String, boolean, Bundle, boolean)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startSearch(this, (String) args[0], (boolean) args[1],
+                            (Bundle) args[2], (boolean) args[3]);
+                    return null;
+                } else {
+                    getOriginal().super_startSearch((String) args[0], (boolean) args[1],
+                            (Bundle) args[2], (boolean) args[3]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(initialQuery, selectInitialQuery, appSearchData, globalSearch);
     }
 
     public ComponentName startService(final Intent service) {
-        return callFunction("startService(Intent)",
-                new PluginCall<ActivityPlugin, ComponentName>() {
-                    @Override
-                    public ComponentName call(final NamedSuperCall<ComponentName> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startService(service);
+        }
 
-                        return plugin.startService(superCall, (Intent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<ComponentName>() {
-                    @Override
-                    public ComponentName call(final Object... args) {
-                        return getOriginal().super_startService((Intent) args[0]);
-                    }
-                }, service);
+        final NamedSuperCall<ComponentName> superCall = new NamedSuperCall<ComponentName>(
+                "startService(Intent)") {
+
+            @Override
+            public ComponentName call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().startService(this, (Intent) args[0]);
+                } else {
+                    return getOriginal().super_startService((Intent) args[0]);
+                }
+            }
+        };
+        return superCall.call(service);
     }
 
     public ActionMode startSupportActionMode(@NonNull final ActionMode.Callback callback) {
-        return callFunction("startSupportActionMode(ActionMode.Callback)",
-                new PluginCall<ActivityPlugin, ActionMode>() {
-                    @Override
-                    public ActionMode call(final NamedSuperCall<ActionMode> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_startSupportActionMode(callback);
+        }
 
-                        return plugin
-                                .startSupportActionMode(superCall, (ActionMode.Callback) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<ActionMode>() {
-                    @Override
-                    public ActionMode call(final Object... args) {
-                        return getOriginal()
-                                .super_startSupportActionMode((ActionMode.Callback) args[0]);
-                    }
-                }, callback);
+        final NamedSuperCall<ActionMode> superCall = new NamedSuperCall<ActionMode>(
+                "startSupportActionMode(ActionMode.Callback)") {
+
+            @Override
+            public ActionMode call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .startSupportActionMode(this, (ActionMode.Callback) args[0]);
+                } else {
+                    return getOriginal()
+                            .super_startSupportActionMode((ActionMode.Callback) args[0]);
+                }
+            }
+        };
+        return superCall.call(callback);
     }
 
     public void stopLockTask() {
-        callHook("stopLockTask()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_stopLockTask();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("stopLockTask()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.stopLockTask(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().stopLockTask(this);
+                    return null;
+                } else {
+                    getOriginal().super_stopLockTask();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_stopLockTask();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void stopManagingCursor(final Cursor c) {
-        callHook("stopManagingCursor(Cursor)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_stopManagingCursor(c);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "stopManagingCursor(Cursor)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.stopManagingCursor(superCall, (Cursor) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().stopManagingCursor(this, (Cursor) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_stopManagingCursor((Cursor) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_stopManagingCursor((Cursor) args[0]);
-            }
-        }, c);
+        };
+        superCall.call(c);
     }
 
     public boolean stopService(final Intent name) {
-        return callFunction("stopService(Intent)", new PluginCall<ActivityPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_stopService(name);
+        }
 
-                return plugin.stopService(superCall, (Intent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "stopService(Intent)") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_stopService((Intent) args[0]);
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().stopService(this, (Intent) args[0]);
+                } else {
+                    return getOriginal().super_stopService((Intent) args[0]);
+                }
             }
-        }, name);
+        };
+        return superCall.call(name);
     }
 
     public void supportFinishAfterTransition() {
-        callHook("supportFinishAfterTransition()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_supportFinishAfterTransition();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "supportFinishAfterTransition()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.supportFinishAfterTransition(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().supportFinishAfterTransition(this);
+                    return null;
+                } else {
+                    getOriginal().super_supportFinishAfterTransition();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_supportFinishAfterTransition();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void supportInvalidateOptionsMenu() {
-        callHook("supportInvalidateOptionsMenu()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_supportInvalidateOptionsMenu();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "supportInvalidateOptionsMenu()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.supportInvalidateOptionsMenu(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().supportInvalidateOptionsMenu(this);
+                    return null;
+                } else {
+                    getOriginal().super_supportInvalidateOptionsMenu();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_supportInvalidateOptionsMenu();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void supportNavigateUpTo(@NonNull final Intent upIntent) {
-        callHook("supportNavigateUpTo(Intent)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_supportNavigateUpTo(upIntent);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "supportNavigateUpTo(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.supportNavigateUpTo(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().supportNavigateUpTo(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_supportNavigateUpTo((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_supportNavigateUpTo((Intent) args[0]);
-            }
-        }, upIntent);
+        };
+        superCall.call(upIntent);
     }
 
     public void supportPostponeEnterTransition() {
-        callHook("supportPostponeEnterTransition()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_supportPostponeEnterTransition();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "supportPostponeEnterTransition()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.supportPostponeEnterTransition(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().supportPostponeEnterTransition(this);
+                    return null;
+                } else {
+                    getOriginal().super_supportPostponeEnterTransition();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_supportPostponeEnterTransition();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public boolean supportRequestWindowFeature(final int featureId) {
-        return callFunction("supportRequestWindowFeature(int)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_supportRequestWindowFeature(featureId);
+        }
 
-                        return plugin.supportRequestWindowFeature(superCall, (int) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_supportRequestWindowFeature((int) args[0]);
-                    }
-                }, featureId);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "supportRequestWindowFeature(int)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().supportRequestWindowFeature(this, (int) args[0]);
+                } else {
+                    return getOriginal().super_supportRequestWindowFeature((int) args[0]);
+                }
+            }
+        };
+        return superCall.call(featureId);
     }
 
     public boolean supportShouldUpRecreateTask(@NonNull final Intent targetIntent) {
-        return callFunction("supportShouldUpRecreateTask(Intent)",
-                new PluginCall<ActivityPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_supportShouldUpRecreateTask(targetIntent);
+        }
 
-                        return plugin.supportShouldUpRecreateTask(superCall, (Intent) args[0]);
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_supportShouldUpRecreateTask((Intent) args[0]);
-                    }
-                }, targetIntent);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "supportShouldUpRecreateTask(Intent)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().supportShouldUpRecreateTask(this, (Intent) args[0]);
+                } else {
+                    return getOriginal().super_supportShouldUpRecreateTask((Intent) args[0]);
+                }
+            }
+        };
+        return superCall.call(targetIntent);
     }
 
     public void supportStartPostponedEnterTransition() {
-        callHook("supportStartPostponedEnterTransition()", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_supportStartPostponedEnterTransition();
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "supportStartPostponedEnterTransition()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.supportStartPostponedEnterTransition(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().supportStartPostponedEnterTransition(this);
+                    return null;
+                } else {
+                    getOriginal().super_supportStartPostponedEnterTransition();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_supportStartPostponedEnterTransition();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void takeKeyEvents(final boolean get) {
-        callHook("takeKeyEvents(boolean)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_takeKeyEvents(get);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("takeKeyEvents(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.takeKeyEvents(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().takeKeyEvents(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_takeKeyEvents((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_takeKeyEvents((boolean) args[0]);
-            }
-        }, get);
+        };
+        superCall.call(get);
     }
 
     public void triggerSearch(final String query, final Bundle appSearchData) {
-        callHook("triggerSearch(String, Bundle)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_triggerSearch(query, appSearchData);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "triggerSearch(String, Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.triggerSearch(superCall, (String) args[0], (Bundle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().triggerSearch(this, (String) args[0], (Bundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_triggerSearch((String) args[0], (Bundle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_triggerSearch((String) args[0], (Bundle) args[1]);
-            }
-        }, query, appSearchData);
+        };
+        superCall.call(query, appSearchData);
     }
 
     public void unbindService(final ServiceConnection conn) {
-        callHook("unbindService(ServiceConnection)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_unbindService(conn);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "unbindService(ServiceConnection)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.unbindService(superCall, (ServiceConnection) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().unbindService(this, (ServiceConnection) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_unbindService((ServiceConnection) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_unbindService((ServiceConnection) args[0]);
-            }
-        }, conn);
+        };
+        superCall.call(conn);
     }
 
     public void unregisterComponentCallbacks(final ComponentCallbacks callback) {
-        callHook("unregisterComponentCallbacks(ComponentCallbacks)",
-                new PluginCallVoid<ActivityPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final ActivityPlugin plugin, final Object... args) {
-                        plugin.unregisterComponentCallbacks(superCall,
-                                (ComponentCallbacks) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_unregisterComponentCallbacks((ComponentCallbacks) args[0]);
-                    }
-                }, callback);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_unregisterComponentCallbacks(callback);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "unregisterComponentCallbacks(ComponentCallbacks)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .unregisterComponentCallbacks(this, (ComponentCallbacks) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_unregisterComponentCallbacks((ComponentCallbacks) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(callback);
     }
 
     public void unregisterForContextMenu(final View view) {
-        callHook("unregisterForContextMenu(View)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_unregisterForContextMenu(view);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "unregisterForContextMenu(View)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.unregisterForContextMenu(superCall, (View) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().unregisterForContextMenu(this, (View) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_unregisterForContextMenu((View) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_unregisterForContextMenu((View) args[0]);
-            }
-        }, view);
+        };
+        superCall.call(view);
     }
 
     public void unregisterReceiver(final BroadcastReceiver receiver) {
-        callHook("unregisterReceiver(BroadcastReceiver)", new PluginCallVoid<ActivityPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_unregisterReceiver(receiver);
+            return;
+        }
+
+        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "unregisterReceiver(BroadcastReceiver)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final ActivityPlugin plugin,
-                    final Object... args) {
-                plugin.unregisterReceiver(superCall, (BroadcastReceiver) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().unregisterReceiver(this, (BroadcastReceiver) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_unregisterReceiver((BroadcastReceiver) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_unregisterReceiver((BroadcastReceiver) args[0]);
-            }
-        }, receiver);
+        };
+        superCall.call(receiver);
     }
 
 }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -1,7 +1,21 @@
 package com.pascalwelsch.compositeandroid.activity;
 
 import com.pascalwelsch.compositeandroid.core.AbstractDelegate;
-import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
+import com.pascalwelsch.compositeandroid.core.CallFun0;
+import com.pascalwelsch.compositeandroid.core.CallFun1;
+import com.pascalwelsch.compositeandroid.core.CallFun2;
+import com.pascalwelsch.compositeandroid.core.CallFun3;
+import com.pascalwelsch.compositeandroid.core.CallFun4;
+import com.pascalwelsch.compositeandroid.core.CallFun6;
+import com.pascalwelsch.compositeandroid.core.CallVoid0;
+import com.pascalwelsch.compositeandroid.core.CallVoid1;
+import com.pascalwelsch.compositeandroid.core.CallVoid2;
+import com.pascalwelsch.compositeandroid.core.CallVoid3;
+import com.pascalwelsch.compositeandroid.core.CallVoid4;
+import com.pascalwelsch.compositeandroid.core.CallVoid5;
+import com.pascalwelsch.compositeandroid.core.CallVoid6;
+import com.pascalwelsch.compositeandroid.core.CallVoid7;
+import com.pascalwelsch.compositeandroid.core.CallVoid8;
 
 import android.app.Activity;
 import android.app.ActivityManager;
@@ -96,19 +110,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<View, ViewGroup.LayoutParams> superCall
+                = new CallVoid2<View, ViewGroup.LayoutParams>(
                 "addContentView(View, ViewGroup.LayoutParams)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view, final ViewGroup.LayoutParams params) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .addContentView(this, (View) args[0], (ViewGroup.LayoutParams) args[1]);
-                    return null;
+                    iterator.previous().addContentView(this, view, params);
                 } else {
-                    getOriginal()
-                            .super_addContentView((View) args[0], (ViewGroup.LayoutParams) args[1]);
-                    return null;
+                    getOriginal().super_addContentView(view, params);
                 }
             }
         };
@@ -123,17 +134,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Configuration> superCall = new CallVoid1<Configuration>(
                 "applyOverrideConfiguration(Configuration)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Configuration overrideConfiguration) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().applyOverrideConfiguration(this, (Configuration) args[0]);
-                    return null;
+                    iterator.previous().applyOverrideConfiguration(this, overrideConfiguration);
                 } else {
-                    getOriginal().super_applyOverrideConfiguration((Configuration) args[0]);
-                    return null;
+                    getOriginal().super_applyOverrideConfiguration(overrideConfiguration);
                 }
             }
         };
@@ -148,17 +157,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "attachBaseContext(Context)") {
+        final CallVoid1<Context> superCall = new CallVoid1<Context>("attachBaseContext(Context)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Context newBase) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().attachBaseContext(this, (Context) args[0]);
-                    return null;
+                    iterator.previous().attachBaseContext(this, newBase);
                 } else {
-                    getOriginal().super_attachBaseContext((Context) args[0]);
-                    return null;
+                    getOriginal().super_attachBaseContext(newBase);
                 }
             }
         };
@@ -173,19 +179,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "bindService(Intent, ServiceConnection, int)") {
+        final CallFun3<Boolean, Intent, ServiceConnection, Integer> superCall
+                = new CallFun3<Boolean, Intent, ServiceConnection, Integer>(
+                "bindService(Intent, ServiceConnection, Integer)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent service, final ServiceConnection conn,
+                    final Integer flags) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .bindService(this, (Intent) args[0], (ServiceConnection) args[1],
-                                    (int) args[2]);
+                    return iterator.previous().bindService(this, service, conn, flags);
                 } else {
-                    return getOriginal()
-                            .super_bindService((Intent) args[0], (ServiceConnection) args[1],
-                                    (int) args[2]);
+                    return getOriginal().super_bindService(service, conn, flags);
                 }
             }
         };
@@ -199,15 +203,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+        final CallFun1<Integer, String> superCall = new CallFun1<Integer, String>(
                 "checkCallingOrSelfPermission(String)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final String permission) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().checkCallingOrSelfPermission(this, (String) args[0]);
+                    return iterator.previous().checkCallingOrSelfPermission(this, permission);
                 } else {
-                    return getOriginal().super_checkCallingOrSelfPermission((String) args[0]);
+                    return getOriginal().super_checkCallingOrSelfPermission(permission);
                 }
             }
         };
@@ -221,17 +225,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
-                "checkCallingOrSelfUriPermission(Uri, int)") {
+        final CallFun2<Integer, Uri, Integer> superCall = new CallFun2<Integer, Uri, Integer>(
+                "checkCallingOrSelfUriPermission(Uri, Integer)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final Uri uri, final Integer modeFlags) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .checkCallingOrSelfUriPermission(this, (Uri) args[0], (int) args[1]);
+                            .checkCallingOrSelfUriPermission(this, uri, modeFlags);
                 } else {
-                    return getOriginal()
-                            .super_checkCallingOrSelfUriPermission((Uri) args[0], (int) args[1]);
+                    return getOriginal().super_checkCallingOrSelfUriPermission(uri, modeFlags);
                 }
             }
         };
@@ -245,15 +248,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+        final CallFun1<Integer, String> superCall = new CallFun1<Integer, String>(
                 "checkCallingPermission(String)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final String permission) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().checkCallingPermission(this, (String) args[0]);
+                    return iterator.previous().checkCallingPermission(this, permission);
                 } else {
-                    return getOriginal().super_checkCallingPermission((String) args[0]);
+                    return getOriginal().super_checkCallingPermission(permission);
                 }
             }
         };
@@ -267,17 +270,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
-                "checkCallingUriPermission(Uri, int)") {
+        final CallFun2<Integer, Uri, Integer> superCall = new CallFun2<Integer, Uri, Integer>(
+                "checkCallingUriPermission(Uri, Integer)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final Uri uri, final Integer modeFlags) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .checkCallingUriPermission(this, (Uri) args[0], (int) args[1]);
+                    return iterator.previous().checkCallingUriPermission(this, uri, modeFlags);
                 } else {
-                    return getOriginal()
-                            .super_checkCallingUriPermission((Uri) args[0], (int) args[1]);
+                    return getOriginal().super_checkCallingUriPermission(uri, modeFlags);
                 }
             }
         };
@@ -291,17 +292,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
-                "checkPermission(String, int, int)") {
+        final CallFun3<Integer, String, Integer, Integer> superCall
+                = new CallFun3<Integer, String, Integer, Integer>(
+                "checkPermission(String, Integer, Integer)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final String permission, final Integer pid, final Integer uid) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .checkPermission(this, (String) args[0], (int) args[1], (int) args[2]);
+                    return iterator.previous().checkPermission(this, permission, pid, uid);
                 } else {
-                    return getOriginal()
-                            .super_checkPermission((String) args[0], (int) args[1], (int) args[2]);
+                    return getOriginal().super_checkPermission(permission, pid, uid);
                 }
             }
         };
@@ -315,15 +315,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+        final CallFun1<Integer, String> superCall = new CallFun1<Integer, String>(
                 "checkSelfPermission(String)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final String permission) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().checkSelfPermission(this, (String) args[0]);
+                    return iterator.previous().checkSelfPermission(this, permission);
                 } else {
-                    return getOriginal().super_checkSelfPermission((String) args[0]);
+                    return getOriginal().super_checkSelfPermission(permission);
                 }
             }
         };
@@ -338,19 +338,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
-                "checkUriPermission(Uri, int, int, int)") {
+        final CallFun4<Integer, Uri, Integer, Integer, Integer> superCall
+                = new CallFun4<Integer, Uri, Integer, Integer, Integer>(
+                "checkUriPermission(Uri, Integer, Integer, Integer)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final Uri uri, final Integer pid, final Integer uid,
+                    final Integer modeFlags) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .checkUriPermission(this, (Uri) args[0], (int) args[1], (int) args[2],
-                                    (int) args[3]);
+                    return iterator.previous().checkUriPermission(this, uri, pid, uid, modeFlags);
                 } else {
-                    return getOriginal()
-                            .super_checkUriPermission((Uri) args[0], (int) args[1], (int) args[2],
-                                    (int) args[3]);
+                    return getOriginal().super_checkUriPermission(uri, pid, uid, modeFlags);
                 }
             }
         };
@@ -367,18 +365,22 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
-                "checkUriPermission(Uri, String, String, int, int, int)") {
+        final CallFun6<Integer, Uri, String, String, Integer, Integer, Integer> superCall
+                = new CallFun6<Integer, Uri, String, String, Integer, Integer, Integer>(
+                "checkUriPermission(Uri, String, String, Integer, Integer, Integer)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final Uri uri, final String readPermission,
+                    final String writePermission, final Integer pid, final Integer uid,
+                    final Integer modeFlags) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .checkUriPermission(this, (Uri) args[0], (String) args[1],
-                                    (String) args[2], (int) args[3], (int) args[4], (int) args[5]);
+                            .checkUriPermission(this, uri, readPermission, writePermission, pid,
+                                    uid, modeFlags);
                 } else {
-                    return getOriginal().super_checkUriPermission((Uri) args[0], (String) args[1],
-                            (String) args[2], (int) args[3], (int) args[4], (int) args[5]);
+                    return getOriginal()
+                            .super_checkUriPermission(uri, readPermission, writePermission, pid,
+                                    uid, modeFlags);
                 }
             }
         };
@@ -397,21 +399,19 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("clearWallpaper()") {
+        final CallVoid0 superCall = new CallVoid0("clearWallpaper()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     try {
                         iterator.previous().clearWallpaper(this);
-                        return null;
                     } catch (IOException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
                         getOriginal().super_clearWallpaper();
-                        return null;
                     } catch (IOException e) {
                         throw new SuppressedException(e);
                     }
@@ -429,16 +429,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("closeContextMenu()") {
+        final CallVoid0 superCall = new CallVoid0("closeContextMenu()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().closeContextMenu(this);
-                    return null;
                 } else {
                     getOriginal().super_closeContextMenu();
-                    return null;
                 }
             }
         };
@@ -453,16 +451,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("closeOptionsMenu()") {
+        final CallVoid0 superCall = new CallVoid0("closeOptionsMenu()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().closeOptionsMenu(this);
-                    return null;
                 } else {
                     getOriginal().super_closeOptionsMenu();
-                    return null;
                 }
             }
         };
@@ -476,16 +472,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
+        final CallFun1<Context, Configuration> superCall = new CallFun1<Context, Configuration>(
                 "createConfigurationContext(Configuration)") {
 
             @Override
-            public Context call(final Object... args) {
+            public Context call(final Configuration overrideConfiguration) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .createConfigurationContext(this, (Configuration) args[0]);
+                            .createConfigurationContext(this, overrideConfiguration);
                 } else {
-                    return getOriginal().super_createConfigurationContext((Configuration) args[0]);
+                    return getOriginal().super_createConfigurationContext(overrideConfiguration);
                 }
             }
         };
@@ -499,15 +495,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
+        final CallFun1<Context, Display> superCall = new CallFun1<Context, Display>(
                 "createDisplayContext(Display)") {
 
             @Override
-            public Context call(final Object... args) {
+            public Context call(final Display display) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().createDisplayContext(this, (Display) args[0]);
+                    return iterator.previous().createDisplayContext(this, display);
                 } else {
-                    return getOriginal().super_createDisplayContext((Display) args[0]);
+                    return getOriginal().super_createDisplayContext(display);
                 }
             }
         };
@@ -526,22 +522,20 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
-                "createPackageContext(String, int)") {
+        final CallFun2<Context, String, Integer> superCall = new CallFun2<Context, String, Integer>(
+                "createPackageContext(String, Integer)") {
 
             @Override
-            public Context call(final Object... args) {
+            public Context call(final String packageName, final Integer flags) {
                 if (iterator.hasPrevious()) {
                     try {
-                        return iterator.previous()
-                                .createPackageContext(this, (String) args[0], (int) args[1]);
+                        return iterator.previous().createPackageContext(this, packageName, flags);
                     } catch (PackageManager.NameNotFoundException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        return getOriginal()
-                                .super_createPackageContext((String) args[0], (int) args[1]);
+                        return getOriginal().super_createPackageContext(packageName, flags);
                     } catch (PackageManager.NameNotFoundException e) {
                         throw new SuppressedException(e);
                     }
@@ -559,18 +553,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<PendingIntent> superCall = new NamedSuperCall<PendingIntent>(
-                "createPendingResult(int, Intent, int)") {
+        final CallFun3<PendingIntent, Integer, Intent, Integer> superCall
+                = new CallFun3<PendingIntent, Integer, Intent, Integer>(
+                "createPendingResult(Integer, Intent, Integer)") {
 
             @Override
-            public PendingIntent call(final Object... args) {
+            public PendingIntent call(final Integer requestCode, final Intent data,
+                    final Integer flags) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .createPendingResult(this, (int) args[0], (Intent) args[1],
-                                    (int) args[2]);
+                    return iterator.previous().createPendingResult(this, requestCode, data, flags);
                 } else {
-                    return getOriginal().super_createPendingResult((int) args[0], (Intent) args[1],
-                            (int) args[2]);
+                    return getOriginal().super_createPendingResult(requestCode, data, flags);
                 }
             }
         };
@@ -584,10 +577,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String[]> superCall = new NamedSuperCall<String[]>("databaseList()") {
+        final CallFun0<String[]> superCall = new CallFun0<String[]>("databaseList()") {
 
             @Override
-            public String[] call(final Object... args) {
+            public String[] call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().databaseList(this);
                 } else {
@@ -605,15 +598,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "deleteDatabase(String)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final String name) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().deleteDatabase(this, (String) args[0]);
+                    return iterator.previous().deleteDatabase(this, name);
                 } else {
-                    return getOriginal().super_deleteDatabase((String) args[0]);
+                    return getOriginal().super_deleteDatabase(name);
                 }
             }
         };
@@ -627,15 +620,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "deleteFile(String)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final String name) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().deleteFile(this, (String) args[0]);
+                    return iterator.previous().deleteFile(this, name);
                 } else {
-                    return getOriginal().super_deleteFile((String) args[0]);
+                    return getOriginal().super_deleteFile(name);
                 }
             }
         };
@@ -649,16 +642,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "dispatchGenericMotionEvent(MotionEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MotionEvent ev) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .dispatchGenericMotionEvent(this, (MotionEvent) args[0]);
+                    return iterator.previous().dispatchGenericMotionEvent(this, ev);
                 } else {
-                    return getOriginal().super_dispatchGenericMotionEvent((MotionEvent) args[0]);
+                    return getOriginal().super_dispatchGenericMotionEvent(ev);
                 }
             }
         };
@@ -672,15 +664,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, KeyEvent> superCall = new CallFun1<Boolean, KeyEvent>(
                 "dispatchKeyEvent(KeyEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final KeyEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().dispatchKeyEvent(this, (KeyEvent) args[0]);
+                    return iterator.previous().dispatchKeyEvent(this, event);
                 } else {
-                    return getOriginal().super_dispatchKeyEvent((KeyEvent) args[0]);
+                    return getOriginal().super_dispatchKeyEvent(event);
                 }
             }
         };
@@ -694,15 +686,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, KeyEvent> superCall = new CallFun1<Boolean, KeyEvent>(
                 "dispatchKeyShortcutEvent(KeyEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final KeyEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().dispatchKeyShortcutEvent(this, (KeyEvent) args[0]);
+                    return iterator.previous().dispatchKeyShortcutEvent(this, event);
                 } else {
-                    return getOriginal().super_dispatchKeyShortcutEvent((KeyEvent) args[0]);
+                    return getOriginal().super_dispatchKeyShortcutEvent(event);
                 }
             }
         };
@@ -716,17 +708,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, AccessibilityEvent> superCall
+                = new CallFun1<Boolean, AccessibilityEvent>(
                 "dispatchPopulateAccessibilityEvent(AccessibilityEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final AccessibilityEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .dispatchPopulateAccessibilityEvent(this, (AccessibilityEvent) args[0]);
+                    return iterator.previous().dispatchPopulateAccessibilityEvent(this, event);
                 } else {
-                    return getOriginal()
-                            .super_dispatchPopulateAccessibilityEvent((AccessibilityEvent) args[0]);
+                    return getOriginal().super_dispatchPopulateAccessibilityEvent(event);
                 }
             }
         };
@@ -740,15 +731,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "dispatchTouchEvent(MotionEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MotionEvent ev) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().dispatchTouchEvent(this, (MotionEvent) args[0]);
+                    return iterator.previous().dispatchTouchEvent(this, ev);
                 } else {
-                    return getOriginal().super_dispatchTouchEvent((MotionEvent) args[0]);
+                    return getOriginal().super_dispatchTouchEvent(ev);
                 }
             }
         };
@@ -762,15 +753,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "dispatchTrackballEvent(MotionEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MotionEvent ev) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().dispatchTrackballEvent(this, (MotionEvent) args[0]);
+                    return iterator.previous().dispatchTrackballEvent(this, ev);
                 } else {
-                    return getOriginal().super_dispatchTrackballEvent((MotionEvent) args[0]);
+                    return getOriginal().super_dispatchTrackballEvent(ev);
                 }
             }
         };
@@ -786,19 +777,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid4<String, FileDescriptor, PrintWriter, String[]> superCall
+                = new CallVoid4<String, FileDescriptor, PrintWriter, String[]>(
                 "dump(String, FileDescriptor, PrintWriter, String[])") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String prefix, final FileDescriptor fd, final PrintWriter writer,
+                    final String[] args) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().dump(this, (String) args[0], (FileDescriptor) args[1],
-                            (PrintWriter) args[2], (String[]) args[3]);
-                    return null;
+                    iterator.previous().dump(this, prefix, fd, writer, args);
                 } else {
-                    getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
-                            (PrintWriter) args[2], (String[]) args[3]);
-                    return null;
+                    getOriginal().super_dump(prefix, fd, writer, args);
                 }
             }
         };
@@ -813,19 +802,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<String, String> superCall = new CallVoid2<String, String>(
                 "enforceCallingOrSelfPermission(String, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String permission, final String message) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().enforceCallingOrSelfPermission(this, (String) args[0],
-                            (String) args[1]);
-                    return null;
+                    iterator.previous().enforceCallingOrSelfPermission(this, permission, message);
                 } else {
-                    getOriginal().super_enforceCallingOrSelfPermission((String) args[0],
-                            (String) args[1]);
-                    return null;
+                    getOriginal().super_enforceCallingOrSelfPermission(permission, message);
                 }
             }
         };
@@ -841,21 +826,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "enforceCallingOrSelfUriPermission(Uri, int, String)") {
+        final CallVoid3<Uri, Integer, String> superCall = new CallVoid3<Uri, Integer, String>(
+                "enforceCallingOrSelfUriPermission(Uri, Integer, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Uri uri, final Integer modeFlags, final String message) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .enforceCallingOrSelfUriPermission(this, (Uri) args[0], (int) args[1],
-                                    (String) args[2]);
-                    return null;
+                            .enforceCallingOrSelfUriPermission(this, uri, modeFlags, message);
                 } else {
-                    getOriginal()
-                            .super_enforceCallingOrSelfUriPermission((Uri) args[0], (int) args[1],
-                                    (String) args[2]);
-                    return null;
+                    getOriginal().super_enforceCallingOrSelfUriPermission(uri, modeFlags, message);
                 }
             }
         };
@@ -870,19 +850,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<String, String> superCall = new CallVoid2<String, String>(
                 "enforceCallingPermission(String, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String permission, final String message) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .enforceCallingPermission(this, (String) args[0], (String) args[1]);
-                    return null;
+                    iterator.previous().enforceCallingPermission(this, permission, message);
                 } else {
-                    getOriginal()
-                            .super_enforceCallingPermission((String) args[0], (String) args[1]);
-                    return null;
+                    getOriginal().super_enforceCallingPermission(permission, message);
                 }
             }
         };
@@ -898,20 +874,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "enforceCallingUriPermission(Uri, int, String)") {
+        final CallVoid3<Uri, Integer, String> superCall = new CallVoid3<Uri, Integer, String>(
+                "enforceCallingUriPermission(Uri, Integer, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Uri uri, final Integer modeFlags, final String message) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .enforceCallingUriPermission(this, (Uri) args[0], (int) args[1],
-                                    (String) args[2]);
-                    return null;
+                    iterator.previous().enforceCallingUriPermission(this, uri, modeFlags, message);
                 } else {
-                    getOriginal().super_enforceCallingUriPermission((Uri) args[0], (int) args[1],
-                            (String) args[2]);
-                    return null;
+                    getOriginal().super_enforceCallingUriPermission(uri, modeFlags, message);
                 }
             }
         };
@@ -927,21 +898,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "enforcePermission(String, int, int, String)") {
+        final CallVoid4<String, Integer, Integer, String> superCall
+                = new CallVoid4<String, Integer, Integer, String>(
+                "enforcePermission(String, Integer, Integer, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String permission, final Integer pid, final Integer uid,
+                    final String message) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .enforcePermission(this, (String) args[0], (int) args[1], (int) args[2],
-                                    (String) args[3]);
-                    return null;
+                    iterator.previous().enforcePermission(this, permission, pid, uid, message);
                 } else {
-                    getOriginal()
-                            .super_enforcePermission((String) args[0], (int) args[1], (int) args[2],
-                                    (String) args[3]);
-                    return null;
+                    getOriginal().super_enforcePermission(permission, pid, uid, message);
                 }
             }
         };
@@ -957,21 +924,18 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "enforceUriPermission(Uri, int, int, int, String)") {
+        final CallVoid5<Uri, Integer, Integer, Integer, String> superCall
+                = new CallVoid5<Uri, Integer, Integer, Integer, String>(
+                "enforceUriPermission(Uri, Integer, Integer, Integer, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Uri uri, final Integer pid, final Integer uid,
+                    final Integer modeFlags, final String message) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .enforceUriPermission(this, (Uri) args[0], (int) args[1], (int) args[2],
-                                    (int) args[3], (String) args[4]);
-                    return null;
+                            .enforceUriPermission(this, uri, pid, uid, modeFlags, message);
                 } else {
-                    getOriginal()
-                            .super_enforceUriPermission((Uri) args[0], (int) args[1], (int) args[2],
-                                    (int) args[3], (String) args[4]);
-                    return null;
+                    getOriginal().super_enforceUriPermission(uri, pid, uid, modeFlags, message);
                 }
             }
         };
@@ -989,21 +953,22 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "enforceUriPermission(Uri, String, String, int, int, int, String)") {
+        final CallVoid7<Uri, String, String, Integer, Integer, Integer, String> superCall
+                = new CallVoid7<Uri, String, String, Integer, Integer, Integer, String>(
+                "enforceUriPermission(Uri, String, String, Integer, Integer, Integer, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Uri uri, final String readPermission,
+                    final String writePermission, final Integer pid, final Integer uid,
+                    final Integer modeFlags, final String message) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().enforceUriPermission(this, (Uri) args[0], (String) args[1],
-                            (String) args[2], (int) args[3], (int) args[4], (int) args[5],
-                            (String) args[6]);
-                    return null;
+                    iterator.previous()
+                            .enforceUriPermission(this, uri, readPermission, writePermission, pid,
+                                    uid, modeFlags, message);
                 } else {
-                    getOriginal().super_enforceUriPermission((Uri) args[0], (String) args[1],
-                            (String) args[2], (int) args[3], (int) args[4], (int) args[5],
-                            (String) args[6]);
-                    return null;
+                    getOriginal()
+                            .super_enforceUriPermission(uri, readPermission, writePermission, pid,
+                                    uid, modeFlags, message);
                 }
             }
         };
@@ -1017,10 +982,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String[]> superCall = new NamedSuperCall<String[]>("fileList()") {
+        final CallFun0<String[]> superCall = new CallFun0<String[]>("fileList()") {
 
             @Override
-            public String[] call(final Object... args) {
+            public String[] call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().fileList(this);
                 } else {
@@ -1038,14 +1003,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("findViewById(int)") {
+        final CallFun1<View, Integer> superCall = new CallFun1<View, Integer>(
+                "findViewById(Integer)") {
 
             @Override
-            public View call(final Object... args) {
+            public View call(final Integer id) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().findViewById(this, (int) args[0]);
+                    return iterator.previous().findViewById(this, id);
                 } else {
-                    return getOriginal().super_findViewById((int) args[0]);
+                    return getOriginal().super_findViewById(id);
                 }
             }
         };
@@ -1060,16 +1026,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finish()") {
+        final CallVoid0 superCall = new CallVoid0("finish()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().finish(this);
-                    return null;
                 } else {
                     getOriginal().super_finish();
-                    return null;
                 }
             }
         };
@@ -1084,16 +1048,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishActivity(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>("finishActivity(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer requestCode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().finishActivity(this, (int) args[0]);
-                    return null;
+                    iterator.previous().finishActivity(this, requestCode);
                 } else {
-                    getOriginal().super_finishActivity((int) args[0]);
-                    return null;
+                    getOriginal().super_finishActivity(requestCode);
                 }
             }
         };
@@ -1108,18 +1070,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "finishActivityFromChild(Activity, int)") {
+        final CallVoid2<Activity, Integer> superCall = new CallVoid2<Activity, Integer>(
+                "finishActivityFromChild(Activity, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity child, final Integer requestCode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .finishActivityFromChild(this, (Activity) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().finishActivityFromChild(this, child, requestCode);
                 } else {
-                    getOriginal().super_finishActivityFromChild((Activity) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_finishActivityFromChild(child, requestCode);
                 }
             }
         };
@@ -1134,16 +1093,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishAffinity()") {
+        final CallVoid0 superCall = new CallVoid0("finishAffinity()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().finishAffinity(this);
-                    return null;
                 } else {
                     getOriginal().super_finishAffinity();
-                    return null;
                 }
             }
         };
@@ -1158,16 +1115,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishAfterTransition()") {
+        final CallVoid0 superCall = new CallVoid0("finishAfterTransition()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().finishAfterTransition(this);
-                    return null;
                 } else {
                     getOriginal().super_finishAfterTransition();
-                    return null;
                 }
             }
         };
@@ -1182,16 +1137,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("finishAndRemoveTask()") {
+        final CallVoid0 superCall = new CallVoid0("finishAndRemoveTask()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().finishAndRemoveTask(this);
-                    return null;
                 } else {
                     getOriginal().super_finishAndRemoveTask();
-                    return null;
                 }
             }
         };
@@ -1206,17 +1159,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "finishFromChild(Activity)") {
+        final CallVoid1<Activity> superCall = new CallVoid1<Activity>("finishFromChild(Activity)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity child) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().finishFromChild(this, (Activity) args[0]);
-                    return null;
+                    iterator.previous().finishFromChild(this, child);
                 } else {
-                    getOriginal().super_finishFromChild((Activity) args[0]);
-                    return null;
+                    getOriginal().super_finishFromChild(child);
                 }
             }
         };
@@ -1230,11 +1180,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<android.app.ActionBar> superCall
-                = new NamedSuperCall<android.app.ActionBar>("getActionBar()") {
+        final CallFun0<android.app.ActionBar> superCall = new CallFun0<android.app.ActionBar>(
+                "getActionBar()") {
 
             @Override
-            public android.app.ActionBar call(final Object... args) {
+            public android.app.ActionBar call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getActionBar(this);
                 } else {
@@ -1252,11 +1202,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>(
-                "getApplicationContext()") {
+        final CallFun0<Context> superCall = new CallFun0<Context>("getApplicationContext()") {
 
             @Override
-            public Context call(final Object... args) {
+            public Context call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getApplicationContext(this);
                 } else {
@@ -1274,11 +1223,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ApplicationInfo> superCall = new NamedSuperCall<ApplicationInfo>(
+        final CallFun0<ApplicationInfo> superCall = new CallFun0<ApplicationInfo>(
                 "getApplicationInfo()") {
 
             @Override
-            public ApplicationInfo call(final Object... args) {
+            public ApplicationInfo call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getApplicationInfo(this);
                 } else {
@@ -1296,11 +1245,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<AssetManager> superCall = new NamedSuperCall<AssetManager>(
-                "getAssets()") {
+        final CallFun0<AssetManager> superCall = new CallFun0<AssetManager>("getAssets()") {
 
             @Override
-            public AssetManager call(final Object... args) {
+            public AssetManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getAssets(this);
                 } else {
@@ -1318,10 +1266,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>("getBaseContext()") {
+        final CallFun0<Context> superCall = new CallFun0<Context>("getBaseContext()") {
 
             @Override
-            public Context call(final Object... args) {
+            public Context call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getBaseContext(this);
                 } else {
@@ -1339,10 +1287,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getCacheDir()") {
+        final CallFun0<File> superCall = new CallFun0<File>("getCacheDir()") {
 
             @Override
-            public File call(final Object... args) {
+            public File call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getCacheDir(this);
                 } else {
@@ -1360,11 +1308,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ComponentName> superCall = new NamedSuperCall<ComponentName>(
+        final CallFun0<ComponentName> superCall = new CallFun0<ComponentName>(
                 "getCallingActivity()") {
 
             @Override
-            public ComponentName call(final Object... args) {
+            public ComponentName call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getCallingActivity(this);
                 } else {
@@ -1382,10 +1330,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("getCallingPackage()") {
+        final CallFun0<String> superCall = new CallFun0<String>("getCallingPackage()") {
 
             @Override
-            public String call(final Object... args) {
+            public String call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getCallingPackage(this);
                 } else {
@@ -1403,11 +1351,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
-                "getChangingConfigurations()") {
+        final CallFun0<Integer> superCall = new CallFun0<Integer>("getChangingConfigurations()") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getChangingConfigurations(this);
                 } else {
@@ -1425,11 +1372,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ClassLoader> superCall = new NamedSuperCall<ClassLoader>(
-                "getClassLoader()") {
+        final CallFun0<ClassLoader> superCall = new CallFun0<ClassLoader>("getClassLoader()") {
 
             @Override
-            public ClassLoader call(final Object... args) {
+            public ClassLoader call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getClassLoader(this);
                 } else {
@@ -1447,10 +1393,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getCodeCacheDir()") {
+        final CallFun0<File> superCall = new CallFun0<File>("getCodeCacheDir()") {
 
             @Override
-            public File call(final Object... args) {
+            public File call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getCodeCacheDir(this);
                 } else {
@@ -1468,11 +1414,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ComponentName> superCall = new NamedSuperCall<ComponentName>(
+        final CallFun0<ComponentName> superCall = new CallFun0<ComponentName>(
                 "getComponentName()") {
 
             @Override
-            public ComponentName call(final Object... args) {
+            public ComponentName call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getComponentName(this);
                 } else {
@@ -1490,11 +1436,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ContentResolver> superCall = new NamedSuperCall<ContentResolver>(
+        final CallFun0<ContentResolver> superCall = new CallFun0<ContentResolver>(
                 "getContentResolver()") {
 
             @Override
-            public ContentResolver call(final Object... args) {
+            public ContentResolver call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getContentResolver(this);
                 } else {
@@ -1512,10 +1458,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Scene> superCall = new NamedSuperCall<Scene>("getContentScene()") {
+        final CallFun0<Scene> superCall = new CallFun0<Scene>("getContentScene()") {
 
             @Override
-            public Scene call(final Object... args) {
+            public Scene call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getContentScene(this);
                 } else {
@@ -1533,11 +1479,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<TransitionManager> superCall = new NamedSuperCall<TransitionManager>(
+        final CallFun0<TransitionManager> superCall = new CallFun0<TransitionManager>(
                 "getContentTransitionManager()") {
 
             @Override
-            public TransitionManager call(final Object... args) {
+            public TransitionManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getContentTransitionManager(this);
                 } else {
@@ -1555,10 +1501,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("getCurrentFocus()") {
+        final CallFun0<View> superCall = new CallFun0<View>("getCurrentFocus()") {
 
             @Override
-            public View call(final Object... args) {
+            public View call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getCurrentFocus(this);
                 } else {
@@ -1576,14 +1522,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getDatabasePath(String)") {
+        final CallFun1<File, String> superCall = new CallFun1<File, String>(
+                "getDatabasePath(String)") {
 
             @Override
-            public File call(final Object... args) {
+            public File call(final String name) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getDatabasePath(this, (String) args[0]);
+                    return iterator.previous().getDatabasePath(this, name);
                 } else {
-                    return getOriginal().super_getDatabasePath((String) args[0]);
+                    return getOriginal().super_getDatabasePath(name);
                 }
             }
         };
@@ -1597,11 +1544,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<AppCompatDelegate> superCall = new NamedSuperCall<AppCompatDelegate>(
+        final CallFun0<AppCompatDelegate> superCall = new CallFun0<AppCompatDelegate>(
                 "getDelegate()") {
 
             @Override
-            public AppCompatDelegate call(final Object... args) {
+            public AppCompatDelegate call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getDelegate(this);
                 } else {
@@ -1619,14 +1566,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getDir(String, int)") {
+        final CallFun2<File, String, Integer> superCall = new CallFun2<File, String, Integer>(
+                "getDir(String, Integer)") {
 
             @Override
-            public File call(final Object... args) {
+            public File call(final String name, final Integer mode) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getDir(this, (String) args[0], (int) args[1]);
+                    return iterator.previous().getDir(this, name, mode);
                 } else {
-                    return getOriginal().super_getDir((String) args[0], (int) args[1]);
+                    return getOriginal().super_getDir(name, mode);
                 }
             }
         };
@@ -1640,11 +1588,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ActionBarDrawerToggle.Delegate> superCall
-                = new NamedSuperCall<ActionBarDrawerToggle.Delegate>("getDrawerToggleDelegate()") {
+        final CallFun0<ActionBarDrawerToggle.Delegate> superCall
+                = new CallFun0<ActionBarDrawerToggle.Delegate>("getDrawerToggleDelegate()") {
 
             @Override
-            public ActionBarDrawerToggle.Delegate call(final Object... args) {
+            public ActionBarDrawerToggle.Delegate call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getDrawerToggleDelegate(this);
                 } else {
@@ -1662,10 +1610,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getExternalCacheDir()") {
+        final CallFun0<File> superCall = new CallFun0<File>("getExternalCacheDir()") {
 
             @Override
-            public File call(final Object... args) {
+            public File call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getExternalCacheDir(this);
                 } else {
@@ -1683,11 +1631,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>(
-                "getExternalCacheDirs()") {
+        final CallFun0<File[]> superCall = new CallFun0<File[]>("getExternalCacheDirs()") {
 
             @Override
-            public File[] call(final Object... args) {
+            public File[] call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getExternalCacheDirs(this);
                 } else {
@@ -1705,15 +1652,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>(
+        final CallFun1<File, String> superCall = new CallFun1<File, String>(
                 "getExternalFilesDir(String)") {
 
             @Override
-            public File call(final Object... args) {
+            public File call(final String type) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getExternalFilesDir(this, (String) args[0]);
+                    return iterator.previous().getExternalFilesDir(this, type);
                 } else {
-                    return getOriginal().super_getExternalFilesDir((String) args[0]);
+                    return getOriginal().super_getExternalFilesDir(type);
                 }
             }
         };
@@ -1727,15 +1674,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>(
+        final CallFun1<File[], String> superCall = new CallFun1<File[], String>(
                 "getExternalFilesDirs(String)") {
 
             @Override
-            public File[] call(final Object... args) {
+            public File[] call(final String type) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getExternalFilesDirs(this, (String) args[0]);
+                    return iterator.previous().getExternalFilesDirs(this, type);
                 } else {
-                    return getOriginal().super_getExternalFilesDirs((String) args[0]);
+                    return getOriginal().super_getExternalFilesDirs(type);
                 }
             }
         };
@@ -1749,11 +1696,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>(
-                "getExternalMediaDirs()") {
+        final CallFun0<File[]> superCall = new CallFun0<File[]>("getExternalMediaDirs()") {
 
             @Override
-            public File[] call(final Object... args) {
+            public File[] call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getExternalMediaDirs(this);
                 } else {
@@ -1771,15 +1717,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>(
+        final CallFun1<File, String> superCall = new CallFun1<File, String>(
                 "getFileStreamPath(String)") {
 
             @Override
-            public File call(final Object... args) {
+            public File call(final String name) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getFileStreamPath(this, (String) args[0]);
+                    return iterator.previous().getFileStreamPath(this, name);
                 } else {
-                    return getOriginal().super_getFileStreamPath((String) args[0]);
+                    return getOriginal().super_getFileStreamPath(name);
                 }
             }
         };
@@ -1793,10 +1739,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getFilesDir()") {
+        final CallFun0<File> superCall = new CallFun0<File>("getFilesDir()") {
 
             @Override
-            public File call(final Object... args) {
+            public File call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getFilesDir(this);
                 } else {
@@ -1814,11 +1760,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<android.app.FragmentManager> superCall
-                = new NamedSuperCall<android.app.FragmentManager>("getFragmentManager()") {
+        final CallFun0<android.app.FragmentManager> superCall
+                = new CallFun0<android.app.FragmentManager>("getFragmentManager()") {
 
             @Override
-            public android.app.FragmentManager call(final Object... args) {
+            public android.app.FragmentManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getFragmentManager(this);
                 } else {
@@ -1836,10 +1782,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>("getIntent()") {
+        final CallFun0<Intent> superCall = new CallFun0<Intent>("getIntent()") {
 
             @Override
-            public Intent call(final Object... args) {
+            public Intent call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getIntent(this);
                 } else {
@@ -1875,11 +1821,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<LayoutInflater> superCall = new NamedSuperCall<LayoutInflater>(
+        final CallFun0<LayoutInflater> superCall = new CallFun0<LayoutInflater>(
                 "getLayoutInflater()") {
 
             @Override
-            public LayoutInflater call(final Object... args) {
+            public LayoutInflater call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getLayoutInflater(this);
                 } else {
@@ -1897,11 +1843,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<android.app.LoaderManager> superCall
-                = new NamedSuperCall<android.app.LoaderManager>("getLoaderManager()") {
+        final CallFun0<android.app.LoaderManager> superCall
+                = new CallFun0<android.app.LoaderManager>("getLoaderManager()") {
 
             @Override
-            public android.app.LoaderManager call(final Object... args) {
+            public android.app.LoaderManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getLoaderManager(this);
                 } else {
@@ -1919,10 +1865,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("getLocalClassName()") {
+        final CallFun0<String> superCall = new CallFun0<String>("getLocalClassName()") {
 
             @Override
-            public String call(final Object... args) {
+            public String call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getLocalClassName(this);
                 } else {
@@ -1940,10 +1886,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Looper> superCall = new NamedSuperCall<Looper>("getMainLooper()") {
+        final CallFun0<Looper> superCall = new CallFun0<Looper>("getMainLooper()") {
 
             @Override
-            public Looper call(final Object... args) {
+            public Looper call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getMainLooper(this);
                 } else {
@@ -1961,11 +1907,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<MenuInflater> superCall = new NamedSuperCall<MenuInflater>(
-                "getMenuInflater()") {
+        final CallFun0<MenuInflater> superCall = new CallFun0<MenuInflater>("getMenuInflater()") {
 
             @Override
-            public MenuInflater call(final Object... args) {
+            public MenuInflater call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getMenuInflater(this);
                 } else {
@@ -1983,10 +1928,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getNoBackupFilesDir()") {
+        final CallFun0<File> superCall = new CallFun0<File>("getNoBackupFilesDir()") {
 
             @Override
-            public File call(final Object... args) {
+            public File call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getNoBackupFilesDir(this);
                 } else {
@@ -2004,10 +1949,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File> superCall = new NamedSuperCall<File>("getObbDir()") {
+        final CallFun0<File> superCall = new CallFun0<File>("getObbDir()") {
 
             @Override
-            public File call(final Object... args) {
+            public File call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getObbDir(this);
                 } else {
@@ -2025,10 +1970,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<File[]> superCall = new NamedSuperCall<File[]>("getObbDirs()") {
+        final CallFun0<File[]> superCall = new CallFun0<File[]>("getObbDirs()") {
 
             @Override
-            public File[] call(final Object... args) {
+            public File[] call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getObbDirs(this);
                 } else {
@@ -2046,11 +1991,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String> superCall = new NamedSuperCall<String>(
-                "getPackageCodePath()") {
+        final CallFun0<String> superCall = new CallFun0<String>("getPackageCodePath()") {
 
             @Override
-            public String call(final Object... args) {
+            public String call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getPackageCodePath(this);
                 } else {
@@ -2068,11 +2012,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<PackageManager> superCall = new NamedSuperCall<PackageManager>(
+        final CallFun0<PackageManager> superCall = new CallFun0<PackageManager>(
                 "getPackageManager()") {
 
             @Override
-            public PackageManager call(final Object... args) {
+            public PackageManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getPackageManager(this);
                 } else {
@@ -2090,10 +2034,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("getPackageName()") {
+        final CallFun0<String> superCall = new CallFun0<String>("getPackageName()") {
 
             @Override
-            public String call(final Object... args) {
+            public String call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getPackageName(this);
                 } else {
@@ -2111,11 +2055,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String> superCall = new NamedSuperCall<String>(
-                "getPackageResourcePath()") {
+        final CallFun0<String> superCall = new CallFun0<String>("getPackageResourcePath()") {
 
             @Override
-            public String call(final Object... args) {
+            public String call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getPackageResourcePath(this);
                 } else {
@@ -2133,11 +2076,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
-                "getParentActivityIntent()") {
+        final CallFun0<Intent> superCall = new CallFun0<Intent>("getParentActivityIntent()") {
 
             @Override
-            public Intent call(final Object... args) {
+            public Intent call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getParentActivityIntent(this);
                 } else {
@@ -2155,15 +2097,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<SharedPreferences> superCall = new NamedSuperCall<SharedPreferences>(
-                "getPreferences(int)") {
+        final CallFun1<SharedPreferences, Integer> superCall
+                = new CallFun1<SharedPreferences, Integer>("getPreferences(Integer)") {
 
             @Override
-            public SharedPreferences call(final Object... args) {
+            public SharedPreferences call(final Integer mode) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getPreferences(this, (int) args[0]);
+                    return iterator.previous().getPreferences(this, mode);
                 } else {
-                    return getOriginal().super_getPreferences((int) args[0]);
+                    return getOriginal().super_getPreferences(mode);
                 }
             }
         };
@@ -2177,10 +2119,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Uri> superCall = new NamedSuperCall<Uri>("getReferrer()") {
+        final CallFun0<Uri> superCall = new CallFun0<Uri>("getReferrer()") {
 
             @Override
-            public Uri call(final Object... args) {
+            public Uri call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getReferrer(this);
                 } else {
@@ -2198,11 +2140,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
-                "getRequestedOrientation()") {
+        final CallFun0<Integer> superCall = new CallFun0<Integer>("getRequestedOrientation()") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getRequestedOrientation(this);
                 } else {
@@ -2220,11 +2161,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Resources> superCall = new NamedSuperCall<Resources>(
-                "getResources()") {
+        final CallFun0<Resources> superCall = new CallFun0<Resources>("getResources()") {
 
             @Override
-            public Resources call(final Object... args) {
+            public Resources call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getResources(this);
                 } else {
@@ -2242,17 +2182,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<SharedPreferences> superCall = new NamedSuperCall<SharedPreferences>(
-                "getSharedPreferences(String, int)") {
+        final CallFun2<SharedPreferences, String, Integer> superCall
+                = new CallFun2<SharedPreferences, String, Integer>(
+                "getSharedPreferences(String, Integer)") {
 
             @Override
-            public SharedPreferences call(final Object... args) {
+            public SharedPreferences call(final String name, final Integer mode) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .getSharedPreferences(this, (String) args[0], (int) args[1]);
+                    return iterator.previous().getSharedPreferences(this, name, mode);
                 } else {
-                    return getOriginal()
-                            .super_getSharedPreferences((String) args[0], (int) args[1]);
+                    return getOriginal().super_getSharedPreferences(name, mode);
                 }
             }
         };
@@ -2266,11 +2205,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ActionBar> superCall = new NamedSuperCall<ActionBar>(
-                "getSupportActionBar()") {
+        final CallFun0<ActionBar> superCall = new CallFun0<ActionBar>("getSupportActionBar()") {
 
             @Override
-            public ActionBar call(final Object... args) {
+            public ActionBar call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getSupportActionBar(this);
                 } else {
@@ -2288,11 +2226,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<FragmentManager> superCall = new NamedSuperCall<FragmentManager>(
+        final CallFun0<FragmentManager> superCall = new CallFun0<FragmentManager>(
                 "getSupportFragmentManager()") {
 
             @Override
-            public FragmentManager call(final Object... args) {
+            public FragmentManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getSupportFragmentManager(this);
                 } else {
@@ -2310,11 +2248,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<LoaderManager> superCall = new NamedSuperCall<LoaderManager>(
+        final CallFun0<LoaderManager> superCall = new CallFun0<LoaderManager>(
                 "getSupportLoaderManager()") {
 
             @Override
-            public LoaderManager call(final Object... args) {
+            public LoaderManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getSupportLoaderManager(this);
                 } else {
@@ -2332,11 +2270,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
+        final CallFun0<Intent> superCall = new CallFun0<Intent>(
                 "getSupportParentActivityIntent()") {
 
             @Override
-            public Intent call(final Object... args) {
+            public Intent call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getSupportParentActivityIntent(this);
                 } else {
@@ -2354,15 +2292,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+        final CallFun1<Object, String> superCall = new CallFun1<Object, String>(
                 "getSystemService(String)") {
 
             @Override
-            public Object call(final Object... args) {
+            public Object call(final String name) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getSystemService(this, (String) args[0]);
+                    return iterator.previous().getSystemService(this, name);
                 } else {
-                    return getOriginal().super_getSystemService((String) args[0]);
+                    return getOriginal().super_getSystemService(name);
                 }
             }
         };
@@ -2376,15 +2314,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String> superCall = new NamedSuperCall<String>(
+        final CallFun1<String, Class<?>> superCall = new CallFun1<String, Class<?>>(
                 "getSystemServiceName(Class<?>)") {
 
             @Override
-            public String call(final Object... args) {
+            public String call(final Class<?> serviceClass) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getSystemServiceName(this, (Class<?>) args[0]);
+                    return iterator.previous().getSystemServiceName(this, serviceClass);
                 } else {
-                    return getOriginal().super_getSystemServiceName((Class<?>) args[0]);
+                    return getOriginal().super_getSystemServiceName(serviceClass);
                 }
             }
         };
@@ -2398,10 +2336,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>("getTaskId()") {
+        final CallFun0<Integer> superCall = new CallFun0<Integer>("getTaskId()") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getTaskId(this);
                 } else {
@@ -2419,11 +2357,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Resources.Theme> superCall = new NamedSuperCall<Resources.Theme>(
-                "getTheme()") {
+        final CallFun0<Resources.Theme> superCall = new CallFun0<Resources.Theme>("getTheme()") {
 
             @Override
-            public Resources.Theme call(final Object... args) {
+            public Resources.Theme call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getTheme(this);
                 } else {
@@ -2441,11 +2378,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<VoiceInteractor> superCall = new NamedSuperCall<VoiceInteractor>(
+        final CallFun0<VoiceInteractor> superCall = new CallFun0<VoiceInteractor>(
                 "getVoiceInteractor()") {
 
             @Override
-            public VoiceInteractor call(final Object... args) {
+            public VoiceInteractor call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getVoiceInteractor(this);
                 } else {
@@ -2463,10 +2400,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Drawable> superCall = new NamedSuperCall<Drawable>("getWallpaper()") {
+        final CallFun0<Drawable> superCall = new CallFun0<Drawable>("getWallpaper()") {
 
             @Override
-            public Drawable call(final Object... args) {
+            public Drawable call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getWallpaper(this);
                 } else {
@@ -2484,11 +2421,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+        final CallFun0<Integer> superCall = new CallFun0<Integer>(
                 "getWallpaperDesiredMinimumHeight()") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getWallpaperDesiredMinimumHeight(this);
                 } else {
@@ -2506,11 +2443,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+        final CallFun0<Integer> superCall = new CallFun0<Integer>(
                 "getWallpaperDesiredMinimumWidth()") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getWallpaperDesiredMinimumWidth(this);
                 } else {
@@ -2528,10 +2465,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Window> superCall = new NamedSuperCall<Window>("getWindow()") {
+        final CallFun0<Window> superCall = new CallFun0<Window>("getWindow()") {
 
             @Override
-            public Window call(final Object... args) {
+            public Window call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getWindow(this);
                 } else {
@@ -2549,11 +2486,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<WindowManager> superCall = new NamedSuperCall<WindowManager>(
+        final CallFun0<WindowManager> superCall = new CallFun0<WindowManager>(
                 "getWindowManager()") {
 
             @Override
-            public WindowManager call(final Object... args) {
+            public WindowManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getWindowManager(this);
                 } else {
@@ -2572,19 +2509,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "grantUriPermission(String, Uri, int)") {
+        final CallVoid3<String, Uri, Integer> superCall = new CallVoid3<String, Uri, Integer>(
+                "grantUriPermission(String, Uri, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String toPackage, final Uri uri, final Integer modeFlags) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().grantUriPermission(this, (String) args[0], (Uri) args[1],
-                            (int) args[2]);
-                    return null;
+                    iterator.previous().grantUriPermission(this, toPackage, uri, modeFlags);
                 } else {
-                    getOriginal().super_grantUriPermission((String) args[0], (Uri) args[1],
-                            (int) args[2]);
-                    return null;
+                    getOriginal().super_grantUriPermission(toPackage, uri, modeFlags);
                 }
             }
         };
@@ -2598,10 +2531,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("hasWindowFocus()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("hasWindowFocus()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().hasWindowFocus(this);
                 } else {
@@ -2620,16 +2553,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("invalidateOptionsMenu()") {
+        final CallVoid0 superCall = new CallVoid0("invalidateOptionsMenu()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().invalidateOptionsMenu(this);
-                    return null;
                 } else {
                     getOriginal().super_invalidateOptionsMenu();
-                    return null;
                 }
             }
         };
@@ -2643,11 +2574,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "isChangingConfigurations()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isChangingConfigurations()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isChangingConfigurations(this);
                 } else {
@@ -2665,10 +2595,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isDestroyed()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isDestroyed()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isDestroyed(this);
                 } else {
@@ -2686,10 +2616,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isFinishing()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isFinishing()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isFinishing(this);
                 } else {
@@ -2707,10 +2637,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isImmersive()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isImmersive()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isImmersive(this);
                 } else {
@@ -2728,10 +2658,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isRestricted()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isRestricted()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isRestricted(this);
                 } else {
@@ -2749,10 +2679,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isTaskRoot()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isTaskRoot()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isTaskRoot(this);
                 } else {
@@ -2770,11 +2700,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "isVoiceInteraction()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isVoiceInteraction()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isVoiceInteraction(this);
                 } else {
@@ -2792,11 +2721,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "isVoiceInteractionRoot()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isVoiceInteractionRoot()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isVoiceInteractionRoot(this);
                 } else {
@@ -2814,15 +2742,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "moveTaskToBack(boolean)") {
+        final CallFun1<Boolean, Boolean> superCall = new CallFun1<Boolean, Boolean>(
+                "moveTaskToBack(Boolean)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Boolean nonRoot) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().moveTaskToBack(this, (boolean) args[0]);
+                    return iterator.previous().moveTaskToBack(this, nonRoot);
                 } else {
-                    return getOriginal().super_moveTaskToBack((boolean) args[0]);
+                    return getOriginal().super_moveTaskToBack(nonRoot);
                 }
             }
         };
@@ -2836,15 +2764,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "navigateUpTo(Intent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent upIntent) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().navigateUpTo(this, (Intent) args[0]);
+                    return iterator.previous().navigateUpTo(this, upIntent);
                 } else {
-                    return getOriginal().super_navigateUpTo((Intent) args[0]);
+                    return getOriginal().super_navigateUpTo(upIntent);
                 }
             }
         };
@@ -2858,17 +2786,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun2<Boolean, Activity, Intent> superCall
+                = new CallFun2<Boolean, Activity, Intent>(
                 "navigateUpToFromChild(Activity, Intent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Activity child, final Intent upIntent) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .navigateUpToFromChild(this, (Activity) args[0], (Intent) args[1]);
+                    return iterator.previous().navigateUpToFromChild(this, child, upIntent);
                 } else {
-                    return getOriginal()
-                            .super_navigateUpToFromChild((Activity) args[0], (Intent) args[1]);
+                    return getOriginal().super_navigateUpToFromChild(child, upIntent);
                 }
             }
         };
@@ -2883,18 +2810,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.view.ActionMode> superCall = new CallVoid1<android.view.ActionMode>(
                 "onActionModeFinished(android.view.ActionMode)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.view.ActionMode mode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onActionModeFinished(this, (android.view.ActionMode) args[0]);
-                    return null;
+                    iterator.previous().onActionModeFinished(this, mode);
                 } else {
-                    getOriginal().super_onActionModeFinished((android.view.ActionMode) args[0]);
-                    return null;
+                    getOriginal().super_onActionModeFinished(mode);
                 }
             }
         };
@@ -2909,18 +2833,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.view.ActionMode> superCall = new CallVoid1<android.view.ActionMode>(
                 "onActionModeStarted(android.view.ActionMode)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.view.ActionMode mode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onActionModeStarted(this, (android.view.ActionMode) args[0]);
-                    return null;
+                    iterator.previous().onActionModeStarted(this, mode);
                 } else {
-                    getOriginal().super_onActionModeStarted((android.view.ActionMode) args[0]);
-                    return null;
+                    getOriginal().super_onActionModeStarted(mode);
                 }
             }
         };
@@ -2935,17 +2856,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onActivityReenter(int, Intent)") {
+        final CallVoid2<Integer, Intent> superCall = new CallVoid2<Integer, Intent>(
+                "onActivityReenter(Integer, Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer resultCode, final Intent data) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onActivityReenter(this, (int) args[0], (Intent) args[1]);
-                    return null;
+                    iterator.previous().onActivityReenter(this, resultCode, data);
                 } else {
-                    getOriginal().super_onActivityReenter((int) args[0], (Intent) args[1]);
-                    return null;
+                    getOriginal().super_onActivityReenter(resultCode, data);
                 }
             }
         };
@@ -2960,19 +2879,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onActivityResult(int, int, Intent)") {
+        final CallVoid3<Integer, Integer, Intent> superCall
+                = new CallVoid3<Integer, Integer, Intent>(
+                "onActivityResult(Integer, Integer, Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer requestCode, final Integer resultCode,
+                    final Intent data) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onActivityResult(this, (int) args[0], (int) args[1], (Intent) args[2]);
-                    return null;
+                    iterator.previous().onActivityResult(this, requestCode, resultCode, data);
                 } else {
-                    getOriginal()
-                            .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
-                    return null;
+                    getOriginal().super_onActivityResult(requestCode, resultCode, data);
                 }
             }
         };
@@ -2988,21 +2905,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onApplyThemeResource(Resources.Theme, int, boolean)") {
+        final CallVoid3<Resources.Theme, Integer, Boolean> superCall
+                = new CallVoid3<Resources.Theme, Integer, Boolean>(
+                "onApplyThemeResource(Resources.Theme, Integer, Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Resources.Theme theme, final Integer resid,
+                    final Boolean first) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onApplyThemeResource(this, (Resources.Theme) args[0], (int) args[1],
-                                    (boolean) args[2]);
-                    return null;
+                    iterator.previous().onApplyThemeResource(this, theme, resid, first);
                 } else {
-                    getOriginal()
-                            .super_onApplyThemeResource((Resources.Theme) args[0], (int) args[1],
-                                    (boolean) args[2]);
-                    return null;
+                    getOriginal().super_onApplyThemeResource(theme, resid, first);
                 }
             }
         };
@@ -3017,17 +2930,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Fragment> superCall = new CallVoid1<Fragment>(
                 "onAttachFragment(Fragment)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Fragment fragment) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onAttachFragment(this, (Fragment) args[0]);
-                    return null;
+                    iterator.previous().onAttachFragment(this, fragment);
                 } else {
-                    getOriginal().super_onAttachFragment((Fragment) args[0]);
-                    return null;
+                    getOriginal().super_onAttachFragment(fragment);
                 }
             }
         };
@@ -3042,17 +2953,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.app.Fragment> superCall = new CallVoid1<android.app.Fragment>(
                 "onAttachFragment(android.app.Fragment)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.app.Fragment fragment) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onAttachFragment(this, (android.app.Fragment) args[0]);
-                    return null;
+                    iterator.previous().onAttachFragment(this, fragment);
                 } else {
-                    getOriginal().super_onAttachFragment((android.app.Fragment) args[0]);
-                    return null;
+                    getOriginal().super_onAttachFragment(fragment);
                 }
             }
         };
@@ -3067,16 +2976,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onAttachedToWindow()") {
+        final CallVoid0 superCall = new CallVoid0("onAttachedToWindow()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onAttachedToWindow(this);
-                    return null;
                 } else {
                     getOriginal().super_onAttachedToWindow();
-                    return null;
                 }
             }
         };
@@ -3091,16 +2998,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onBackPressed()") {
+        final CallVoid0 superCall = new CallVoid0("onBackPressed()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onBackPressed(this);
-                    return null;
                 } else {
                     getOriginal().super_onBackPressed();
-                    return null;
                 }
             }
         };
@@ -3115,19 +3020,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Activity, CharSequence> superCall = new CallVoid2<Activity, CharSequence>(
                 "onChildTitleChanged(Activity, CharSequence)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity childActivity, final CharSequence title) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onChildTitleChanged(this, (Activity) args[0], (CharSequence) args[1]);
-                    return null;
+                    iterator.previous().onChildTitleChanged(this, childActivity, title);
                 } else {
-                    getOriginal()
-                            .super_onChildTitleChanged((Activity) args[0], (CharSequence) args[1]);
-                    return null;
+                    getOriginal().super_onChildTitleChanged(childActivity, title);
                 }
             }
         };
@@ -3142,17 +3043,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Configuration> superCall = new CallVoid1<Configuration>(
                 "onConfigurationChanged(Configuration)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Configuration newConfig) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onConfigurationChanged(this, (Configuration) args[0]);
-                    return null;
+                    iterator.previous().onConfigurationChanged(this, newConfig);
                 } else {
-                    getOriginal().super_onConfigurationChanged((Configuration) args[0]);
-                    return null;
+                    getOriginal().super_onConfigurationChanged(newConfig);
                 }
             }
         };
@@ -3167,16 +3066,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onContentChanged()") {
+        final CallVoid0 superCall = new CallVoid0("onContentChanged()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onContentChanged(this);
-                    return null;
                 } else {
                     getOriginal().super_onContentChanged();
-                    return null;
                 }
             }
         };
@@ -3190,15 +3087,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onContextItemSelected(MenuItem)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MenuItem item) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onContextItemSelected(this, (MenuItem) args[0]);
+                    return iterator.previous().onContextItemSelected(this, item);
                 } else {
-                    return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
+                    return getOriginal().super_onContextItemSelected(item);
                 }
             }
         };
@@ -3213,17 +3110,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onContextMenuClosed(Menu)") {
+        final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onContextMenuClosed(Menu)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onContextMenuClosed(this, (Menu) args[0]);
-                    return null;
+                    iterator.previous().onContextMenuClosed(this, menu);
                 } else {
-                    getOriginal().super_onContextMenuClosed((Menu) args[0]);
-                    return null;
+                    getOriginal().super_onContextMenuClosed(menu);
                 }
             }
         };
@@ -3238,18 +3132,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onCreate(Bundle, PersistableBundle)") {
+        final CallVoid2<Bundle, PersistableBundle> superCall
+                = new CallVoid2<Bundle, PersistableBundle>("onCreate(Bundle, PersistableBundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState,
+                    final PersistableBundle persistentState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onCreate(this, (Bundle) args[0], (PersistableBundle) args[1]);
-                    return null;
+                    iterator.previous().onCreate(this, savedInstanceState, persistentState);
                 } else {
-                    getOriginal().super_onCreate((Bundle) args[0], (PersistableBundle) args[1]);
-                    return null;
+                    getOriginal().super_onCreate(savedInstanceState, persistentState);
                 }
             }
         };
@@ -3264,16 +3156,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onCreate(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onCreate(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onCreate(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onCreate(this, savedInstanceState);
                 } else {
-                    getOriginal().super_onCreate((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onCreate(savedInstanceState);
                 }
             }
         };
@@ -3289,20 +3179,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo> superCall
+                = new CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo>(
                 "onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ContextMenu menu, final View v,
+                    final ContextMenu.ContextMenuInfo menuInfo) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onCreateContextMenu(this, (ContextMenu) args[0], (View) args[1],
-                                    (ContextMenu.ContextMenuInfo) args[2]);
-                    return null;
+                    iterator.previous().onCreateContextMenu(this, menu, v, menuInfo);
                 } else {
-                    getOriginal().super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
-                            (ContextMenu.ContextMenuInfo) args[2]);
-                    return null;
+                    getOriginal().super_onCreateContextMenu(menu, v, menuInfo);
                 }
             }
         };
@@ -3316,11 +3203,11 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<CharSequence> superCall = new NamedSuperCall<CharSequence>(
+        final CallFun0<CharSequence> superCall = new CallFun0<CharSequence>(
                 "onCreateDescription()") {
 
             @Override
-            public CharSequence call(final Object... args) {
+            public CharSequence call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().onCreateDescription(this);
                 } else {
@@ -3338,14 +3225,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>("onCreateDialog(int)") {
+        final CallFun1<Dialog, Integer> superCall = new CallFun1<Dialog, Integer>(
+                "onCreateDialog(Integer)") {
 
             @Override
-            public Dialog call(final Object... args) {
+            public Dialog call(final Integer id) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onCreateDialog(this, (int) args[0]);
+                    return iterator.previous().onCreateDialog(this, id);
                 } else {
-                    return getOriginal().super_onCreateDialog((int) args[0]);
+                    return getOriginal().super_onCreateDialog(id);
                 }
             }
         };
@@ -3359,16 +3247,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>(
-                "onCreateDialog(int, Bundle)") {
+        final CallFun2<Dialog, Integer, Bundle> superCall = new CallFun2<Dialog, Integer, Bundle>(
+                "onCreateDialog(Integer, Bundle)") {
 
             @Override
-            public Dialog call(final Object... args) {
+            public Dialog call(final Integer id, final Bundle args) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onCreateDialog(this, (int) args[0], (Bundle) args[1]);
+                    return iterator.previous().onCreateDialog(this, id, args);
                 } else {
-                    return getOriginal().super_onCreateDialog((int) args[0], (Bundle) args[1]);
+                    return getOriginal().super_onCreateDialog(id, args);
                 }
             }
         };
@@ -3383,18 +3270,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<TaskStackBuilder> superCall = new CallVoid1<TaskStackBuilder>(
                 "onCreateNavigateUpTaskStack(TaskStackBuilder)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final TaskStackBuilder builder) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onCreateNavigateUpTaskStack(this, (TaskStackBuilder) args[0]);
-                    return null;
+                    iterator.previous().onCreateNavigateUpTaskStack(this, builder);
                 } else {
-                    getOriginal().super_onCreateNavigateUpTaskStack((TaskStackBuilder) args[0]);
-                    return null;
+                    getOriginal().super_onCreateNavigateUpTaskStack(builder);
                 }
             }
         };
@@ -3408,15 +3292,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Menu> superCall = new CallFun1<Boolean, Menu>(
                 "onCreateOptionsMenu(Menu)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onCreateOptionsMenu(this, (Menu) args[0]);
+                    return iterator.previous().onCreateOptionsMenu(this, menu);
                 } else {
-                    return getOriginal().super_onCreateOptionsMenu((Menu) args[0]);
+                    return getOriginal().super_onCreateOptionsMenu(menu);
                 }
             }
         };
@@ -3430,16 +3314,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onCreatePanelMenu(int, Menu)") {
+        final CallFun2<Boolean, Integer, Menu> superCall = new CallFun2<Boolean, Integer, Menu>(
+                "onCreatePanelMenu(Integer, Menu)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer featureId, final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onCreatePanelMenu(this, (int) args[0], (Menu) args[1]);
+                    return iterator.previous().onCreatePanelMenu(this, featureId, menu);
                 } else {
-                    return getOriginal().super_onCreatePanelMenu((int) args[0], (Menu) args[1]);
+                    return getOriginal().super_onCreatePanelMenu(featureId, menu);
                 }
             }
         };
@@ -3453,14 +3336,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("onCreatePanelView(int)") {
+        final CallFun1<View, Integer> superCall = new CallFun1<View, Integer>(
+                "onCreatePanelView(Integer)") {
 
             @Override
-            public View call(final Object... args) {
+            public View call(final Integer featureId) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onCreatePanelView(this, (int) args[0]);
+                    return iterator.previous().onCreatePanelView(this, featureId);
                 } else {
-                    return getOriginal().super_onCreatePanelView((int) args[0]);
+                    return getOriginal().super_onCreatePanelView(featureId);
                 }
             }
         };
@@ -3476,19 +3360,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.support.v4.app.TaskStackBuilder> superCall
+                = new CallVoid1<android.support.v4.app.TaskStackBuilder>(
                 "onCreateSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.support.v4.app.TaskStackBuilder builder) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onCreateSupportNavigateUpTaskStack(this,
-                            (android.support.v4.app.TaskStackBuilder) args[0]);
-                    return null;
+                    iterator.previous().onCreateSupportNavigateUpTaskStack(this, builder);
                 } else {
-                    getOriginal().super_onCreateSupportNavigateUpTaskStack(
-                            (android.support.v4.app.TaskStackBuilder) args[0]);
-                    return null;
+                    getOriginal().super_onCreateSupportNavigateUpTaskStack(builder);
                 }
             }
         };
@@ -3502,17 +3383,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun2<Boolean, Bitmap, Canvas> superCall = new CallFun2<Boolean, Bitmap, Canvas>(
                 "onCreateThumbnail(Bitmap, Canvas)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Bitmap outBitmap, final Canvas canvas) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onCreateThumbnail(this, (Bitmap) args[0], (Canvas) args[1]);
+                    return iterator.previous().onCreateThumbnail(this, outBitmap, canvas);
                 } else {
-                    return getOriginal()
-                            .super_onCreateThumbnail((Bitmap) args[0], (Canvas) args[1]);
+                    return getOriginal().super_onCreateThumbnail(outBitmap, canvas);
                 }
             }
         };
@@ -3527,19 +3406,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<View> superCall = new NamedSuperCall<View>(
+        final CallFun4<View, View, String, Context, AttributeSet> superCall
+                = new CallFun4<View, View, String, Context, AttributeSet>(
                 "onCreateView(View, String, Context, AttributeSet)") {
 
             @Override
-            public View call(final Object... args) {
+            public View call(final View parent, final String name, final Context context,
+                    final AttributeSet attrs) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onCreateView(this, (View) args[0], (String) args[1], (Context) args[2],
-                                    (AttributeSet) args[3]);
+                    return iterator.previous().onCreateView(this, parent, name, context, attrs);
                 } else {
-                    return getOriginal()
-                            .super_onCreateView((View) args[0], (String) args[1], (Context) args[2],
-                                    (AttributeSet) args[3]);
+                    return getOriginal().super_onCreateView(parent, name, context, attrs);
                 }
             }
         };
@@ -3553,18 +3430,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<View> superCall = new NamedSuperCall<View>(
+        final CallFun3<View, String, Context, AttributeSet> superCall
+                = new CallFun3<View, String, Context, AttributeSet>(
                 "onCreateView(String, Context, AttributeSet)") {
 
             @Override
-            public View call(final Object... args) {
+            public View call(final String name, final Context context, final AttributeSet attrs) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onCreateView(this, (String) args[0], (Context) args[1],
-                                    (AttributeSet) args[2]);
+                    return iterator.previous().onCreateView(this, name, context, attrs);
                 } else {
-                    return getOriginal().super_onCreateView((String) args[0], (Context) args[1],
-                            (AttributeSet) args[2]);
+                    return getOriginal().super_onCreateView(name, context, attrs);
                 }
             }
         };
@@ -3579,16 +3454,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroy()") {
+        final CallVoid0 superCall = new CallVoid0("onDestroy()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onDestroy(this);
-                    return null;
                 } else {
                     getOriginal().super_onDestroy();
-                    return null;
                 }
             }
         };
@@ -3603,16 +3476,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDetachedFromWindow()") {
+        final CallVoid0 superCall = new CallVoid0("onDetachedFromWindow()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onDetachedFromWindow(this);
-                    return null;
                 } else {
                     getOriginal().super_onDetachedFromWindow();
-                    return null;
                 }
             }
         };
@@ -3627,17 +3498,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onEnterAnimationComplete()") {
+        final CallVoid0 superCall = new CallVoid0("onEnterAnimationComplete()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onEnterAnimationComplete(this);
-                    return null;
                 } else {
                     getOriginal().super_onEnterAnimationComplete();
-                    return null;
                 }
             }
         };
@@ -3651,15 +3519,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "onGenericMotionEvent(MotionEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MotionEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onGenericMotionEvent(this, (MotionEvent) args[0]);
+                    return iterator.previous().onGenericMotionEvent(this, event);
                 } else {
-                    return getOriginal().super_onGenericMotionEvent((MotionEvent) args[0]);
+                    return getOriginal().super_onGenericMotionEvent(event);
                 }
             }
         };
@@ -3673,15 +3541,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onKeyDown(int, KeyEvent)") {
+        final CallFun2<Boolean, Integer, KeyEvent> superCall
+                = new CallFun2<Boolean, Integer, KeyEvent>("onKeyDown(Integer, KeyEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer keyCode, final KeyEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onKeyDown(this, (int) args[0], (KeyEvent) args[1]);
+                    return iterator.previous().onKeyDown(this, keyCode, event);
                 } else {
-                    return getOriginal().super_onKeyDown((int) args[0], (KeyEvent) args[1]);
+                    return getOriginal().super_onKeyDown(keyCode, event);
                 }
             }
         };
@@ -3695,16 +3563,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onKeyLongPress(int, KeyEvent)") {
+        final CallFun2<Boolean, Integer, KeyEvent> superCall
+                = new CallFun2<Boolean, Integer, KeyEvent>("onKeyLongPress(Integer, KeyEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer keyCode, final KeyEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onKeyLongPress(this, (int) args[0], (KeyEvent) args[1]);
+                    return iterator.previous().onKeyLongPress(this, keyCode, event);
                 } else {
-                    return getOriginal().super_onKeyLongPress((int) args[0], (KeyEvent) args[1]);
+                    return getOriginal().super_onKeyLongPress(keyCode, event);
                 }
             }
         };
@@ -3718,17 +3585,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onKeyMultiple(int, int, KeyEvent)") {
+        final CallFun3<Boolean, Integer, Integer, KeyEvent> superCall
+                = new CallFun3<Boolean, Integer, Integer, KeyEvent>(
+                "onKeyMultiple(Integer, Integer, KeyEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer keyCode, final Integer repeatCount,
+                    final KeyEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onKeyMultiple(this, (int) args[0], (int) args[1], (KeyEvent) args[2]);
+                    return iterator.previous().onKeyMultiple(this, keyCode, repeatCount, event);
                 } else {
-                    return getOriginal()
-                            .super_onKeyMultiple((int) args[0], (int) args[1], (KeyEvent) args[2]);
+                    return getOriginal().super_onKeyMultiple(keyCode, repeatCount, event);
                 }
             }
         };
@@ -3742,16 +3609,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onKeyShortcut(int, KeyEvent)") {
+        final CallFun2<Boolean, Integer, KeyEvent> superCall
+                = new CallFun2<Boolean, Integer, KeyEvent>("onKeyShortcut(Integer, KeyEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer keyCode, final KeyEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onKeyShortcut(this, (int) args[0], (KeyEvent) args[1]);
+                    return iterator.previous().onKeyShortcut(this, keyCode, event);
                 } else {
-                    return getOriginal().super_onKeyShortcut((int) args[0], (KeyEvent) args[1]);
+                    return getOriginal().super_onKeyShortcut(keyCode, event);
                 }
             }
         };
@@ -3765,15 +3631,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onKeyUp(int, KeyEvent)") {
+        final CallFun2<Boolean, Integer, KeyEvent> superCall
+                = new CallFun2<Boolean, Integer, KeyEvent>("onKeyUp(Integer, KeyEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer keyCode, final KeyEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onKeyUp(this, (int) args[0], (KeyEvent) args[1]);
+                    return iterator.previous().onKeyUp(this, keyCode, event);
                 } else {
-                    return getOriginal().super_onKeyUp((int) args[0], (KeyEvent) args[1]);
+                    return getOriginal().super_onKeyUp(keyCode, event);
                 }
             }
         };
@@ -3788,16 +3654,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onLowMemory()") {
+        final CallVoid0 superCall = new CallVoid0("onLowMemory()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onLowMemory(this);
-                    return null;
                 } else {
                     getOriginal().super_onLowMemory();
-                    return null;
                 }
             }
         };
@@ -3811,15 +3675,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onMenuOpened(int, Menu)") {
+        final CallFun2<Boolean, Integer, Menu> superCall = new CallFun2<Boolean, Integer, Menu>(
+                "onMenuOpened(Integer, Menu)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer featureId, final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onMenuOpened(this, (int) args[0], (Menu) args[1]);
+                    return iterator.previous().onMenuOpened(this, featureId, menu);
                 } else {
-                    return getOriginal().super_onMenuOpened((int) args[0], (Menu) args[1]);
+                    return getOriginal().super_onMenuOpened(featureId, menu);
                 }
             }
         };
@@ -3833,10 +3697,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("onNavigateUp()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("onNavigateUp()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().onNavigateUp(this);
                 } else {
@@ -3854,15 +3718,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Activity> superCall = new CallFun1<Boolean, Activity>(
                 "onNavigateUpFromChild(Activity)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Activity child) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onNavigateUpFromChild(this, (Activity) args[0]);
+                    return iterator.previous().onNavigateUpFromChild(this, child);
                 } else {
-                    return getOriginal().super_onNavigateUpFromChild((Activity) args[0]);
+                    return getOriginal().super_onNavigateUpFromChild(child);
                 }
             }
         };
@@ -3877,16 +3741,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onNewIntent(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("onNewIntent(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onNewIntent(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().onNewIntent(this, intent);
                 } else {
-                    getOriginal().super_onNewIntent((Intent) args[0]);
-                    return null;
+                    getOriginal().super_onNewIntent(intent);
                 }
             }
         };
@@ -3900,15 +3762,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onOptionsItemSelected(MenuItem)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MenuItem item) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onOptionsItemSelected(this, (MenuItem) args[0]);
+                    return iterator.previous().onOptionsItemSelected(this, item);
                 } else {
-                    return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
+                    return getOriginal().super_onOptionsItemSelected(item);
                 }
             }
         };
@@ -3923,17 +3785,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onOptionsMenuClosed(Menu)") {
+        final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onOptionsMenuClosed(Menu)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onOptionsMenuClosed(this, (Menu) args[0]);
-                    return null;
+                    iterator.previous().onOptionsMenuClosed(this, menu);
                 } else {
-                    getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
-                    return null;
+                    getOriginal().super_onOptionsMenuClosed(menu);
                 }
             }
         };
@@ -3948,17 +3807,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onPanelClosed(int, Menu)") {
+        final CallVoid2<Integer, Menu> superCall = new CallVoid2<Integer, Menu>(
+                "onPanelClosed(Integer, Menu)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer featureId, final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onPanelClosed(this, (int) args[0], (Menu) args[1]);
-                    return null;
+                    iterator.previous().onPanelClosed(this, featureId, menu);
                 } else {
-                    getOriginal().super_onPanelClosed((int) args[0], (Menu) args[1]);
-                    return null;
+                    getOriginal().super_onPanelClosed(featureId, menu);
                 }
             }
         };
@@ -3973,16 +3830,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPause()") {
+        final CallVoid0 superCall = new CallVoid0("onPause()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onPause(this);
-                    return null;
                 } else {
                     getOriginal().super_onPause();
-                    return null;
                 }
             }
         };
@@ -3998,18 +3853,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Bundle, PersistableBundle> superCall
+                = new CallVoid2<Bundle, PersistableBundle>(
                 "onPostCreate(Bundle, PersistableBundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState,
+                    final PersistableBundle persistentState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onPostCreate(this, (Bundle) args[0], (PersistableBundle) args[1]);
-                    return null;
+                    iterator.previous().onPostCreate(this, savedInstanceState, persistentState);
                 } else {
-                    getOriginal().super_onPostCreate((Bundle) args[0], (PersistableBundle) args[1]);
-                    return null;
+                    getOriginal().super_onPostCreate(savedInstanceState, persistentState);
                 }
             }
         };
@@ -4024,16 +3878,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPostCreate(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onPostCreate(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onPostCreate(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onPostCreate(this, savedInstanceState);
                 } else {
-                    getOriginal().super_onPostCreate((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onPostCreate(savedInstanceState);
                 }
             }
         };
@@ -4048,16 +3900,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPostResume()") {
+        final CallVoid0 superCall = new CallVoid0("onPostResume()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onPostResume(this);
-                    return null;
                 } else {
                     getOriginal().super_onPostResume();
-                    return null;
                 }
             }
         };
@@ -4072,17 +3922,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onPrepareDialog(int, Dialog)") {
+        final CallVoid2<Integer, Dialog> superCall = new CallVoid2<Integer, Dialog>(
+                "onPrepareDialog(Integer, Dialog)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer id, final Dialog dialog) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onPrepareDialog(this, (int) args[0], (Dialog) args[1]);
-                    return null;
+                    iterator.previous().onPrepareDialog(this, id, dialog);
                 } else {
-                    getOriginal().super_onPrepareDialog((int) args[0], (Dialog) args[1]);
-                    return null;
+                    getOriginal().super_onPrepareDialog(id, dialog);
                 }
             }
         };
@@ -4097,19 +3945,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onPrepareDialog(int, Dialog, Bundle)") {
+        final CallVoid3<Integer, Dialog, Bundle> superCall = new CallVoid3<Integer, Dialog, Bundle>(
+                "onPrepareDialog(Integer, Dialog, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer id, final Dialog dialog, final Bundle args) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onPrepareDialog(this, (int) args[0], (Dialog) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    iterator.previous().onPrepareDialog(this, id, dialog, args);
                 } else {
-                    getOriginal().super_onPrepareDialog((int) args[0], (Dialog) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    getOriginal().super_onPrepareDialog(id, dialog, args);
                 }
             }
         };
@@ -4124,18 +3968,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<TaskStackBuilder> superCall = new CallVoid1<TaskStackBuilder>(
                 "onPrepareNavigateUpTaskStack(TaskStackBuilder)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final TaskStackBuilder builder) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onPrepareNavigateUpTaskStack(this, (TaskStackBuilder) args[0]);
-                    return null;
+                    iterator.previous().onPrepareNavigateUpTaskStack(this, builder);
                 } else {
-                    getOriginal().super_onPrepareNavigateUpTaskStack((TaskStackBuilder) args[0]);
-                    return null;
+                    getOriginal().super_onPrepareNavigateUpTaskStack(builder);
                 }
             }
         };
@@ -4149,15 +3990,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Menu> superCall = new CallFun1<Boolean, Menu>(
                 "onPrepareOptionsMenu(Menu)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onPrepareOptionsMenu(this, (Menu) args[0]);
+                    return iterator.previous().onPrepareOptionsMenu(this, menu);
                 } else {
-                    return getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
+                    return getOriginal().super_onPrepareOptionsMenu(menu);
                 }
             }
         };
@@ -4171,17 +4012,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun2<Boolean, View, Menu> superCall = new CallFun2<Boolean, View, Menu>(
                 "onPrepareOptionsPanel(View, Menu)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final View view, final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onPrepareOptionsPanel(this, (View) args[0], (Menu) args[1]);
+                    return iterator.previous().onPrepareOptionsPanel(this, view, menu);
                 } else {
-                    return getOriginal()
-                            .super_onPrepareOptionsPanel((View) args[0], (Menu) args[1]);
+                    return getOriginal().super_onPrepareOptionsPanel(view, menu);
                 }
             }
         };
@@ -4195,17 +4034,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onPreparePanel(int, View, Menu)") {
+        final CallFun3<Boolean, Integer, View, Menu> superCall
+                = new CallFun3<Boolean, Integer, View, Menu>(
+                "onPreparePanel(Integer, View, Menu)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer featureId, final View view, final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onPreparePanel(this, (int) args[0], (View) args[1], (Menu) args[2]);
+                    return iterator.previous().onPreparePanel(this, featureId, view, menu);
                 } else {
-                    return getOriginal()
-                            .super_onPreparePanel((int) args[0], (View) args[1], (Menu) args[2]);
+                    return getOriginal().super_onPreparePanel(featureId, view, menu);
                 }
             }
         };
@@ -4221,19 +4059,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.support.v4.app.TaskStackBuilder> superCall
+                = new CallVoid1<android.support.v4.app.TaskStackBuilder>(
                 "onPrepareSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.support.v4.app.TaskStackBuilder builder) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onPrepareSupportNavigateUpTaskStack(this,
-                            (android.support.v4.app.TaskStackBuilder) args[0]);
-                    return null;
+                    iterator.previous().onPrepareSupportNavigateUpTaskStack(this, builder);
                 } else {
-                    getOriginal().super_onPrepareSupportNavigateUpTaskStack(
-                            (android.support.v4.app.TaskStackBuilder) args[0]);
-                    return null;
+                    getOriginal().super_onPrepareSupportNavigateUpTaskStack(builder);
                 }
             }
         };
@@ -4248,17 +4083,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<AssistContent> superCall = new CallVoid1<AssistContent>(
                 "onProvideAssistContent(AssistContent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final AssistContent outContent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onProvideAssistContent(this, (AssistContent) args[0]);
-                    return null;
+                    iterator.previous().onProvideAssistContent(this, outContent);
                 } else {
-                    getOriginal().super_onProvideAssistContent((AssistContent) args[0]);
-                    return null;
+                    getOriginal().super_onProvideAssistContent(outContent);
                 }
             }
         };
@@ -4273,17 +4106,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onProvideAssistData(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onProvideAssistData(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle data) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onProvideAssistData(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onProvideAssistData(this, data);
                 } else {
-                    getOriginal().super_onProvideAssistData((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onProvideAssistData(data);
                 }
             }
         };
@@ -4297,10 +4127,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Uri> superCall = new NamedSuperCall<Uri>("onProvideReferrer()") {
+        final CallFun0<Uri> superCall = new CallFun0<Uri>("onProvideReferrer()") {
 
             @Override
-            public Uri call(final Object... args) {
+            public Uri call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().onProvideReferrer(this);
                 } else {
@@ -4320,21 +4150,19 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onRequestPermissionsResult(int, String[], int[])") {
+        final CallVoid3<Integer, String[], int[]> superCall
+                = new CallVoid3<Integer, String[], int[]>(
+                "onRequestPermissionsResult(Integer, String[], int[])") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer requestCode, final String[] permissions,
+                    final int[] grantResults) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onRequestPermissionsResult(this, (int) args[0], (String[]) args[1],
-                                    (int[]) args[2]);
-                    return null;
+                    iterator.previous().onRequestPermissionsResult(this, requestCode, permissions,
+                            grantResults);
                 } else {
-                    getOriginal()
-                            .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
-                                    (int[]) args[2]);
-                    return null;
+                    getOriginal().super_onRequestPermissionsResult(requestCode, permissions,
+                            grantResults);
                 }
             }
         };
@@ -4349,16 +4177,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onRestart()") {
+        final CallVoid0 superCall = new CallVoid0("onRestart()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onRestart(this);
-                    return null;
                 } else {
                     getOriginal().super_onRestart();
-                    return null;
                 }
             }
         };
@@ -4374,19 +4200,18 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Bundle, PersistableBundle> superCall
+                = new CallVoid2<Bundle, PersistableBundle>(
                 "onRestoreInstanceState(Bundle, PersistableBundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState,
+                    final PersistableBundle persistentState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onRestoreInstanceState(this, (Bundle) args[0],
-                            (PersistableBundle) args[1]);
-                    return null;
+                    iterator.previous()
+                            .onRestoreInstanceState(this, savedInstanceState, persistentState);
                 } else {
-                    getOriginal().super_onRestoreInstanceState((Bundle) args[0],
-                            (PersistableBundle) args[1]);
-                    return null;
+                    getOriginal().super_onRestoreInstanceState(savedInstanceState, persistentState);
                 }
             }
         };
@@ -4401,17 +4226,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>(
                 "onRestoreInstanceState(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onRestoreInstanceState(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onRestoreInstanceState(this, savedInstanceState);
                 } else {
-                    getOriginal().super_onRestoreInstanceState((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onRestoreInstanceState(savedInstanceState);
                 }
             }
         };
@@ -4426,16 +4249,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onResume()") {
+        final CallVoid0 superCall = new CallVoid0("onResume()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onResume(this);
-                    return null;
                 } else {
                     getOriginal().super_onResume();
-                    return null;
                 }
             }
         };
@@ -4450,16 +4271,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onResumeFragments()") {
+        final CallVoid0 superCall = new CallVoid0("onResumeFragments()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onResumeFragments(this);
-                    return null;
                 } else {
                     getOriginal().super_onResumeFragments();
-                    return null;
                 }
             }
         };
@@ -4488,19 +4307,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Bundle, PersistableBundle> superCall
+                = new CallVoid2<Bundle, PersistableBundle>(
                 "onSaveInstanceState(Bundle, PersistableBundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle outState, final PersistableBundle outPersistentState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onSaveInstanceState(this, (Bundle) args[0],
-                            (PersistableBundle) args[1]);
-                    return null;
+                    iterator.previous().onSaveInstanceState(this, outState, outPersistentState);
                 } else {
-                    getOriginal().super_onSaveInstanceState((Bundle) args[0],
-                            (PersistableBundle) args[1]);
-                    return null;
+                    getOriginal().super_onSaveInstanceState(outState, outPersistentState);
                 }
             }
         };
@@ -4515,17 +4331,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onSaveInstanceState(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onSaveInstanceState(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle outState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onSaveInstanceState(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onSaveInstanceState(this, outState);
                 } else {
-                    getOriginal().super_onSaveInstanceState((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onSaveInstanceState(outState);
                 }
             }
         };
@@ -4539,15 +4352,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, SearchEvent> superCall = new CallFun1<Boolean, SearchEvent>(
                 "onSearchRequested(SearchEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final SearchEvent searchEvent) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onSearchRequested(this, (SearchEvent) args[0]);
+                    return iterator.previous().onSearchRequested(this, searchEvent);
                 } else {
-                    return getOriginal().super_onSearchRequested((SearchEvent) args[0]);
+                    return getOriginal().super_onSearchRequested(searchEvent);
                 }
             }
         };
@@ -4561,11 +4374,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onSearchRequested()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("onSearchRequested()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().onSearchRequested(this);
                 } else {
@@ -4584,16 +4396,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStart()") {
+        final CallVoid0 superCall = new CallVoid0("onStart()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onStart(this);
-                    return null;
                 } else {
                     getOriginal().super_onStart();
-                    return null;
                 }
             }
         };
@@ -4608,16 +4418,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStateNotSaved()") {
+        final CallVoid0 superCall = new CallVoid0("onStateNotSaved()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onStateNotSaved(this);
-                    return null;
                 } else {
                     getOriginal().super_onStateNotSaved();
-                    return null;
                 }
             }
         };
@@ -4632,16 +4440,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStop()") {
+        final CallVoid0 superCall = new CallVoid0("onStop()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onStop(this);
-                    return null;
                 } else {
                     getOriginal().super_onStop();
-                    return null;
                 }
             }
         };
@@ -4656,17 +4462,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<ActionMode> superCall = new CallVoid1<ActionMode>(
                 "onSupportActionModeFinished(ActionMode)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ActionMode mode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onSupportActionModeFinished(this, (ActionMode) args[0]);
-                    return null;
+                    iterator.previous().onSupportActionModeFinished(this, mode);
                 } else {
-                    getOriginal().super_onSupportActionModeFinished((ActionMode) args[0]);
-                    return null;
+                    getOriginal().super_onSupportActionModeFinished(mode);
                 }
             }
         };
@@ -4681,17 +4485,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<ActionMode> superCall = new CallVoid1<ActionMode>(
                 "onSupportActionModeStarted(ActionMode)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ActionMode mode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onSupportActionModeStarted(this, (ActionMode) args[0]);
-                    return null;
+                    iterator.previous().onSupportActionModeStarted(this, mode);
                 } else {
-                    getOriginal().super_onSupportActionModeStarted((ActionMode) args[0]);
-                    return null;
+                    getOriginal().super_onSupportActionModeStarted(mode);
                 }
             }
         };
@@ -4706,17 +4508,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onSupportContentChanged()") {
+        final CallVoid0 superCall = new CallVoid0("onSupportContentChanged()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onSupportContentChanged(this);
-                    return null;
                 } else {
                     getOriginal().super_onSupportContentChanged();
-                    return null;
                 }
             }
         };
@@ -4730,11 +4529,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "onSupportNavigateUp()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("onSupportNavigateUp()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().onSupportNavigateUp(this);
                 } else {
@@ -4753,17 +4551,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onTitleChanged(CharSequence, int)") {
+        final CallVoid2<CharSequence, Integer> superCall = new CallVoid2<CharSequence, Integer>(
+                "onTitleChanged(CharSequence, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final CharSequence title, final Integer color) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onTitleChanged(this, (CharSequence) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().onTitleChanged(this, title, color);
                 } else {
-                    getOriginal().super_onTitleChanged((CharSequence) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_onTitleChanged(title, color);
                 }
             }
         };
@@ -4777,15 +4573,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "onTouchEvent(MotionEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MotionEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onTouchEvent(this, (MotionEvent) args[0]);
+                    return iterator.previous().onTouchEvent(this, event);
                 } else {
-                    return getOriginal().super_onTouchEvent((MotionEvent) args[0]);
+                    return getOriginal().super_onTouchEvent(event);
                 }
             }
         };
@@ -4799,15 +4595,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "onTrackballEvent(MotionEvent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MotionEvent event) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onTrackballEvent(this, (MotionEvent) args[0]);
+                    return iterator.previous().onTrackballEvent(this, event);
                 } else {
-                    return getOriginal().super_onTrackballEvent((MotionEvent) args[0]);
+                    return getOriginal().super_onTrackballEvent(event);
                 }
             }
         };
@@ -4822,16 +4618,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onTrimMemory(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>("onTrimMemory(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer level) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onTrimMemory(this, (int) args[0]);
-                    return null;
+                    iterator.previous().onTrimMemory(this, level);
                 } else {
-                    getOriginal().super_onTrimMemory((int) args[0]);
-                    return null;
+                    getOriginal().super_onTrimMemory(level);
                 }
             }
         };
@@ -4846,16 +4640,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onUserInteraction()") {
+        final CallVoid0 superCall = new CallVoid0("onUserInteraction()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onUserInteraction(this);
-                    return null;
                 } else {
                     getOriginal().super_onUserInteraction();
-                    return null;
                 }
             }
         };
@@ -4870,16 +4662,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onUserLeaveHint()") {
+        final CallVoid0 superCall = new CallVoid0("onUserLeaveHint()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onUserLeaveHint(this);
-                    return null;
                 } else {
                     getOriginal().super_onUserLeaveHint();
-                    return null;
                 }
             }
         };
@@ -4894,17 +4684,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onVisibleBehindCanceled()") {
+        final CallVoid0 superCall = new CallVoid0("onVisibleBehindCanceled()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onVisibleBehindCanceled(this);
-                    return null;
                 } else {
                     getOriginal().super_onVisibleBehindCanceled();
-                    return null;
                 }
             }
         };
@@ -4919,19 +4706,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<WindowManager.LayoutParams> superCall
+                = new CallVoid1<WindowManager.LayoutParams>(
                 "onWindowAttributesChanged(WindowManager.LayoutParams)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final WindowManager.LayoutParams params) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onWindowAttributesChanged(this, (WindowManager.LayoutParams) args[0]);
-                    return null;
+                    iterator.previous().onWindowAttributesChanged(this, params);
                 } else {
-                    getOriginal()
-                            .super_onWindowAttributesChanged((WindowManager.LayoutParams) args[0]);
-                    return null;
+                    getOriginal().super_onWindowAttributesChanged(params);
                 }
             }
         };
@@ -4946,17 +4730,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onWindowFocusChanged(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
+                "onWindowFocusChanged(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean hasFocus) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onWindowFocusChanged(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().onWindowFocusChanged(this, hasFocus);
                 } else {
-                    getOriginal().super_onWindowFocusChanged((boolean) args[0]);
-                    return null;
+                    getOriginal().super_onWindowFocusChanged(hasFocus);
                 }
             }
         };
@@ -4971,18 +4753,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<android.view.ActionMode> superCall
-                = new NamedSuperCall<android.view.ActionMode>(
+        final CallFun1<android.view.ActionMode, android.view.ActionMode.Callback> superCall
+                = new CallFun1<android.view.ActionMode, android.view.ActionMode.Callback>(
                 "onWindowStartingActionMode(android.view.ActionMode.Callback)") {
 
             @Override
-            public android.view.ActionMode call(final Object... args) {
+            public android.view.ActionMode call(final android.view.ActionMode.Callback callback) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onWindowStartingActionMode(this,
-                            (android.view.ActionMode.Callback) args[0]);
+                    return iterator.previous().onWindowStartingActionMode(this, callback);
                 } else {
-                    return getOriginal().super_onWindowStartingActionMode(
-                            (android.view.ActionMode.Callback) args[0]);
+                    return getOriginal().super_onWindowStartingActionMode(callback);
                 }
             }
         };
@@ -4997,18 +4777,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<android.view.ActionMode> superCall
-                = new NamedSuperCall<android.view.ActionMode>(
-                "onWindowStartingActionMode(android.view.ActionMode.Callback, int)") {
+        final CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer> superCall
+                = new CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer>(
+                "onWindowStartingActionMode(android.view.ActionMode.Callback, Integer)") {
 
             @Override
-            public android.view.ActionMode call(final Object... args) {
+            public android.view.ActionMode call(final android.view.ActionMode.Callback callback,
+                    final Integer type) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onWindowStartingActionMode(this,
-                            (android.view.ActionMode.Callback) args[0], (int) args[1]);
+                    return iterator.previous().onWindowStartingActionMode(this, callback, type);
                 } else {
-                    return getOriginal().super_onWindowStartingActionMode(
-                            (android.view.ActionMode.Callback) args[0], (int) args[1]);
+                    return getOriginal().super_onWindowStartingActionMode(callback, type);
                 }
             }
         };
@@ -5023,17 +4802,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ActionMode> superCall = new NamedSuperCall<ActionMode>(
+        final CallFun1<ActionMode, ActionMode.Callback> superCall
+                = new CallFun1<ActionMode, ActionMode.Callback>(
                 "onWindowStartingSupportActionMode(ActionMode.Callback)") {
 
             @Override
-            public ActionMode call(final Object... args) {
+            public ActionMode call(final ActionMode.Callback callback) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onWindowStartingSupportActionMode(this, (ActionMode.Callback) args[0]);
+                    return iterator.previous().onWindowStartingSupportActionMode(this, callback);
                 } else {
-                    return getOriginal()
-                            .super_onWindowStartingSupportActionMode((ActionMode.Callback) args[0]);
+                    return getOriginal().super_onWindowStartingSupportActionMode(callback);
                 }
             }
         };
@@ -5048,16 +4826,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("openContextMenu(View)") {
+        final CallVoid1<View> superCall = new CallVoid1<View>("openContextMenu(View)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().openContextMenu(this, (View) args[0]);
-                    return null;
+                    iterator.previous().openContextMenu(this, view);
                 } else {
-                    getOriginal().super_openContextMenu((View) args[0]);
-                    return null;
+                    getOriginal().super_openContextMenu(view);
                 }
             }
         };
@@ -5075,20 +4851,20 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<FileInputStream> superCall = new NamedSuperCall<FileInputStream>(
+        final CallFun1<FileInputStream, String> superCall = new CallFun1<FileInputStream, String>(
                 "openFileInput(String)") {
 
             @Override
-            public FileInputStream call(final Object... args) {
+            public FileInputStream call(final String name) {
                 if (iterator.hasPrevious()) {
                     try {
-                        return iterator.previous().openFileInput(this, (String) args[0]);
+                        return iterator.previous().openFileInput(this, name);
                     } catch (FileNotFoundException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        return getOriginal().super_openFileInput((String) args[0]);
+                        return getOriginal().super_openFileInput(name);
                     } catch (FileNotFoundException e) {
                         throw new SuppressedException(e);
                     }
@@ -5110,21 +4886,21 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<FileOutputStream> superCall = new NamedSuperCall<FileOutputStream>(
-                "openFileOutput(String, int)") {
+        final CallFun2<FileOutputStream, String, Integer> superCall
+                = new CallFun2<FileOutputStream, String, Integer>(
+                "openFileOutput(String, Integer)") {
 
             @Override
-            public FileOutputStream call(final Object... args) {
+            public FileOutputStream call(final String name, final Integer mode) {
                 if (iterator.hasPrevious()) {
                     try {
-                        return iterator.previous()
-                                .openFileOutput(this, (String) args[0], (int) args[1]);
+                        return iterator.previous().openFileOutput(this, name, mode);
                     } catch (FileNotFoundException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        return getOriginal().super_openFileOutput((String) args[0], (int) args[1]);
+                        return getOriginal().super_openFileOutput(name, mode);
                     } catch (FileNotFoundException e) {
                         throw new SuppressedException(e);
                     }
@@ -5142,16 +4918,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("openOptionsMenu()") {
+        final CallVoid0 superCall = new CallVoid0("openOptionsMenu()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().openOptionsMenu(this);
-                    return null;
                 } else {
                     getOriginal().super_openOptionsMenu();
-                    return null;
                 }
             }
         };
@@ -5166,18 +4940,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<SQLiteDatabase> superCall = new NamedSuperCall<SQLiteDatabase>(
-                "openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory)") {
+        final CallFun3<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory> superCall
+                = new CallFun3<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory>(
+                "openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory)") {
 
             @Override
-            public SQLiteDatabase call(final Object... args) {
+            public SQLiteDatabase call(final String name, final Integer mode,
+                    final SQLiteDatabase.CursorFactory factory) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .openOrCreateDatabase(this, (String) args[0], (int) args[1],
-                                    (SQLiteDatabase.CursorFactory) args[2]);
+                    return iterator.previous().openOrCreateDatabase(this, name, mode, factory);
                 } else {
-                    return getOriginal().super_openOrCreateDatabase((String) args[0], (int) args[1],
-                            (SQLiteDatabase.CursorFactory) args[2]);
+                    return getOriginal().super_openOrCreateDatabase(name, mode, factory);
                 }
             }
         };
@@ -5192,19 +4965,21 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<SQLiteDatabase> superCall = new NamedSuperCall<SQLiteDatabase>(
-                "openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)") {
+        final CallFun4<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler>
+                superCall
+                = new CallFun4<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler>(
+                "openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)") {
 
             @Override
-            public SQLiteDatabase call(final Object... args) {
+            public SQLiteDatabase call(final String name, final Integer mode,
+                    final SQLiteDatabase.CursorFactory factory,
+                    final DatabaseErrorHandler errorHandler) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .openOrCreateDatabase(this, (String) args[0], (int) args[1],
-                                    (SQLiteDatabase.CursorFactory) args[2],
-                                    (DatabaseErrorHandler) args[3]);
+                            .openOrCreateDatabase(this, name, mode, factory, errorHandler);
                 } else {
-                    return getOriginal().super_openOrCreateDatabase((String) args[0], (int) args[1],
-                            (SQLiteDatabase.CursorFactory) args[2], (DatabaseErrorHandler) args[3]);
+                    return getOriginal()
+                            .super_openOrCreateDatabase(name, mode, factory, errorHandler);
                 }
             }
         };
@@ -5219,18 +4994,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "overridePendingTransition(int, int)") {
+        final CallVoid2<Integer, Integer> superCall = new CallVoid2<Integer, Integer>(
+                "overridePendingTransition(Integer, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer enterAnim, final Integer exitAnim) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .overridePendingTransition(this, (int) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().overridePendingTransition(this, enterAnim, exitAnim);
                 } else {
-                    getOriginal().super_overridePendingTransition((int) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_overridePendingTransition(enterAnim, exitAnim);
                 }
             }
         };
@@ -5244,10 +5016,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Drawable> superCall = new NamedSuperCall<Drawable>("peekWallpaper()") {
+        final CallFun0<Drawable> superCall = new CallFun0<Drawable>("peekWallpaper()") {
 
             @Override
-            public Drawable call(final Object... args) {
+            public Drawable call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().peekWallpaper(this);
                 } else {
@@ -5266,17 +5038,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "postponeEnterTransition()") {
+        final CallVoid0 superCall = new CallVoid0("postponeEnterTransition()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().postponeEnterTransition(this);
-                    return null;
                 } else {
                     getOriginal().super_postponeEnterTransition();
-                    return null;
                 }
             }
         };
@@ -5291,16 +5060,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("recreate()") {
+        final CallVoid0 superCall = new CallVoid0("recreate()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().recreate(this);
-                    return null;
                 } else {
                     getOriginal().super_recreate();
-                    return null;
                 }
             }
         };
@@ -5315,18 +5082,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<ComponentCallbacks> superCall = new CallVoid1<ComponentCallbacks>(
                 "registerComponentCallbacks(ComponentCallbacks)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ComponentCallbacks callback) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .registerComponentCallbacks(this, (ComponentCallbacks) args[0]);
-                    return null;
+                    iterator.previous().registerComponentCallbacks(this, callback);
                 } else {
-                    getOriginal().super_registerComponentCallbacks((ComponentCallbacks) args[0]);
-                    return null;
+                    getOriginal().super_registerComponentCallbacks(callback);
                 }
             }
         };
@@ -5341,17 +5105,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "registerForContextMenu(View)") {
+        final CallVoid1<View> superCall = new CallVoid1<View>("registerForContextMenu(View)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().registerForContextMenu(this, (View) args[0]);
-                    return null;
+                    iterator.previous().registerForContextMenu(this, view);
                 } else {
-                    getOriginal().super_registerForContextMenu((View) args[0]);
-                    return null;
+                    getOriginal().super_registerForContextMenu(view);
                 }
             }
         };
@@ -5365,17 +5126,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
+        final CallFun2<Intent, BroadcastReceiver, IntentFilter> superCall
+                = new CallFun2<Intent, BroadcastReceiver, IntentFilter>(
                 "registerReceiver(BroadcastReceiver, IntentFilter)") {
 
             @Override
-            public Intent call(final Object... args) {
+            public Intent call(final BroadcastReceiver receiver, final IntentFilter filter) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().registerReceiver(this, (BroadcastReceiver) args[0],
-                            (IntentFilter) args[1]);
+                    return iterator.previous().registerReceiver(this, receiver, filter);
                 } else {
-                    return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
-                            (IntentFilter) args[1]);
+                    return getOriginal().super_registerReceiver(receiver, filter);
                 }
             }
         };
@@ -5391,17 +5151,21 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Intent> superCall = new NamedSuperCall<Intent>(
+        final CallFun4<Intent, BroadcastReceiver, IntentFilter, String, Handler> superCall
+                = new CallFun4<Intent, BroadcastReceiver, IntentFilter, String, Handler>(
                 "registerReceiver(BroadcastReceiver, IntentFilter, String, Handler)") {
 
             @Override
-            public Intent call(final Object... args) {
+            public Intent call(final BroadcastReceiver receiver, final IntentFilter filter,
+                    final String broadcastPermission, final Handler scheduler) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().registerReceiver(this, (BroadcastReceiver) args[0],
-                            (IntentFilter) args[1], (String) args[2], (Handler) args[3]);
+                    return iterator.previous()
+                            .registerReceiver(this, receiver, filter, broadcastPermission,
+                                    scheduler);
                 } else {
-                    return getOriginal().super_registerReceiver((BroadcastReceiver) args[0],
-                            (IntentFilter) args[1], (String) args[2], (Handler) args[3]);
+                    return getOriginal()
+                            .super_registerReceiver(receiver, filter, broadcastPermission,
+                                    scheduler);
                 }
             }
         };
@@ -5415,10 +5179,10 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("releaseInstance()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("releaseInstance()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().releaseInstance(this);
                 } else {
@@ -5437,17 +5201,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "removeStickyBroadcast(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("removeStickyBroadcast(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().removeStickyBroadcast(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().removeStickyBroadcast(this, intent);
                 } else {
-                    getOriginal().super_removeStickyBroadcast((Intent) args[0]);
-                    return null;
+                    getOriginal().super_removeStickyBroadcast(intent);
                 }
             }
         };
@@ -5462,19 +5223,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent, UserHandle> superCall = new CallVoid2<Intent, UserHandle>(
                 "removeStickyBroadcastAsUser(Intent, UserHandle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final UserHandle user) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().removeStickyBroadcastAsUser(this, (Intent) args[0],
-                            (UserHandle) args[1]);
-                    return null;
+                    iterator.previous().removeStickyBroadcastAsUser(this, intent, user);
                 } else {
-                    getOriginal().super_removeStickyBroadcastAsUser((Intent) args[0],
-                            (UserHandle) args[1]);
-                    return null;
+                    getOriginal().super_removeStickyBroadcastAsUser(intent, user);
                 }
             }
         };
@@ -5489,16 +5246,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("reportFullyDrawn()") {
+        final CallVoid0 superCall = new CallVoid0("reportFullyDrawn()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().reportFullyDrawn(this);
-                    return null;
                 } else {
                     getOriginal().super_reportFullyDrawn();
-                    return null;
                 }
             }
         };
@@ -5512,15 +5267,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "requestVisibleBehind(boolean)") {
+        final CallFun1<Boolean, Boolean> superCall = new CallFun1<Boolean, Boolean>(
+                "requestVisibleBehind(Boolean)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Boolean visible) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().requestVisibleBehind(this, (boolean) args[0]);
+                    return iterator.previous().requestVisibleBehind(this, visible);
                 } else {
-                    return getOriginal().super_requestVisibleBehind((boolean) args[0]);
+                    return getOriginal().super_requestVisibleBehind(visible);
                 }
             }
         };
@@ -5535,17 +5290,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "revokeUriPermission(Uri, int)") {
+        final CallVoid2<Uri, Integer> superCall = new CallVoid2<Uri, Integer>(
+                "revokeUriPermission(Uri, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Uri uri, final Integer modeFlags) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().revokeUriPermission(this, (Uri) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().revokeUriPermission(this, uri, modeFlags);
                 } else {
-                    getOriginal().super_revokeUriPermission((Uri) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_revokeUriPermission(uri, modeFlags);
                 }
             }
         };
@@ -5560,16 +5313,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("sendBroadcast(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("sendBroadcast(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().sendBroadcast(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().sendBroadcast(this, intent);
                 } else {
-                    getOriginal().super_sendBroadcast((Intent) args[0]);
-                    return null;
+                    getOriginal().super_sendBroadcast(intent);
                 }
             }
         };
@@ -5584,17 +5335,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent, String> superCall = new CallVoid2<Intent, String>(
                 "sendBroadcast(Intent, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final String receiverPermission) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().sendBroadcast(this, (Intent) args[0], (String) args[1]);
-                    return null;
+                    iterator.previous().sendBroadcast(this, intent, receiverPermission);
                 } else {
-                    getOriginal().super_sendBroadcast((Intent) args[0], (String) args[1]);
-                    return null;
+                    getOriginal().super_sendBroadcast(intent, receiverPermission);
                 }
             }
         };
@@ -5609,18 +5358,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent, UserHandle> superCall = new CallVoid2<Intent, UserHandle>(
                 "sendBroadcastAsUser(Intent, UserHandle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final UserHandle user) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .sendBroadcastAsUser(this, (Intent) args[0], (UserHandle) args[1]);
-                    return null;
+                    iterator.previous().sendBroadcastAsUser(this, intent, user);
                 } else {
-                    getOriginal().super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1]);
-                    return null;
+                    getOriginal().super_sendBroadcastAsUser(intent, user);
                 }
             }
         };
@@ -5636,20 +5382,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid3<Intent, UserHandle, String> superCall
+                = new CallVoid3<Intent, UserHandle, String>(
                 "sendBroadcastAsUser(Intent, UserHandle, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final UserHandle user,
+                    final String receiverPermission) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .sendBroadcastAsUser(this, (Intent) args[0], (UserHandle) args[1],
-                                    (String) args[2]);
-                    return null;
+                    iterator.previous().sendBroadcastAsUser(this, intent, user, receiverPermission);
                 } else {
-                    getOriginal().super_sendBroadcastAsUser((Intent) args[0], (UserHandle) args[1],
-                            (String) args[2]);
-                    return null;
+                    getOriginal().super_sendBroadcastAsUser(intent, user, receiverPermission);
                 }
             }
         };
@@ -5664,18 +5407,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent, String> superCall = new CallVoid2<Intent, String>(
                 "sendOrderedBroadcast(Intent, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final String receiverPermission) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .sendOrderedBroadcast(this, (Intent) args[0], (String) args[1]);
-                    return null;
+                    iterator.previous().sendOrderedBroadcast(this, intent, receiverPermission);
                 } else {
-                    getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1]);
-                    return null;
+                    getOriginal().super_sendOrderedBroadcast(intent, receiverPermission);
                 }
             }
         };
@@ -5693,22 +5433,24 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, int, String, Bundle)") {
+        final CallVoid7<Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle>
+                superCall
+                = new CallVoid7<Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle>(
+                "sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final String receiverPermission,
+                    final BroadcastReceiver resultReceiver, final Handler scheduler,
+                    final Integer initialCode, final String initialData,
+                    final Bundle initialExtras) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .sendOrderedBroadcast(this, (Intent) args[0], (String) args[1],
-                                    (BroadcastReceiver) args[2], (Handler) args[3], (int) args[4],
-                                    (String) args[5], (Bundle) args[6]);
-                    return null;
+                            .sendOrderedBroadcast(this, intent, receiverPermission, resultReceiver,
+                                    scheduler, initialCode, initialData, initialExtras);
                 } else {
-                    getOriginal().super_sendOrderedBroadcast((Intent) args[0], (String) args[1],
-                            (BroadcastReceiver) args[2], (Handler) args[3], (int) args[4],
-                            (String) args[5], (Bundle) args[6]);
-                    return null;
+                    getOriginal()
+                            .super_sendOrderedBroadcast(intent, receiverPermission, resultReceiver,
+                                    scheduler, initialCode, initialData, initialExtras);
                 }
             }
         };
@@ -5728,21 +5470,24 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, int, String, Bundle)") {
+        final CallVoid8<Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle>
+                superCall
+                = new CallVoid8<Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle>(
+                "sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final UserHandle user,
+                    final String receiverPermission, final BroadcastReceiver resultReceiver,
+                    final Handler scheduler, final Integer initialCode, final String initialData,
+                    final Bundle initialExtras) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().sendOrderedBroadcastAsUser(this, (Intent) args[0],
-                            (UserHandle) args[1], (String) args[2], (BroadcastReceiver) args[3],
-                            (Handler) args[4], (int) args[5], (String) args[6], (Bundle) args[7]);
-                    return null;
+                    iterator.previous()
+                            .sendOrderedBroadcastAsUser(this, intent, user, receiverPermission,
+                                    resultReceiver, scheduler, initialCode, initialData,
+                                    initialExtras);
                 } else {
-                    getOriginal().super_sendOrderedBroadcastAsUser((Intent) args[0],
-                            (UserHandle) args[1], (String) args[2], (BroadcastReceiver) args[3],
-                            (Handler) args[4], (int) args[5], (String) args[6], (Bundle) args[7]);
-                    return null;
+                    getOriginal().super_sendOrderedBroadcastAsUser(intent, user, receiverPermission,
+                            resultReceiver, scheduler, initialCode, initialData, initialExtras);
                 }
             }
         };
@@ -5758,17 +5503,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "sendStickyBroadcast(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("sendStickyBroadcast(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().sendStickyBroadcast(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().sendStickyBroadcast(this, intent);
                 } else {
-                    getOriginal().super_sendStickyBroadcast((Intent) args[0]);
-                    return null;
+                    getOriginal().super_sendStickyBroadcast(intent);
                 }
             }
         };
@@ -5783,19 +5525,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent, UserHandle> superCall = new CallVoid2<Intent, UserHandle>(
                 "sendStickyBroadcastAsUser(Intent, UserHandle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final UserHandle user) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().sendStickyBroadcastAsUser(this, (Intent) args[0],
-                            (UserHandle) args[1]);
-                    return null;
+                    iterator.previous().sendStickyBroadcastAsUser(this, intent, user);
                 } else {
-                    getOriginal().super_sendStickyBroadcastAsUser((Intent) args[0],
-                            (UserHandle) args[1]);
-                    return null;
+                    getOriginal().super_sendStickyBroadcastAsUser(intent, user);
                 }
             }
         };
@@ -5813,21 +5551,22 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, int, String, Bundle)") {
+        final CallVoid6<Intent, BroadcastReceiver, Handler, Integer, String, Bundle> superCall
+                = new CallVoid6<Intent, BroadcastReceiver, Handler, Integer, String, Bundle>(
+                "sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, Integer, String, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final BroadcastReceiver resultReceiver,
+                    final Handler scheduler, final Integer initialCode, final String initialData,
+                    final Bundle initialExtras) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().sendStickyOrderedBroadcast(this, (Intent) args[0],
-                            (BroadcastReceiver) args[1], (Handler) args[2], (int) args[3],
-                            (String) args[4], (Bundle) args[5]);
-                    return null;
+                    iterator.previous()
+                            .sendStickyOrderedBroadcast(this, intent, resultReceiver, scheduler,
+                                    initialCode, initialData, initialExtras);
                 } else {
-                    getOriginal().super_sendStickyOrderedBroadcast((Intent) args[0],
-                            (BroadcastReceiver) args[1], (Handler) args[2], (int) args[3],
-                            (String) args[4], (Bundle) args[5]);
-                    return null;
+                    getOriginal()
+                            .super_sendStickyOrderedBroadcast(intent, resultReceiver, scheduler,
+                                    initialCode, initialData, initialExtras);
                 }
             }
         };
@@ -5846,21 +5585,24 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, int, String, Bundle)") {
+        final CallVoid7<Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle>
+                superCall
+                = new CallVoid7<Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle>(
+                "sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final UserHandle user,
+                    final BroadcastReceiver resultReceiver, final Handler scheduler,
+                    final Integer initialCode, final String initialData,
+                    final Bundle initialExtras) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().sendStickyOrderedBroadcastAsUser(this, (Intent) args[0],
-                            (UserHandle) args[1], (BroadcastReceiver) args[2], (Handler) args[3],
-                            (int) args[4], (String) args[5], (Bundle) args[6]);
-                    return null;
+                    iterator.previous()
+                            .sendStickyOrderedBroadcastAsUser(this, intent, user, resultReceiver,
+                                    scheduler, initialCode, initialData, initialExtras);
                 } else {
-                    getOriginal().super_sendStickyOrderedBroadcastAsUser((Intent) args[0],
-                            (UserHandle) args[1], (BroadcastReceiver) args[2], (Handler) args[3],
-                            (int) args[4], (String) args[5], (Bundle) args[6]);
-                    return null;
+                    getOriginal()
+                            .super_sendStickyOrderedBroadcastAsUser(intent, user, resultReceiver,
+                                    scheduler, initialCode, initialData, initialExtras);
                 }
             }
         };
@@ -5876,16 +5618,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setActionBar(Toolbar)") {
+        final CallVoid1<Toolbar> superCall = new CallVoid1<Toolbar>("setActionBar(Toolbar)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Toolbar toolbar) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setActionBar(this, (Toolbar) args[0]);
-                    return null;
+                    iterator.previous().setActionBar(this, toolbar);
                 } else {
-                    getOriginal().super_setActionBar((Toolbar) args[0]);
-                    return null;
+                    getOriginal().super_setActionBar(toolbar);
                 }
             }
         };
@@ -5900,18 +5640,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<TransitionManager> superCall = new CallVoid1<TransitionManager>(
                 "setContentTransitionManager(TransitionManager)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final TransitionManager tm) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setContentTransitionManager(this, (TransitionManager) args[0]);
-                    return null;
+                    iterator.previous().setContentTransitionManager(this, tm);
                 } else {
-                    getOriginal().super_setContentTransitionManager((TransitionManager) args[0]);
-                    return null;
+                    getOriginal().super_setContentTransitionManager(tm);
                 }
             }
         };
@@ -5926,16 +5663,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setContentView(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setContentView(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer layoutResID) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setContentView(this, (int) args[0]);
-                    return null;
+                    iterator.previous().setContentView(this, layoutResID);
                 } else {
-                    getOriginal().super_setContentView((int) args[0]);
-                    return null;
+                    getOriginal().super_setContentView(layoutResID);
                 }
             }
         };
@@ -5950,16 +5685,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setContentView(View)") {
+        final CallVoid1<View> superCall = new CallVoid1<View>("setContentView(View)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setContentView(this, (View) args[0]);
-                    return null;
+                    iterator.previous().setContentView(this, view);
                 } else {
-                    getOriginal().super_setContentView((View) args[0]);
-                    return null;
+                    getOriginal().super_setContentView(view);
                 }
             }
         };
@@ -5974,19 +5707,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<View, ViewGroup.LayoutParams> superCall
+                = new CallVoid2<View, ViewGroup.LayoutParams>(
                 "setContentView(View, ViewGroup.LayoutParams)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view, final ViewGroup.LayoutParams params) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setContentView(this, (View) args[0], (ViewGroup.LayoutParams) args[1]);
-                    return null;
+                    iterator.previous().setContentView(this, view, params);
                 } else {
-                    getOriginal()
-                            .super_setContentView((View) args[0], (ViewGroup.LayoutParams) args[1]);
-                    return null;
+                    getOriginal().super_setContentView(view, params);
                 }
             }
         };
@@ -6001,19 +5731,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setEnterSharedElementCallback(SharedElementCallback)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final SharedElementCallback callback) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setEnterSharedElementCallback(this, (SharedElementCallback) args[0]);
-                    return null;
+                    iterator.previous().setEnterSharedElementCallback(this, callback);
                 } else {
-                    getOriginal()
-                            .super_setEnterSharedElementCallback((SharedElementCallback) args[0]);
-                    return null;
+                    getOriginal().super_setEnterSharedElementCallback(callback);
                 }
             }
         };
@@ -6028,19 +5754,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.app.SharedElementCallback> superCall
+                = new CallVoid1<android.app.SharedElementCallback>(
                 "setEnterSharedElementCallback(android.app.SharedElementCallback)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.app.SharedElementCallback callback) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setEnterSharedElementCallback(this,
-                            (android.app.SharedElementCallback) args[0]);
-                    return null;
+                    iterator.previous().setEnterSharedElementCallback(this, callback);
                 } else {
-                    getOriginal().super_setEnterSharedElementCallback(
-                            (android.app.SharedElementCallback) args[0]);
-                    return null;
+                    getOriginal().super_setEnterSharedElementCallback(callback);
                 }
             }
         };
@@ -6055,19 +5778,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setExitSharedElementCallback(SharedElementCallback)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final SharedElementCallback listener) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setExitSharedElementCallback(this, (SharedElementCallback) args[0]);
-                    return null;
+                    iterator.previous().setExitSharedElementCallback(this, listener);
                 } else {
-                    getOriginal()
-                            .super_setExitSharedElementCallback((SharedElementCallback) args[0]);
-                    return null;
+                    getOriginal().super_setExitSharedElementCallback(listener);
                 }
             }
         };
@@ -6082,19 +5801,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.app.SharedElementCallback> superCall
+                = new CallVoid1<android.app.SharedElementCallback>(
                 "setExitSharedElementCallback(android.app.SharedElementCallback)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.app.SharedElementCallback callback) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setExitSharedElementCallback(this,
-                            (android.app.SharedElementCallback) args[0]);
-                    return null;
+                    iterator.previous().setExitSharedElementCallback(this, callback);
                 } else {
-                    getOriginal().super_setExitSharedElementCallback(
-                            (android.app.SharedElementCallback) args[0]);
-                    return null;
+                    getOriginal().super_setExitSharedElementCallback(callback);
                 }
             }
         };
@@ -6109,17 +5825,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setFinishOnTouchOutside(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
+                "setFinishOnTouchOutside(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean finish) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setFinishOnTouchOutside(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setFinishOnTouchOutside(this, finish);
                 } else {
-                    getOriginal().super_setFinishOnTouchOutside((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setFinishOnTouchOutside(finish);
                 }
             }
         };
@@ -6134,16 +5848,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setImmersive(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setImmersive(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean i) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setImmersive(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setImmersive(this, i);
                 } else {
-                    getOriginal().super_setImmersive((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setImmersive(i);
                 }
             }
         };
@@ -6158,16 +5870,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setIntent(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("setIntent(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent newIntent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setIntent(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().setIntent(this, newIntent);
                 } else {
-                    getOriginal().super_setIntent((Intent) args[0]);
-                    return null;
+                    getOriginal().super_setIntent(newIntent);
                 }
             }
         };
@@ -6182,17 +5892,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setRequestedOrientation(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>(
+                "setRequestedOrientation(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer requestedOrientation) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setRequestedOrientation(this, (int) args[0]);
-                    return null;
+                    iterator.previous().setRequestedOrientation(this, requestedOrientation);
                 } else {
-                    getOriginal().super_setRequestedOrientation((int) args[0]);
-                    return null;
+                    getOriginal().super_setRequestedOrientation(requestedOrientation);
                 }
             }
         };
@@ -6207,19 +5915,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<android.support.v7.widget.Toolbar> superCall
+                = new CallVoid1<android.support.v7.widget.Toolbar>(
                 "setSupportActionBar(android.support.v7.widget.Toolbar)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.support.v7.widget.Toolbar toolbar) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setSupportActionBar(this, (android.support.v7.widget.Toolbar) args[0]);
-                    return null;
+                    iterator.previous().setSupportActionBar(this, toolbar);
                 } else {
-                    getOriginal()
-                            .super_setSupportActionBar((android.support.v7.widget.Toolbar) args[0]);
-                    return null;
+                    getOriginal().super_setSupportActionBar(toolbar);
                 }
             }
         };
@@ -6234,16 +5939,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setSupportProgress(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setSupportProgress(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer progress) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setSupportProgress(this, (int) args[0]);
-                    return null;
+                    iterator.previous().setSupportProgress(this, progress);
                 } else {
-                    getOriginal().super_setSupportProgress((int) args[0]);
-                    return null;
+                    getOriginal().super_setSupportProgress(progress);
                 }
             }
         };
@@ -6258,17 +5961,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setSupportProgressBarIndeterminate(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
+                "setSupportProgressBarIndeterminate(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean indeterminate) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setSupportProgressBarIndeterminate(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setSupportProgressBarIndeterminate(this, indeterminate);
                 } else {
-                    getOriginal().super_setSupportProgressBarIndeterminate((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setSupportProgressBarIndeterminate(indeterminate);
                 }
             }
         };
@@ -6283,19 +5984,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setSupportProgressBarIndeterminateVisibility(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
+                "setSupportProgressBarIndeterminateVisibility(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean visible) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setSupportProgressBarIndeterminateVisibility(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setSupportProgressBarIndeterminateVisibility(this, visible);
                 } else {
-                    getOriginal()
-                            .super_setSupportProgressBarIndeterminateVisibility((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setSupportProgressBarIndeterminateVisibility(visible);
                 }
             }
         };
@@ -6310,17 +6007,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setSupportProgressBarVisibility(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
+                "setSupportProgressBarVisibility(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean visible) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setSupportProgressBarVisibility(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setSupportProgressBarVisibility(this, visible);
                 } else {
-                    getOriginal().super_setSupportProgressBarVisibility((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setSupportProgressBarVisibility(visible);
                 }
             }
         };
@@ -6335,19 +6030,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<ActivityManager.TaskDescription> superCall
+                = new CallVoid1<ActivityManager.TaskDescription>(
                 "setTaskDescription(ActivityManager.TaskDescription)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ActivityManager.TaskDescription taskDescription) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setTaskDescription(this, (ActivityManager.TaskDescription) args[0]);
-                    return null;
+                    iterator.previous().setTaskDescription(this, taskDescription);
                 } else {
-                    getOriginal()
-                            .super_setTaskDescription((ActivityManager.TaskDescription) args[0]);
-                    return null;
+                    getOriginal().super_setTaskDescription(taskDescription);
                 }
             }
         };
@@ -6362,16 +6054,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTheme(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setTheme(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer resid) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setTheme(this, (int) args[0]);
-                    return null;
+                    iterator.previous().setTheme(this, resid);
                 } else {
-                    getOriginal().super_setTheme((int) args[0]);
-                    return null;
+                    getOriginal().super_setTheme(resid);
                 }
             }
         };
@@ -6386,16 +6076,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTitle(CharSequence)") {
+        final CallVoid1<CharSequence> superCall = new CallVoid1<CharSequence>(
+                "setTitle(CharSequence)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final CharSequence title) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setTitle(this, (CharSequence) args[0]);
-                    return null;
+                    iterator.previous().setTitle(this, title);
                 } else {
-                    getOriginal().super_setTitle((CharSequence) args[0]);
-                    return null;
+                    getOriginal().super_setTitle(title);
                 }
             }
         };
@@ -6410,16 +6099,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTitle(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setTitle(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer titleId) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setTitle(this, (int) args[0]);
-                    return null;
+                    iterator.previous().setTitle(this, titleId);
                 } else {
-                    getOriginal().super_setTitle((int) args[0]);
-                    return null;
+                    getOriginal().super_setTitle(titleId);
                 }
             }
         };
@@ -6434,16 +6121,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setTitleColor(int)") {
+        final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setTitleColor(Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer textColor) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setTitleColor(this, (int) args[0]);
-                    return null;
+                    iterator.previous().setTitleColor(this, textColor);
                 } else {
-                    getOriginal().super_setTitleColor((int) args[0]);
-                    return null;
+                    getOriginal().super_setTitleColor(textColor);
                 }
             }
         };
@@ -6458,16 +6143,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setVisible(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setVisible(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean visible) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setVisible(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setVisible(this, visible);
                 } else {
-                    getOriginal().super_setVisible((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setVisible(visible);
                 }
             }
         };
@@ -6486,21 +6169,19 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setWallpaper(Bitmap)") {
+        final CallVoid1<Bitmap> superCall = new CallVoid1<Bitmap>("setWallpaper(Bitmap)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bitmap bitmap) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous().setWallpaper(this, (Bitmap) args[0]);
-                        return null;
+                        iterator.previous().setWallpaper(this, bitmap);
                     } catch (IOException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal().super_setWallpaper((Bitmap) args[0]);
-                        return null;
+                        getOriginal().super_setWallpaper(bitmap);
                     } catch (IOException e) {
                         throw new SuppressedException(e);
                     }
@@ -6522,22 +6203,20 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<InputStream> superCall = new CallVoid1<InputStream>(
                 "setWallpaper(InputStream)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final InputStream data) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous().setWallpaper(this, (InputStream) args[0]);
-                        return null;
+                        iterator.previous().setWallpaper(this, data);
                     } catch (IOException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal().super_setWallpaper((InputStream) args[0]);
-                        return null;
+                        getOriginal().super_setWallpaper(data);
                     } catch (IOException e) {
                         throw new SuppressedException(e);
                     }
@@ -6554,17 +6233,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "shouldShowRequestPermissionRationale(String)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final String permission) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .shouldShowRequestPermissionRationale(this, (String) args[0]);
+                            .shouldShowRequestPermissionRationale(this, permission);
                 } else {
-                    return getOriginal()
-                            .super_shouldShowRequestPermissionRationale((String) args[0]);
+                    return getOriginal().super_shouldShowRequestPermissionRationale(permission);
                 }
             }
         };
@@ -6578,15 +6256,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "shouldUpRecreateTask(Intent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent targetIntent) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().shouldUpRecreateTask(this, (Intent) args[0]);
+                    return iterator.previous().shouldUpRecreateTask(this, targetIntent);
                 } else {
-                    return getOriginal().super_shouldUpRecreateTask((Intent) args[0]);
+                    return getOriginal().super_shouldUpRecreateTask(targetIntent);
                 }
             }
         };
@@ -6600,15 +6278,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Bundle> superCall = new CallFun1<Boolean, Bundle>(
                 "showAssist(Bundle)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Bundle args) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().showAssist(this, (Bundle) args[0]);
+                    return iterator.previous().showAssist(this, args);
                 } else {
-                    return getOriginal().super_showAssist((Bundle) args[0]);
+                    return getOriginal().super_showAssist(args);
                 }
             }
         };
@@ -6623,17 +6301,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "showLockTaskEscapeMessage()") {
+        final CallVoid0 superCall = new CallVoid0("showLockTaskEscapeMessage()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().showLockTaskEscapeMessage(this);
-                    return null;
                 } else {
                     getOriginal().super_showLockTaskEscapeMessage();
-                    return null;
                 }
             }
         };
@@ -6648,18 +6323,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<android.view.ActionMode> superCall
-                = new NamedSuperCall<android.view.ActionMode>(
+        final CallFun1<android.view.ActionMode, android.view.ActionMode.Callback> superCall
+                = new CallFun1<android.view.ActionMode, android.view.ActionMode.Callback>(
                 "startActionMode(android.view.ActionMode.Callback)") {
 
             @Override
-            public android.view.ActionMode call(final Object... args) {
+            public android.view.ActionMode call(final android.view.ActionMode.Callback callback) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .startActionMode(this, (android.view.ActionMode.Callback) args[0]);
+                    return iterator.previous().startActionMode(this, callback);
                 } else {
-                    return getOriginal()
-                            .super_startActionMode((android.view.ActionMode.Callback) args[0]);
+                    return getOriginal().super_startActionMode(callback);
                 }
             }
         };
@@ -6674,20 +6347,17 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<android.view.ActionMode> superCall
-                = new NamedSuperCall<android.view.ActionMode>(
-                "startActionMode(android.view.ActionMode.Callback, int)") {
+        final CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer> superCall
+                = new CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer>(
+                "startActionMode(android.view.ActionMode.Callback, Integer)") {
 
             @Override
-            public android.view.ActionMode call(final Object... args) {
+            public android.view.ActionMode call(final android.view.ActionMode.Callback callback,
+                    final Integer type) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .startActionMode(this, (android.view.ActionMode.Callback) args[0],
-                                    (int) args[1]);
+                    return iterator.previous().startActionMode(this, callback, type);
                 } else {
-                    return getOriginal()
-                            .super_startActionMode((android.view.ActionMode.Callback) args[0],
-                                    (int) args[1]);
+                    return getOriginal().super_startActionMode(callback, type);
                 }
             }
         };
@@ -6702,17 +6372,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivities(Intent[])") {
+        final CallVoid1<Intent[]> superCall = new CallVoid1<Intent[]>("startActivities(Intent[])") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent[] intents) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startActivities(this, (Intent[]) args[0]);
-                    return null;
+                    iterator.previous().startActivities(this, intents);
                 } else {
-                    getOriginal().super_startActivities((Intent[]) args[0]);
-                    return null;
+                    getOriginal().super_startActivities(intents);
                 }
             }
         };
@@ -6727,17 +6394,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent[], Bundle> superCall = new CallVoid2<Intent[], Bundle>(
                 "startActivities(Intent[], Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent[] intents, final Bundle options) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startActivities(this, (Intent[]) args[0], (Bundle) args[1]);
-                    return null;
+                    iterator.previous().startActivities(this, intents, options);
                 } else {
-                    getOriginal().super_startActivities((Intent[]) args[0], (Bundle) args[1]);
-                    return null;
+                    getOriginal().super_startActivities(intents, options);
                 }
             }
         };
@@ -6752,16 +6417,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("startActivity(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("startActivity(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startActivity(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().startActivity(this, intent);
                 } else {
-                    getOriginal().super_startActivity((Intent) args[0]);
-                    return null;
+                    getOriginal().super_startActivity(intent);
                 }
             }
         };
@@ -6776,17 +6439,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent, Bundle> superCall = new CallVoid2<Intent, Bundle>(
                 "startActivity(Intent, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final Bundle options) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startActivity(this, (Intent) args[0], (Bundle) args[1]);
-                    return null;
+                    iterator.previous().startActivity(this, intent, options);
                 } else {
-                    getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
-                    return null;
+                    getOriginal().super_startActivity(intent, options);
                 }
             }
         };
@@ -6801,18 +6462,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityForResult(Intent, int)") {
+        final CallVoid2<Intent, Integer> superCall = new CallVoid2<Intent, Integer>(
+                "startActivityForResult(Intent, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final Integer requestCode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .startActivityForResult(this, (Intent) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().startActivityForResult(this, intent, requestCode);
                 } else {
-                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_startActivityForResult(intent, requestCode);
                 }
             }
         };
@@ -6828,20 +6486,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityForResult(Intent, int, Bundle)") {
+        final CallVoid3<Intent, Integer, Bundle> superCall = new CallVoid3<Intent, Integer, Bundle>(
+                "startActivityForResult(Intent, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final Integer requestCode, final Bundle options) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .startActivityForResult(this, (Intent) args[0], (int) args[1],
-                                    (Bundle) args[2]);
-                    return null;
+                    iterator.previous().startActivityForResult(this, intent, requestCode, options);
                 } else {
-                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    getOriginal().super_startActivityForResult(intent, requestCode, options);
                 }
             }
         };
@@ -6857,20 +6510,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityFromChild(Activity, Intent, int)") {
+        final CallVoid3<Activity, Intent, Integer> superCall
+                = new CallVoid3<Activity, Intent, Integer>(
+                "startActivityFromChild(Activity, Intent, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity child, final Intent intent, final Integer requestCode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .startActivityFromChild(this, (Activity) args[0], (Intent) args[1],
-                                    (int) args[2]);
-                    return null;
+                    iterator.previous().startActivityFromChild(this, child, intent, requestCode);
                 } else {
-                    getOriginal().super_startActivityFromChild((Activity) args[0], (Intent) args[1],
-                            (int) args[2]);
-                    return null;
+                    getOriginal().super_startActivityFromChild(child, intent, requestCode);
                 }
             }
         };
@@ -6886,20 +6535,18 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityFromChild(Activity, Intent, int, Bundle)") {
+        final CallVoid4<Activity, Intent, Integer, Bundle> superCall
+                = new CallVoid4<Activity, Intent, Integer, Bundle>(
+                "startActivityFromChild(Activity, Intent, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity child, final Intent intent, final Integer requestCode,
+                    final Bundle options) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .startActivityFromChild(this, (Activity) args[0], (Intent) args[1],
-                                    (int) args[2], (Bundle) args[3]);
-                    return null;
+                            .startActivityFromChild(this, child, intent, requestCode, options);
                 } else {
-                    getOriginal().super_startActivityFromChild((Activity) args[0], (Intent) args[1],
-                            (int) args[2], (Bundle) args[3]);
-                    return null;
+                    getOriginal().super_startActivityFromChild(child, intent, requestCode, options);
                 }
             }
         };
@@ -6915,21 +6562,18 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityFromFragment(Fragment, Intent, int)") {
+        final CallVoid3<Fragment, Intent, Integer> superCall
+                = new CallVoid3<Fragment, Intent, Integer>(
+                "startActivityFromFragment(Fragment, Intent, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Fragment fragment, final Intent intent,
+                    final Integer requestCode) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .startActivityFromFragment(this, (Fragment) args[0], (Intent) args[1],
-                                    (int) args[2]);
-                    return null;
+                            .startActivityFromFragment(this, fragment, intent, requestCode);
                 } else {
-                    getOriginal()
-                            .super_startActivityFromFragment((Fragment) args[0], (Intent) args[1],
-                                    (int) args[2]);
-                    return null;
+                    getOriginal().super_startActivityFromFragment(fragment, intent, requestCode);
                 }
             }
         };
@@ -6945,21 +6589,20 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityFromFragment(Fragment, Intent, int, Bundle)") {
+        final CallVoid4<Fragment, Intent, Integer, Bundle> superCall
+                = new CallVoid4<Fragment, Intent, Integer, Bundle>(
+                "startActivityFromFragment(Fragment, Intent, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Fragment fragment, final Intent intent,
+                    final Integer requestCode, final Bundle options) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .startActivityFromFragment(this, (Fragment) args[0], (Intent) args[1],
-                                    (int) args[2], (Bundle) args[3]);
-                    return null;
+                            .startActivityFromFragment(this, fragment, intent, requestCode,
+                                    options);
                 } else {
-                    getOriginal()
-                            .super_startActivityFromFragment((Fragment) args[0], (Intent) args[1],
-                                    (int) args[2], (Bundle) args[3]);
-                    return null;
+                    getOriginal().super_startActivityFromFragment(fragment, intent, requestCode,
+                            options);
                 }
             }
         };
@@ -6975,20 +6618,18 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityFromFragment(android.app.Fragment, Intent, int)") {
+        final CallVoid3<android.app.Fragment, Intent, Integer> superCall
+                = new CallVoid3<android.app.Fragment, Intent, Integer>(
+                "startActivityFromFragment(android.app.Fragment, Intent, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.app.Fragment fragment, final Intent intent,
+                    final Integer requestCode) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .startActivityFromFragment(this, (android.app.Fragment) args[0],
-                                    (Intent) args[1], (int) args[2]);
-                    return null;
+                            .startActivityFromFragment(this, fragment, intent, requestCode);
                 } else {
-                    getOriginal().super_startActivityFromFragment((android.app.Fragment) args[0],
-                            (Intent) args[1], (int) args[2]);
-                    return null;
+                    getOriginal().super_startActivityFromFragment(fragment, intent, requestCode);
                 }
             }
         };
@@ -7004,20 +6645,20 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityFromFragment(android.app.Fragment, Intent, int, Bundle)") {
+        final CallVoid4<android.app.Fragment, Intent, Integer, Bundle> superCall
+                = new CallVoid4<android.app.Fragment, Intent, Integer, Bundle>(
+                "startActivityFromFragment(android.app.Fragment, Intent, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final android.app.Fragment fragment, final Intent intent,
+                    final Integer requestCode, final Bundle options) {
                 if (iterator.hasPrevious()) {
                     iterator.previous()
-                            .startActivityFromFragment(this, (android.app.Fragment) args[0],
-                                    (Intent) args[1], (int) args[2], (Bundle) args[3]);
-                    return null;
+                            .startActivityFromFragment(this, fragment, intent, requestCode,
+                                    options);
                 } else {
-                    getOriginal().super_startActivityFromFragment((android.app.Fragment) args[0],
-                            (Intent) args[1], (int) args[2], (Bundle) args[3]);
-                    return null;
+                    getOriginal().super_startActivityFromFragment(fragment, intent, requestCode,
+                            options);
                 }
             }
         };
@@ -7031,17 +6672,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "startActivityIfNeeded(Intent, int)") {
+        final CallFun2<Boolean, Intent, Integer> superCall = new CallFun2<Boolean, Intent, Integer>(
+                "startActivityIfNeeded(Intent, Integer)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent intent, final Integer requestCode) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .startActivityIfNeeded(this, (Intent) args[0], (int) args[1]);
+                    return iterator.previous().startActivityIfNeeded(this, intent, requestCode);
                 } else {
-                    return getOriginal()
-                            .super_startActivityIfNeeded((Intent) args[0], (int) args[1]);
+                    return getOriginal().super_startActivityIfNeeded(intent, requestCode);
                 }
             }
         };
@@ -7056,19 +6695,18 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "startActivityIfNeeded(Intent, int, Bundle)") {
+        final CallFun3<Boolean, Intent, Integer, Bundle> superCall
+                = new CallFun3<Boolean, Intent, Integer, Bundle>(
+                "startActivityIfNeeded(Intent, Integer, Bundle)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent intent, final Integer requestCode,
+                    final Bundle options) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .startActivityIfNeeded(this, (Intent) args[0], (int) args[1],
-                                    (Bundle) args[2]);
+                            .startActivityIfNeeded(this, intent, requestCode, options);
                 } else {
-                    return getOriginal()
-                            .super_startActivityIfNeeded((Intent) args[0], (int) args[1],
-                                    (Bundle) args[2]);
+                    return getOriginal().super_startActivityIfNeeded(intent, requestCode, options);
                 }
             }
         };
@@ -7083,19 +6721,19 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun3<Boolean, ComponentName, String, Bundle> superCall
+                = new CallFun3<Boolean, ComponentName, String, Bundle>(
                 "startInstrumentation(ComponentName, String, Bundle)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final ComponentName className, final String profileFile,
+                    final Bundle arguments) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .startInstrumentation(this, (ComponentName) args[0], (String) args[1],
-                                    (Bundle) args[2]);
+                            .startInstrumentation(this, className, profileFile, arguments);
                 } else {
                     return getOriginal()
-                            .super_startInstrumentation((ComponentName) args[0], (String) args[1],
-                                    (Bundle) args[2]);
+                            .super_startInstrumentation(className, profileFile, arguments);
                 }
             }
         };
@@ -7117,26 +6755,24 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startIntentSender(IntentSender, Intent, int, int, int)") {
+        final CallVoid5<IntentSender, Intent, Integer, Integer, Integer> superCall
+                = new CallVoid5<IntentSender, Intent, Integer, Integer, Integer>(
+                "startIntentSender(IntentSender, Intent, Integer, Integer, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final IntentSender intent, final Intent fillInIntent,
+                    final Integer flagsMask, final Integer flagsValues, final Integer extraFlags) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous()
-                                .startIntentSender(this, (IntentSender) args[0], (Intent) args[1],
-                                        (int) args[2], (int) args[3], (int) args[4]);
-                        return null;
+                        iterator.previous().startIntentSender(this, intent, fillInIntent, flagsMask,
+                                flagsValues, extraFlags);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal()
-                                .super_startIntentSender((IntentSender) args[0], (Intent) args[1],
-                                        (int) args[2], (int) args[3], (int) args[4]);
-                        return null;
+                        getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask,
+                                flagsValues, extraFlags);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
@@ -7161,28 +6797,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startIntentSender(IntentSender, Intent, int, int, int, Bundle)") {
+        final CallVoid6<IntentSender, Intent, Integer, Integer, Integer, Bundle> superCall
+                = new CallVoid6<IntentSender, Intent, Integer, Integer, Integer, Bundle>(
+                "startIntentSender(IntentSender, Intent, Integer, Integer, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final IntentSender intent, final Intent fillInIntent,
+                    final Integer flagsMask, final Integer flagsValues, final Integer extraFlags,
+                    final Bundle options) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous()
-                                .startIntentSender(this, (IntentSender) args[0], (Intent) args[1],
-                                        (int) args[2], (int) args[3], (int) args[4],
-                                        (Bundle) args[5]);
-                        return null;
+                        iterator.previous().startIntentSender(this, intent, fillInIntent, flagsMask,
+                                flagsValues, extraFlags, options);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal()
-                                .super_startIntentSender((IntentSender) args[0], (Intent) args[1],
-                                        (int) args[2], (int) args[3], (int) args[4],
-                                        (Bundle) args[5]);
-                        return null;
+                        getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask,
+                                flagsValues, extraFlags, options);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
@@ -7207,26 +6840,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startIntentSenderForResult(IntentSender, int, Intent, int, int, int)") {
+        final CallVoid6<IntentSender, Integer, Intent, Integer, Integer, Integer> superCall
+                = new CallVoid6<IntentSender, Integer, Intent, Integer, Integer, Integer>(
+                "startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final IntentSender intent, final Integer requestCode,
+                    final Intent fillInIntent, final Integer flagsMask, final Integer flagsValues,
+                    final Integer extraFlags) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous().startIntentSenderForResult(this, (IntentSender) args[0],
-                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                (int) args[5]);
-                        return null;
+                        iterator.previous()
+                                .startIntentSenderForResult(this, intent, requestCode, fillInIntent,
+                                        flagsMask, flagsValues, extraFlags);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
-                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                (int) args[5]);
-                        return null;
+                        getOriginal()
+                                .super_startIntentSenderForResult(intent, requestCode, fillInIntent,
+                                        flagsMask, flagsValues, extraFlags);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
@@ -7251,26 +6885,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startIntentSenderForResult(IntentSender, int, Intent, int, int, int, Bundle)") {
+        final CallVoid7<IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle> superCall
+                = new CallVoid7<IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle>(
+                "startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final IntentSender intent, final Integer requestCode,
+                    final Intent fillInIntent, final Integer flagsMask, final Integer flagsValues,
+                    final Integer extraFlags, final Bundle options) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous().startIntentSenderForResult(this, (IntentSender) args[0],
-                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                (int) args[5], (Bundle) args[6]);
-                        return null;
+                        iterator.previous()
+                                .startIntentSenderForResult(this, intent, requestCode, fillInIntent,
+                                        flagsMask, flagsValues, extraFlags, options);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal().super_startIntentSenderForResult((IntentSender) args[0],
-                                (int) args[1], (Intent) args[2], (int) args[3], (int) args[4],
-                                (int) args[5], (Bundle) args[6]);
-                        return null;
+                        getOriginal()
+                                .super_startIntentSenderForResult(intent, requestCode, fillInIntent,
+                                        flagsMask, flagsValues, extraFlags, options);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
@@ -7297,26 +6932,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int)") {
+        final CallVoid7<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer>
+                superCall
+                = new CallVoid7<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer>(
+                "startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity child, final IntentSender intent,
+                    final Integer requestCode, final Intent fillInIntent, final Integer flagsMask,
+                    final Integer flagsValues, final Integer extraFlags) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous().startIntentSenderFromChild(this, (Activity) args[0],
-                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                (int) args[4], (int) args[5], (int) args[6]);
-                        return null;
+                        iterator.previous()
+                                .startIntentSenderFromChild(this, child, intent, requestCode,
+                                        fillInIntent, flagsMask, flagsValues, extraFlags);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal().super_startIntentSenderFromChild((Activity) args[0],
-                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                (int) args[4], (int) args[5], (int) args[6]);
-                        return null;
+                        getOriginal().super_startIntentSenderFromChild(child, intent, requestCode,
+                                fillInIntent, flagsMask, flagsValues, extraFlags);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
@@ -7344,26 +6980,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int, Bundle)") {
+        final CallVoid8<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle>
+                superCall
+                = new CallVoid8<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle>(
+                "startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity child, final IntentSender intent,
+                    final Integer requestCode, final Intent fillInIntent, final Integer flagsMask,
+                    final Integer flagsValues, final Integer extraFlags, final Bundle options) {
                 if (iterator.hasPrevious()) {
                     try {
-                        iterator.previous().startIntentSenderFromChild(this, (Activity) args[0],
-                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                (int) args[4], (int) args[5], (int) args[6], (Bundle) args[7]);
-                        return null;
+                        iterator.previous()
+                                .startIntentSenderFromChild(this, child, intent, requestCode,
+                                        fillInIntent, flagsMask, flagsValues, extraFlags, options);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
                 } else {
                     try {
-                        getOriginal().super_startIntentSenderFromChild((Activity) args[0],
-                                (IntentSender) args[1], (int) args[2], (Intent) args[3],
-                                (int) args[4], (int) args[5], (int) args[6], (Bundle) args[7]);
-                        return null;
+                        getOriginal().super_startIntentSenderFromChild(child, intent, requestCode,
+                                fillInIntent, flagsMask, flagsValues, extraFlags, options);
                     } catch (IntentSender.SendIntentException e) {
                         throw new SuppressedException(e);
                     }
@@ -7382,16 +7019,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("startLockTask()") {
+        final CallVoid0 superCall = new CallVoid0("startLockTask()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().startLockTask(this);
-                    return null;
                 } else {
                     getOriginal().super_startLockTask();
-                    return null;
                 }
             }
         };
@@ -7406,17 +7041,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startManagingCursor(Cursor)") {
+        final CallVoid1<Cursor> superCall = new CallVoid1<Cursor>("startManagingCursor(Cursor)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Cursor c) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startManagingCursor(this, (Cursor) args[0]);
-                    return null;
+                    iterator.previous().startManagingCursor(this, c);
                 } else {
-                    getOriginal().super_startManagingCursor((Cursor) args[0]);
-                    return null;
+                    getOriginal().super_startManagingCursor(c);
                 }
             }
         };
@@ -7430,15 +7062,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "startNextMatchingActivity(Intent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent intent) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().startNextMatchingActivity(this, (Intent) args[0]);
+                    return iterator.previous().startNextMatchingActivity(this, intent);
                 } else {
-                    return getOriginal().super_startNextMatchingActivity((Intent) args[0]);
+                    return getOriginal().super_startNextMatchingActivity(intent);
                 }
             }
         };
@@ -7452,17 +7084,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun2<Boolean, Intent, Bundle> superCall = new CallFun2<Boolean, Intent, Bundle>(
                 "startNextMatchingActivity(Intent, Bundle)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent intent, final Bundle options) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .startNextMatchingActivity(this, (Intent) args[0], (Bundle) args[1]);
+                    return iterator.previous().startNextMatchingActivity(this, intent, options);
                 } else {
-                    return getOriginal()
-                            .super_startNextMatchingActivity((Intent) args[0], (Bundle) args[1]);
+                    return getOriginal().super_startNextMatchingActivity(intent, options);
                 }
             }
         };
@@ -7477,17 +7107,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startPostponedEnterTransition()") {
+        final CallVoid0 superCall = new CallVoid0("startPostponedEnterTransition()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().startPostponedEnterTransition(this);
-                    return null;
                 } else {
                     getOriginal().super_startPostponedEnterTransition();
-                    return null;
                 }
             }
         };
@@ -7504,19 +7131,20 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startSearch(String, boolean, Bundle, boolean)") {
+        final CallVoid4<String, Boolean, Bundle, Boolean> superCall
+                = new CallVoid4<String, Boolean, Bundle, Boolean>(
+                "startSearch(String, Boolean, Bundle, Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String initialQuery, final Boolean selectInitialQuery,
+                    final Bundle appSearchData, final Boolean globalSearch) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startSearch(this, (String) args[0], (boolean) args[1],
-                            (Bundle) args[2], (boolean) args[3]);
-                    return null;
+                    iterator.previous()
+                            .startSearch(this, initialQuery, selectInitialQuery, appSearchData,
+                                    globalSearch);
                 } else {
-                    getOriginal().super_startSearch((String) args[0], (boolean) args[1],
-                            (Bundle) args[2], (boolean) args[3]);
-                    return null;
+                    getOriginal().super_startSearch(initialQuery, selectInitialQuery, appSearchData,
+                            globalSearch);
                 }
             }
         };
@@ -7530,15 +7158,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ComponentName> superCall = new NamedSuperCall<ComponentName>(
+        final CallFun1<ComponentName, Intent> superCall = new CallFun1<ComponentName, Intent>(
                 "startService(Intent)") {
 
             @Override
-            public ComponentName call(final Object... args) {
+            public ComponentName call(final Intent service) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().startService(this, (Intent) args[0]);
+                    return iterator.previous().startService(this, service);
                 } else {
-                    return getOriginal().super_startService((Intent) args[0]);
+                    return getOriginal().super_startService(service);
                 }
             }
         };
@@ -7552,17 +7180,16 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<ActionMode> superCall = new NamedSuperCall<ActionMode>(
+        final CallFun1<ActionMode, ActionMode.Callback> superCall
+                = new CallFun1<ActionMode, ActionMode.Callback>(
                 "startSupportActionMode(ActionMode.Callback)") {
 
             @Override
-            public ActionMode call(final Object... args) {
+            public ActionMode call(final ActionMode.Callback callback) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .startSupportActionMode(this, (ActionMode.Callback) args[0]);
+                    return iterator.previous().startSupportActionMode(this, callback);
                 } else {
-                    return getOriginal()
-                            .super_startSupportActionMode((ActionMode.Callback) args[0]);
+                    return getOriginal().super_startSupportActionMode(callback);
                 }
             }
         };
@@ -7577,16 +7204,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("stopLockTask()") {
+        final CallVoid0 superCall = new CallVoid0("stopLockTask()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().stopLockTask(this);
-                    return null;
                 } else {
                     getOriginal().super_stopLockTask();
-                    return null;
                 }
             }
         };
@@ -7601,17 +7226,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "stopManagingCursor(Cursor)") {
+        final CallVoid1<Cursor> superCall = new CallVoid1<Cursor>("stopManagingCursor(Cursor)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Cursor c) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().stopManagingCursor(this, (Cursor) args[0]);
-                    return null;
+                    iterator.previous().stopManagingCursor(this, c);
                 } else {
-                    getOriginal().super_stopManagingCursor((Cursor) args[0]);
-                    return null;
+                    getOriginal().super_stopManagingCursor(c);
                 }
             }
         };
@@ -7625,15 +7247,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "stopService(Intent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent name) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().stopService(this, (Intent) args[0]);
+                    return iterator.previous().stopService(this, name);
                 } else {
-                    return getOriginal().super_stopService((Intent) args[0]);
+                    return getOriginal().super_stopService(name);
                 }
             }
         };
@@ -7648,17 +7270,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "supportFinishAfterTransition()") {
+        final CallVoid0 superCall = new CallVoid0("supportFinishAfterTransition()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().supportFinishAfterTransition(this);
-                    return null;
                 } else {
                     getOriginal().super_supportFinishAfterTransition();
-                    return null;
                 }
             }
         };
@@ -7673,17 +7292,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "supportInvalidateOptionsMenu()") {
+        final CallVoid0 superCall = new CallVoid0("supportInvalidateOptionsMenu()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().supportInvalidateOptionsMenu(this);
-                    return null;
                 } else {
                     getOriginal().super_supportInvalidateOptionsMenu();
-                    return null;
                 }
             }
         };
@@ -7698,17 +7314,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "supportNavigateUpTo(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("supportNavigateUpTo(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent upIntent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().supportNavigateUpTo(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().supportNavigateUpTo(this, upIntent);
                 } else {
-                    getOriginal().super_supportNavigateUpTo((Intent) args[0]);
-                    return null;
+                    getOriginal().super_supportNavigateUpTo(upIntent);
                 }
             }
         };
@@ -7723,17 +7336,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "supportPostponeEnterTransition()") {
+        final CallVoid0 superCall = new CallVoid0("supportPostponeEnterTransition()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().supportPostponeEnterTransition(this);
-                    return null;
                 } else {
                     getOriginal().super_supportPostponeEnterTransition();
-                    return null;
                 }
             }
         };
@@ -7747,15 +7357,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "supportRequestWindowFeature(int)") {
+        final CallFun1<Boolean, Integer> superCall = new CallFun1<Boolean, Integer>(
+                "supportRequestWindowFeature(Integer)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Integer featureId) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().supportRequestWindowFeature(this, (int) args[0]);
+                    return iterator.previous().supportRequestWindowFeature(this, featureId);
                 } else {
-                    return getOriginal().super_supportRequestWindowFeature((int) args[0]);
+                    return getOriginal().super_supportRequestWindowFeature(featureId);
                 }
             }
         };
@@ -7769,15 +7379,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "supportShouldUpRecreateTask(Intent)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final Intent targetIntent) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().supportShouldUpRecreateTask(this, (Intent) args[0]);
+                    return iterator.previous().supportShouldUpRecreateTask(this, targetIntent);
                 } else {
-                    return getOriginal().super_supportShouldUpRecreateTask((Intent) args[0]);
+                    return getOriginal().super_supportShouldUpRecreateTask(targetIntent);
                 }
             }
         };
@@ -7792,17 +7402,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "supportStartPostponedEnterTransition()") {
+        final CallVoid0 superCall = new CallVoid0("supportStartPostponedEnterTransition()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().supportStartPostponedEnterTransition(this);
-                    return null;
                 } else {
                     getOriginal().super_supportStartPostponedEnterTransition();
-                    return null;
                 }
             }
         };
@@ -7817,16 +7424,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("takeKeyEvents(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("takeKeyEvents(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean get) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().takeKeyEvents(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().takeKeyEvents(this, get);
                 } else {
-                    getOriginal().super_takeKeyEvents((boolean) args[0]);
-                    return null;
+                    getOriginal().super_takeKeyEvents(get);
                 }
             }
         };
@@ -7841,17 +7446,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<String, Bundle> superCall = new CallVoid2<String, Bundle>(
                 "triggerSearch(String, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String query, final Bundle appSearchData) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().triggerSearch(this, (String) args[0], (Bundle) args[1]);
-                    return null;
+                    iterator.previous().triggerSearch(this, query, appSearchData);
                 } else {
-                    getOriginal().super_triggerSearch((String) args[0], (Bundle) args[1]);
-                    return null;
+                    getOriginal().super_triggerSearch(query, appSearchData);
                 }
             }
         };
@@ -7866,17 +7469,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<ServiceConnection> superCall = new CallVoid1<ServiceConnection>(
                 "unbindService(ServiceConnection)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ServiceConnection conn) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().unbindService(this, (ServiceConnection) args[0]);
-                    return null;
+                    iterator.previous().unbindService(this, conn);
                 } else {
-                    getOriginal().super_unbindService((ServiceConnection) args[0]);
-                    return null;
+                    getOriginal().super_unbindService(conn);
                 }
             }
         };
@@ -7891,18 +7492,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<ComponentCallbacks> superCall = new CallVoid1<ComponentCallbacks>(
                 "unregisterComponentCallbacks(ComponentCallbacks)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ComponentCallbacks callback) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .unregisterComponentCallbacks(this, (ComponentCallbacks) args[0]);
-                    return null;
+                    iterator.previous().unregisterComponentCallbacks(this, callback);
                 } else {
-                    getOriginal().super_unregisterComponentCallbacks((ComponentCallbacks) args[0]);
-                    return null;
+                    getOriginal().super_unregisterComponentCallbacks(callback);
                 }
             }
         };
@@ -7917,17 +7515,14 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "unregisterForContextMenu(View)") {
+        final CallVoid1<View> superCall = new CallVoid1<View>("unregisterForContextMenu(View)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().unregisterForContextMenu(this, (View) args[0]);
-                    return null;
+                    iterator.previous().unregisterForContextMenu(this, view);
                 } else {
-                    getOriginal().super_unregisterForContextMenu((View) args[0]);
-                    return null;
+                    getOriginal().super_unregisterForContextMenu(view);
                 }
             }
         };
@@ -7942,17 +7537,15 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
         final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<BroadcastReceiver> superCall = new CallVoid1<BroadcastReceiver>(
                 "unregisterReceiver(BroadcastReceiver)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final BroadcastReceiver receiver) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().unregisterReceiver(this, (BroadcastReceiver) args[0]);
-                    return null;
+                    iterator.previous().unregisterReceiver(this, receiver);
                 } else {
-                    getOriginal().super_unregisterReceiver((BroadcastReceiver) args[0]);
-                    return null;
+                    getOriginal().super_unregisterReceiver(receiver);
                 }
             }
         };

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
@@ -1,7 +1,21 @@
 package com.pascalwelsch.compositeandroid.activity;
 
 import com.pascalwelsch.compositeandroid.core.AbstractPlugin;
-import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
+import com.pascalwelsch.compositeandroid.core.CallFun0;
+import com.pascalwelsch.compositeandroid.core.CallFun1;
+import com.pascalwelsch.compositeandroid.core.CallFun2;
+import com.pascalwelsch.compositeandroid.core.CallFun3;
+import com.pascalwelsch.compositeandroid.core.CallFun4;
+import com.pascalwelsch.compositeandroid.core.CallFun6;
+import com.pascalwelsch.compositeandroid.core.CallVoid0;
+import com.pascalwelsch.compositeandroid.core.CallVoid1;
+import com.pascalwelsch.compositeandroid.core.CallVoid2;
+import com.pascalwelsch.compositeandroid.core.CallVoid3;
+import com.pascalwelsch.compositeandroid.core.CallVoid4;
+import com.pascalwelsch.compositeandroid.core.CallVoid5;
+import com.pascalwelsch.compositeandroid.core.CallVoid6;
+import com.pascalwelsch.compositeandroid.core.CallVoid7;
+import com.pascalwelsch.compositeandroid.core.CallVoid8;
 
 import android.app.Activity;
 import android.app.ActivityManager;
@@ -84,247 +98,258 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
 
     public void addContentView(final View view, final ViewGroup.LayoutParams params) {
         verifyMethodCalledFromDelegate("addContentView(View, ViewGroup.LayoutParams)");
-        mSuperListeners.pop().call(view, params);
+        ((CallVoid2<View, ViewGroup.LayoutParams>) mSuperListeners.pop()).call(view, params);
     }
 
     public void applyOverrideConfiguration(final Configuration overrideConfiguration) {
         verifyMethodCalledFromDelegate("applyOverrideConfiguration(Configuration)");
-        mSuperListeners.pop().call(overrideConfiguration);
+        ((CallVoid1<Configuration>) mSuperListeners.pop()).call(overrideConfiguration);
     }
 
     public void attachBaseContext(final Context newBase) {
         verifyMethodCalledFromDelegate("attachBaseContext(Context)");
-        mSuperListeners.pop().call(newBase);
+        ((CallVoid1<Context>) mSuperListeners.pop()).call(newBase);
     }
 
     public boolean bindService(final Intent service, final ServiceConnection conn,
             final int flags) {
-        verifyMethodCalledFromDelegate("bindService(Intent, ServiceConnection, int)");
-        return (Boolean) mSuperListeners.pop().call(service, conn, flags);
+        verifyMethodCalledFromDelegate("bindService(Intent, ServiceConnection, Integer)");
+        return ((CallFun3<Boolean, Intent, ServiceConnection, Integer>) mSuperListeners.pop())
+                .call(service, conn, flags);
     }
 
     public int checkCallingOrSelfPermission(final String permission) {
         verifyMethodCalledFromDelegate("checkCallingOrSelfPermission(String)");
-        return (Integer) mSuperListeners.pop().call(permission);
+        return ((CallFun1<Integer, String>) mSuperListeners.pop()).call(permission);
     }
 
     public int checkCallingOrSelfUriPermission(final Uri uri, final int modeFlags) {
-        verifyMethodCalledFromDelegate("checkCallingOrSelfUriPermission(Uri, int)");
-        return (Integer) mSuperListeners.pop().call(uri, modeFlags);
+        verifyMethodCalledFromDelegate("checkCallingOrSelfUriPermission(Uri, Integer)");
+        return ((CallFun2<Integer, Uri, Integer>) mSuperListeners.pop()).call(uri, modeFlags);
     }
 
     public int checkCallingPermission(final String permission) {
         verifyMethodCalledFromDelegate("checkCallingPermission(String)");
-        return (Integer) mSuperListeners.pop().call(permission);
+        return ((CallFun1<Integer, String>) mSuperListeners.pop()).call(permission);
     }
 
     public int checkCallingUriPermission(final Uri uri, final int modeFlags) {
-        verifyMethodCalledFromDelegate("checkCallingUriPermission(Uri, int)");
-        return (Integer) mSuperListeners.pop().call(uri, modeFlags);
+        verifyMethodCalledFromDelegate("checkCallingUriPermission(Uri, Integer)");
+        return ((CallFun2<Integer, Uri, Integer>) mSuperListeners.pop()).call(uri, modeFlags);
     }
 
     public int checkPermission(final String permission, final int pid, final int uid) {
-        verifyMethodCalledFromDelegate("checkPermission(String, int, int)");
-        return (Integer) mSuperListeners.pop().call(permission, pid, uid);
+        verifyMethodCalledFromDelegate("checkPermission(String, Integer, Integer)");
+        return ((CallFun3<Integer, String, Integer, Integer>) mSuperListeners.pop())
+                .call(permission, pid, uid);
     }
 
     public int checkSelfPermission(final String permission) {
         verifyMethodCalledFromDelegate("checkSelfPermission(String)");
-        return (Integer) mSuperListeners.pop().call(permission);
+        return ((CallFun1<Integer, String>) mSuperListeners.pop()).call(permission);
     }
 
     public int checkUriPermission(final Uri uri, final int pid, final int uid,
             final int modeFlags) {
-        verifyMethodCalledFromDelegate("checkUriPermission(Uri, int, int, int)");
-        return (Integer) mSuperListeners.pop().call(uri, pid, uid, modeFlags);
+        verifyMethodCalledFromDelegate("checkUriPermission(Uri, Integer, Integer, Integer)");
+        return ((CallFun4<Integer, Uri, Integer, Integer, Integer>) mSuperListeners.pop())
+                .call(uri, pid, uid, modeFlags);
     }
 
     public int checkUriPermission(final Uri uri, final String readPermission,
             final String writePermission, final int pid, final int uid, final int modeFlags) {
-        verifyMethodCalledFromDelegate("checkUriPermission(Uri, String, String, int, int, int)");
-        return (Integer) mSuperListeners.pop()
-                .call(uri, readPermission, writePermission, pid, uid, modeFlags);
+        verifyMethodCalledFromDelegate(
+                "checkUriPermission(Uri, String, String, Integer, Integer, Integer)");
+        return ((CallFun6<Integer, Uri, String, String, Integer, Integer, Integer>) mSuperListeners
+                .pop()).call(uri, readPermission, writePermission, pid, uid, modeFlags);
     }
 
     public void clearWallpaper() throws IOException {
         verifyMethodCalledFromDelegate("clearWallpaper()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void closeContextMenu() {
         verifyMethodCalledFromDelegate("closeContextMenu()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void closeOptionsMenu() {
         verifyMethodCalledFromDelegate("closeOptionsMenu()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public Context createConfigurationContext(final Configuration overrideConfiguration) {
         verifyMethodCalledFromDelegate("createConfigurationContext(Configuration)");
-        return (Context) mSuperListeners.pop().call(overrideConfiguration);
+        return ((CallFun1<Context, Configuration>) mSuperListeners.pop())
+                .call(overrideConfiguration);
     }
 
     public Context createDisplayContext(final Display display) {
         verifyMethodCalledFromDelegate("createDisplayContext(Display)");
-        return (Context) mSuperListeners.pop().call(display);
+        return ((CallFun1<Context, Display>) mSuperListeners.pop()).call(display);
     }
 
     public Context createPackageContext(final String packageName, final int flags)
             throws PackageManager.NameNotFoundException {
-        verifyMethodCalledFromDelegate("createPackageContext(String, int)");
-        return (Context) mSuperListeners.pop().call(packageName, flags);
+        verifyMethodCalledFromDelegate("createPackageContext(String, Integer)");
+        return ((CallFun2<Context, String, Integer>) mSuperListeners.pop())
+                .call(packageName, flags);
     }
 
     public PendingIntent createPendingResult(final int requestCode, final Intent data,
             final int flags) {
-        verifyMethodCalledFromDelegate("createPendingResult(int, Intent, int)");
-        return (PendingIntent) mSuperListeners.pop().call(requestCode, data, flags);
+        verifyMethodCalledFromDelegate("createPendingResult(Integer, Intent, Integer)");
+        return ((CallFun3<PendingIntent, Integer, Intent, Integer>) mSuperListeners.pop())
+                .call(requestCode, data, flags);
     }
 
     public String[] databaseList() {
         verifyMethodCalledFromDelegate("databaseList()");
-        return (String[]) mSuperListeners.pop().call();
+        return ((CallFun0<String[]>) mSuperListeners.pop()).call();
     }
 
     public boolean deleteDatabase(final String name) {
         verifyMethodCalledFromDelegate("deleteDatabase(String)");
-        return (Boolean) mSuperListeners.pop().call(name);
+        return ((CallFun1<Boolean, String>) mSuperListeners.pop()).call(name);
     }
 
     public boolean deleteFile(final String name) {
         verifyMethodCalledFromDelegate("deleteFile(String)");
-        return (Boolean) mSuperListeners.pop().call(name);
+        return ((CallFun1<Boolean, String>) mSuperListeners.pop()).call(name);
     }
 
     public boolean dispatchGenericMotionEvent(final MotionEvent ev) {
         verifyMethodCalledFromDelegate("dispatchGenericMotionEvent(MotionEvent)");
-        return (Boolean) mSuperListeners.pop().call(ev);
+        return ((CallFun1<Boolean, MotionEvent>) mSuperListeners.pop()).call(ev);
     }
 
     public boolean dispatchKeyEvent(final KeyEvent event) {
         verifyMethodCalledFromDelegate("dispatchKeyEvent(KeyEvent)");
-        return (Boolean) mSuperListeners.pop().call(event);
+        return ((CallFun1<Boolean, KeyEvent>) mSuperListeners.pop()).call(event);
     }
 
     public boolean dispatchKeyShortcutEvent(final KeyEvent event) {
         verifyMethodCalledFromDelegate("dispatchKeyShortcutEvent(KeyEvent)");
-        return (Boolean) mSuperListeners.pop().call(event);
+        return ((CallFun1<Boolean, KeyEvent>) mSuperListeners.pop()).call(event);
     }
 
     public boolean dispatchPopulateAccessibilityEvent(final AccessibilityEvent event) {
         verifyMethodCalledFromDelegate("dispatchPopulateAccessibilityEvent(AccessibilityEvent)");
-        return (Boolean) mSuperListeners.pop().call(event);
+        return ((CallFun1<Boolean, AccessibilityEvent>) mSuperListeners.pop()).call(event);
     }
 
     public boolean dispatchTouchEvent(final MotionEvent ev) {
         verifyMethodCalledFromDelegate("dispatchTouchEvent(MotionEvent)");
-        return (Boolean) mSuperListeners.pop().call(ev);
+        return ((CallFun1<Boolean, MotionEvent>) mSuperListeners.pop()).call(ev);
     }
 
     public boolean dispatchTrackballEvent(final MotionEvent ev) {
         verifyMethodCalledFromDelegate("dispatchTrackballEvent(MotionEvent)");
-        return (Boolean) mSuperListeners.pop().call(ev);
+        return ((CallFun1<Boolean, MotionEvent>) mSuperListeners.pop()).call(ev);
     }
 
     public void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args) {
         verifyMethodCalledFromDelegate("dump(String, FileDescriptor, PrintWriter, String[])");
-        mSuperListeners.pop().call(prefix, fd, writer, args);
+        ((CallVoid4<String, FileDescriptor, PrintWriter, String[]>) mSuperListeners.pop())
+                .call(prefix, fd, writer, args);
     }
 
     public void enforceCallingOrSelfPermission(final String permission, final String message) {
         verifyMethodCalledFromDelegate("enforceCallingOrSelfPermission(String, String)");
-        mSuperListeners.pop().call(permission, message);
+        ((CallVoid2<String, String>) mSuperListeners.pop()).call(permission, message);
     }
 
     public void enforceCallingOrSelfUriPermission(final Uri uri, final int modeFlags,
             final String message) {
-        verifyMethodCalledFromDelegate("enforceCallingOrSelfUriPermission(Uri, int, String)");
-        mSuperListeners.pop().call(uri, modeFlags, message);
+        verifyMethodCalledFromDelegate("enforceCallingOrSelfUriPermission(Uri, Integer, String)");
+        ((CallVoid3<Uri, Integer, String>) mSuperListeners.pop()).call(uri, modeFlags, message);
     }
 
     public void enforceCallingPermission(final String permission, final String message) {
         verifyMethodCalledFromDelegate("enforceCallingPermission(String, String)");
-        mSuperListeners.pop().call(permission, message);
+        ((CallVoid2<String, String>) mSuperListeners.pop()).call(permission, message);
     }
 
     public void enforceCallingUriPermission(final Uri uri, final int modeFlags,
             final String message) {
-        verifyMethodCalledFromDelegate("enforceCallingUriPermission(Uri, int, String)");
-        mSuperListeners.pop().call(uri, modeFlags, message);
+        verifyMethodCalledFromDelegate("enforceCallingUriPermission(Uri, Integer, String)");
+        ((CallVoid3<Uri, Integer, String>) mSuperListeners.pop()).call(uri, modeFlags, message);
     }
 
     public void enforcePermission(final String permission, final int pid, final int uid,
             final String message) {
-        verifyMethodCalledFromDelegate("enforcePermission(String, int, int, String)");
-        mSuperListeners.pop().call(permission, pid, uid, message);
+        verifyMethodCalledFromDelegate("enforcePermission(String, Integer, Integer, String)");
+        ((CallVoid4<String, Integer, Integer, String>) mSuperListeners.pop())
+                .call(permission, pid, uid, message);
     }
 
     public void enforceUriPermission(final Uri uri, final int pid, final int uid,
             final int modeFlags, final String message) {
-        verifyMethodCalledFromDelegate("enforceUriPermission(Uri, int, int, int, String)");
-        mSuperListeners.pop().call(uri, pid, uid, modeFlags, message);
+        verifyMethodCalledFromDelegate(
+                "enforceUriPermission(Uri, Integer, Integer, Integer, String)");
+        ((CallVoid5<Uri, Integer, Integer, Integer, String>) mSuperListeners.pop())
+                .call(uri, pid, uid, modeFlags, message);
     }
 
     public void enforceUriPermission(final Uri uri, final String readPermission,
             final String writePermission, final int pid, final int uid, final int modeFlags,
             final String message) {
         verifyMethodCalledFromDelegate(
-                "enforceUriPermission(Uri, String, String, int, int, int, String)");
-        mSuperListeners.pop()
+                "enforceUriPermission(Uri, String, String, Integer, Integer, Integer, String)");
+        ((CallVoid7<Uri, String, String, Integer, Integer, Integer, String>) mSuperListeners.pop())
                 .call(uri, readPermission, writePermission, pid, uid, modeFlags, message);
     }
 
     public String[] fileList() {
         verifyMethodCalledFromDelegate("fileList()");
-        return (String[]) mSuperListeners.pop().call();
+        return ((CallFun0<String[]>) mSuperListeners.pop()).call();
     }
 
     public View findViewById(@IdRes final int id) {
-        verifyMethodCalledFromDelegate("findViewById(int)");
-        return (View) mSuperListeners.pop().call(id);
+        verifyMethodCalledFromDelegate("findViewById(Integer)");
+        return ((CallFun1<View, Integer>) mSuperListeners.pop()).call(id);
     }
 
     public void finish() {
         verifyMethodCalledFromDelegate("finish()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void finishActivity(final int requestCode) {
-        verifyMethodCalledFromDelegate("finishActivity(int)");
-        mSuperListeners.pop().call(requestCode);
+        verifyMethodCalledFromDelegate("finishActivity(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(requestCode);
     }
 
     public void finishActivityFromChild(final Activity child, final int requestCode) {
-        verifyMethodCalledFromDelegate("finishActivityFromChild(Activity, int)");
-        mSuperListeners.pop().call(child, requestCode);
+        verifyMethodCalledFromDelegate("finishActivityFromChild(Activity, Integer)");
+        ((CallVoid2<Activity, Integer>) mSuperListeners.pop()).call(child, requestCode);
     }
 
     public void finishAffinity() {
         verifyMethodCalledFromDelegate("finishAffinity()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void finishAfterTransition() {
         verifyMethodCalledFromDelegate("finishAfterTransition()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void finishAndRemoveTask() {
         verifyMethodCalledFromDelegate("finishAndRemoveTask()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void finishFromChild(final Activity child) {
         verifyMethodCalledFromDelegate("finishFromChild(Activity)");
-        mSuperListeners.pop().call(child);
+        ((CallVoid1<Activity>) mSuperListeners.pop()).call(child);
     }
 
     public android.app.ActionBar getActionBar() {
         verifyMethodCalledFromDelegate("getActionBar()");
-        return (android.app.ActionBar) mSuperListeners.pop().call();
+        return ((CallFun0<android.app.ActionBar>) mSuperListeners.pop()).call();
     }
 
     public Activity getActivity() {
@@ -333,142 +358,142 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
 
     public Context getApplicationContext() {
         verifyMethodCalledFromDelegate("getApplicationContext()");
-        return (Context) mSuperListeners.pop().call();
+        return ((CallFun0<Context>) mSuperListeners.pop()).call();
     }
 
     public ApplicationInfo getApplicationInfo() {
         verifyMethodCalledFromDelegate("getApplicationInfo()");
-        return (ApplicationInfo) mSuperListeners.pop().call();
+        return ((CallFun0<ApplicationInfo>) mSuperListeners.pop()).call();
     }
 
     public AssetManager getAssets() {
         verifyMethodCalledFromDelegate("getAssets()");
-        return (AssetManager) mSuperListeners.pop().call();
+        return ((CallFun0<AssetManager>) mSuperListeners.pop()).call();
     }
 
     public Context getBaseContext() {
         verifyMethodCalledFromDelegate("getBaseContext()");
-        return (Context) mSuperListeners.pop().call();
+        return ((CallFun0<Context>) mSuperListeners.pop()).call();
     }
 
     public File getCacheDir() {
         verifyMethodCalledFromDelegate("getCacheDir()");
-        return (File) mSuperListeners.pop().call();
+        return ((CallFun0<File>) mSuperListeners.pop()).call();
     }
 
     public ComponentName getCallingActivity() {
         verifyMethodCalledFromDelegate("getCallingActivity()");
-        return (ComponentName) mSuperListeners.pop().call();
+        return ((CallFun0<ComponentName>) mSuperListeners.pop()).call();
     }
 
     public String getCallingPackage() {
         verifyMethodCalledFromDelegate("getCallingPackage()");
-        return (String) mSuperListeners.pop().call();
+        return ((CallFun0<String>) mSuperListeners.pop()).call();
     }
 
     public int getChangingConfigurations() {
         verifyMethodCalledFromDelegate("getChangingConfigurations()");
-        return (Integer) mSuperListeners.pop().call();
+        return ((CallFun0<Integer>) mSuperListeners.pop()).call();
     }
 
     public ClassLoader getClassLoader() {
         verifyMethodCalledFromDelegate("getClassLoader()");
-        return (ClassLoader) mSuperListeners.pop().call();
+        return ((CallFun0<ClassLoader>) mSuperListeners.pop()).call();
     }
 
     public File getCodeCacheDir() {
         verifyMethodCalledFromDelegate("getCodeCacheDir()");
-        return (File) mSuperListeners.pop().call();
+        return ((CallFun0<File>) mSuperListeners.pop()).call();
     }
 
     public ComponentName getComponentName() {
         verifyMethodCalledFromDelegate("getComponentName()");
-        return (ComponentName) mSuperListeners.pop().call();
+        return ((CallFun0<ComponentName>) mSuperListeners.pop()).call();
     }
 
     public ContentResolver getContentResolver() {
         verifyMethodCalledFromDelegate("getContentResolver()");
-        return (ContentResolver) mSuperListeners.pop().call();
+        return ((CallFun0<ContentResolver>) mSuperListeners.pop()).call();
     }
 
     public Scene getContentScene() {
         verifyMethodCalledFromDelegate("getContentScene()");
-        return (Scene) mSuperListeners.pop().call();
+        return ((CallFun0<Scene>) mSuperListeners.pop()).call();
     }
 
     public TransitionManager getContentTransitionManager() {
         verifyMethodCalledFromDelegate("getContentTransitionManager()");
-        return (TransitionManager) mSuperListeners.pop().call();
+        return ((CallFun0<TransitionManager>) mSuperListeners.pop()).call();
     }
 
     public View getCurrentFocus() {
         verifyMethodCalledFromDelegate("getCurrentFocus()");
-        return (View) mSuperListeners.pop().call();
+        return ((CallFun0<View>) mSuperListeners.pop()).call();
     }
 
     public File getDatabasePath(final String name) {
         verifyMethodCalledFromDelegate("getDatabasePath(String)");
-        return (File) mSuperListeners.pop().call(name);
+        return ((CallFun1<File, String>) mSuperListeners.pop()).call(name);
     }
 
     public AppCompatDelegate getDelegate() {
         verifyMethodCalledFromDelegate("getDelegate()");
-        return (AppCompatDelegate) mSuperListeners.pop().call();
+        return ((CallFun0<AppCompatDelegate>) mSuperListeners.pop()).call();
     }
 
     public File getDir(final String name, final int mode) {
-        verifyMethodCalledFromDelegate("getDir(String, int)");
-        return (File) mSuperListeners.pop().call(name, mode);
+        verifyMethodCalledFromDelegate("getDir(String, Integer)");
+        return ((CallFun2<File, String, Integer>) mSuperListeners.pop()).call(name, mode);
     }
 
     public ActionBarDrawerToggle.Delegate getDrawerToggleDelegate() {
         verifyMethodCalledFromDelegate("getDrawerToggleDelegate()");
-        return (ActionBarDrawerToggle.Delegate) mSuperListeners.pop().call();
+        return ((CallFun0<ActionBarDrawerToggle.Delegate>) mSuperListeners.pop()).call();
     }
 
     public File getExternalCacheDir() {
         verifyMethodCalledFromDelegate("getExternalCacheDir()");
-        return (File) mSuperListeners.pop().call();
+        return ((CallFun0<File>) mSuperListeners.pop()).call();
     }
 
     public File[] getExternalCacheDirs() {
         verifyMethodCalledFromDelegate("getExternalCacheDirs()");
-        return (File[]) mSuperListeners.pop().call();
+        return ((CallFun0<File[]>) mSuperListeners.pop()).call();
     }
 
     public File getExternalFilesDir(final String type) {
         verifyMethodCalledFromDelegate("getExternalFilesDir(String)");
-        return (File) mSuperListeners.pop().call(type);
+        return ((CallFun1<File, String>) mSuperListeners.pop()).call(type);
     }
 
     public File[] getExternalFilesDirs(final String type) {
         verifyMethodCalledFromDelegate("getExternalFilesDirs(String)");
-        return (File[]) mSuperListeners.pop().call(type);
+        return ((CallFun1<File[], String>) mSuperListeners.pop()).call(type);
     }
 
     public File[] getExternalMediaDirs() {
         verifyMethodCalledFromDelegate("getExternalMediaDirs()");
-        return (File[]) mSuperListeners.pop().call();
+        return ((CallFun0<File[]>) mSuperListeners.pop()).call();
     }
 
     public File getFileStreamPath(final String name) {
         verifyMethodCalledFromDelegate("getFileStreamPath(String)");
-        return (File) mSuperListeners.pop().call(name);
+        return ((CallFun1<File, String>) mSuperListeners.pop()).call(name);
     }
 
     public File getFilesDir() {
         verifyMethodCalledFromDelegate("getFilesDir()");
-        return (File) mSuperListeners.pop().call();
+        return ((CallFun0<File>) mSuperListeners.pop()).call();
     }
 
     public android.app.FragmentManager getFragmentManager() {
         verifyMethodCalledFromDelegate("getFragmentManager()");
-        return (android.app.FragmentManager) mSuperListeners.pop().call();
+        return ((CallFun0<android.app.FragmentManager>) mSuperListeners.pop()).call();
     }
 
     public Intent getIntent() {
         verifyMethodCalledFromDelegate("getIntent()");
-        return (Intent) mSuperListeners.pop().call();
+        return ((CallFun0<Intent>) mSuperListeners.pop()).call();
     }
 
     public Object getLastNonConfigurationInstance(final String key) {
@@ -477,568 +502,580 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
 
     public LayoutInflater getLayoutInflater() {
         verifyMethodCalledFromDelegate("getLayoutInflater()");
-        return (LayoutInflater) mSuperListeners.pop().call();
+        return ((CallFun0<LayoutInflater>) mSuperListeners.pop()).call();
     }
 
     public android.app.LoaderManager getLoaderManager() {
         verifyMethodCalledFromDelegate("getLoaderManager()");
-        return (android.app.LoaderManager) mSuperListeners.pop().call();
+        return ((CallFun0<android.app.LoaderManager>) mSuperListeners.pop()).call();
     }
 
     public String getLocalClassName() {
         verifyMethodCalledFromDelegate("getLocalClassName()");
-        return (String) mSuperListeners.pop().call();
+        return ((CallFun0<String>) mSuperListeners.pop()).call();
     }
 
     public Looper getMainLooper() {
         verifyMethodCalledFromDelegate("getMainLooper()");
-        return (Looper) mSuperListeners.pop().call();
+        return ((CallFun0<Looper>) mSuperListeners.pop()).call();
     }
 
     public MenuInflater getMenuInflater() {
         verifyMethodCalledFromDelegate("getMenuInflater()");
-        return (MenuInflater) mSuperListeners.pop().call();
+        return ((CallFun0<MenuInflater>) mSuperListeners.pop()).call();
     }
 
     public File getNoBackupFilesDir() {
         verifyMethodCalledFromDelegate("getNoBackupFilesDir()");
-        return (File) mSuperListeners.pop().call();
+        return ((CallFun0<File>) mSuperListeners.pop()).call();
     }
 
     public File getObbDir() {
         verifyMethodCalledFromDelegate("getObbDir()");
-        return (File) mSuperListeners.pop().call();
+        return ((CallFun0<File>) mSuperListeners.pop()).call();
     }
 
     public File[] getObbDirs() {
         verifyMethodCalledFromDelegate("getObbDirs()");
-        return (File[]) mSuperListeners.pop().call();
+        return ((CallFun0<File[]>) mSuperListeners.pop()).call();
     }
 
     public String getPackageCodePath() {
         verifyMethodCalledFromDelegate("getPackageCodePath()");
-        return (String) mSuperListeners.pop().call();
+        return ((CallFun0<String>) mSuperListeners.pop()).call();
     }
 
     public PackageManager getPackageManager() {
         verifyMethodCalledFromDelegate("getPackageManager()");
-        return (PackageManager) mSuperListeners.pop().call();
+        return ((CallFun0<PackageManager>) mSuperListeners.pop()).call();
     }
 
     public String getPackageName() {
         verifyMethodCalledFromDelegate("getPackageName()");
-        return (String) mSuperListeners.pop().call();
+        return ((CallFun0<String>) mSuperListeners.pop()).call();
     }
 
     public String getPackageResourcePath() {
         verifyMethodCalledFromDelegate("getPackageResourcePath()");
-        return (String) mSuperListeners.pop().call();
+        return ((CallFun0<String>) mSuperListeners.pop()).call();
     }
 
     public Intent getParentActivityIntent() {
         verifyMethodCalledFromDelegate("getParentActivityIntent()");
-        return (Intent) mSuperListeners.pop().call();
+        return ((CallFun0<Intent>) mSuperListeners.pop()).call();
     }
 
     public SharedPreferences getPreferences(final int mode) {
-        verifyMethodCalledFromDelegate("getPreferences(int)");
-        return (SharedPreferences) mSuperListeners.pop().call(mode);
+        verifyMethodCalledFromDelegate("getPreferences(Integer)");
+        return ((CallFun1<SharedPreferences, Integer>) mSuperListeners.pop()).call(mode);
     }
 
     public Uri getReferrer() {
         verifyMethodCalledFromDelegate("getReferrer()");
-        return (Uri) mSuperListeners.pop().call();
+        return ((CallFun0<Uri>) mSuperListeners.pop()).call();
     }
 
     public int getRequestedOrientation() {
         verifyMethodCalledFromDelegate("getRequestedOrientation()");
-        return (Integer) mSuperListeners.pop().call();
+        return ((CallFun0<Integer>) mSuperListeners.pop()).call();
     }
 
     public Resources getResources() {
         verifyMethodCalledFromDelegate("getResources()");
-        return (Resources) mSuperListeners.pop().call();
+        return ((CallFun0<Resources>) mSuperListeners.pop()).call();
     }
 
     public SharedPreferences getSharedPreferences(final String name, final int mode) {
-        verifyMethodCalledFromDelegate("getSharedPreferences(String, int)");
-        return (SharedPreferences) mSuperListeners.pop().call(name, mode);
+        verifyMethodCalledFromDelegate("getSharedPreferences(String, Integer)");
+        return ((CallFun2<SharedPreferences, String, Integer>) mSuperListeners.pop())
+                .call(name, mode);
     }
 
     public ActionBar getSupportActionBar() {
         verifyMethodCalledFromDelegate("getSupportActionBar()");
-        return (ActionBar) mSuperListeners.pop().call();
+        return ((CallFun0<ActionBar>) mSuperListeners.pop()).call();
     }
 
     public FragmentManager getSupportFragmentManager() {
         verifyMethodCalledFromDelegate("getSupportFragmentManager()");
-        return (FragmentManager) mSuperListeners.pop().call();
+        return ((CallFun0<FragmentManager>) mSuperListeners.pop()).call();
     }
 
     public LoaderManager getSupportLoaderManager() {
         verifyMethodCalledFromDelegate("getSupportLoaderManager()");
-        return (LoaderManager) mSuperListeners.pop().call();
+        return ((CallFun0<LoaderManager>) mSuperListeners.pop()).call();
     }
 
     public Intent getSupportParentActivityIntent() {
         verifyMethodCalledFromDelegate("getSupportParentActivityIntent()");
-        return (Intent) mSuperListeners.pop().call();
+        return ((CallFun0<Intent>) mSuperListeners.pop()).call();
     }
 
     public Object getSystemService(final String name) {
         verifyMethodCalledFromDelegate("getSystemService(String)");
-        return (Object) mSuperListeners.pop().call(name);
+        return ((CallFun1<Object, String>) mSuperListeners.pop()).call(name);
     }
 
     public String getSystemServiceName(final Class<?> serviceClass) {
         verifyMethodCalledFromDelegate("getSystemServiceName(Class<?>)");
-        return (String) mSuperListeners.pop().call(serviceClass);
+        return ((CallFun1<String, Class<?>>) mSuperListeners.pop()).call(serviceClass);
     }
 
     public int getTaskId() {
         verifyMethodCalledFromDelegate("getTaskId()");
-        return (Integer) mSuperListeners.pop().call();
+        return ((CallFun0<Integer>) mSuperListeners.pop()).call();
     }
 
     public Resources.Theme getTheme() {
         verifyMethodCalledFromDelegate("getTheme()");
-        return (Resources.Theme) mSuperListeners.pop().call();
+        return ((CallFun0<Resources.Theme>) mSuperListeners.pop()).call();
     }
 
     public VoiceInteractor getVoiceInteractor() {
         verifyMethodCalledFromDelegate("getVoiceInteractor()");
-        return (VoiceInteractor) mSuperListeners.pop().call();
+        return ((CallFun0<VoiceInteractor>) mSuperListeners.pop()).call();
     }
 
     public Drawable getWallpaper() {
         verifyMethodCalledFromDelegate("getWallpaper()");
-        return (Drawable) mSuperListeners.pop().call();
+        return ((CallFun0<Drawable>) mSuperListeners.pop()).call();
     }
 
     public int getWallpaperDesiredMinimumHeight() {
         verifyMethodCalledFromDelegate("getWallpaperDesiredMinimumHeight()");
-        return (Integer) mSuperListeners.pop().call();
+        return ((CallFun0<Integer>) mSuperListeners.pop()).call();
     }
 
     public int getWallpaperDesiredMinimumWidth() {
         verifyMethodCalledFromDelegate("getWallpaperDesiredMinimumWidth()");
-        return (Integer) mSuperListeners.pop().call();
+        return ((CallFun0<Integer>) mSuperListeners.pop()).call();
     }
 
     public Window getWindow() {
         verifyMethodCalledFromDelegate("getWindow()");
-        return (Window) mSuperListeners.pop().call();
+        return ((CallFun0<Window>) mSuperListeners.pop()).call();
     }
 
     public WindowManager getWindowManager() {
         verifyMethodCalledFromDelegate("getWindowManager()");
-        return (WindowManager) mSuperListeners.pop().call();
+        return ((CallFun0<WindowManager>) mSuperListeners.pop()).call();
     }
 
     public void grantUriPermission(final String toPackage, final Uri uri, final int modeFlags) {
-        verifyMethodCalledFromDelegate("grantUriPermission(String, Uri, int)");
-        mSuperListeners.pop().call(toPackage, uri, modeFlags);
+        verifyMethodCalledFromDelegate("grantUriPermission(String, Uri, Integer)");
+        ((CallVoid3<String, Uri, Integer>) mSuperListeners.pop()).call(toPackage, uri, modeFlags);
     }
 
     public boolean hasWindowFocus() {
         verifyMethodCalledFromDelegate("hasWindowFocus()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public void invalidateOptionsMenu() {
         verifyMethodCalledFromDelegate("invalidateOptionsMenu()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean isChangingConfigurations() {
         verifyMethodCalledFromDelegate("isChangingConfigurations()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean isDestroyed() {
         verifyMethodCalledFromDelegate("isDestroyed()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean isFinishing() {
         verifyMethodCalledFromDelegate("isFinishing()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean isImmersive() {
         verifyMethodCalledFromDelegate("isImmersive()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean isRestricted() {
         verifyMethodCalledFromDelegate("isRestricted()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean isTaskRoot() {
         verifyMethodCalledFromDelegate("isTaskRoot()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean isVoiceInteraction() {
         verifyMethodCalledFromDelegate("isVoiceInteraction()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean isVoiceInteractionRoot() {
         verifyMethodCalledFromDelegate("isVoiceInteractionRoot()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean moveTaskToBack(final boolean nonRoot) {
-        verifyMethodCalledFromDelegate("moveTaskToBack(boolean)");
-        return (Boolean) mSuperListeners.pop().call(nonRoot);
+        verifyMethodCalledFromDelegate("moveTaskToBack(Boolean)");
+        return ((CallFun1<Boolean, Boolean>) mSuperListeners.pop()).call(nonRoot);
     }
 
     public boolean navigateUpTo(final Intent upIntent) {
         verifyMethodCalledFromDelegate("navigateUpTo(Intent)");
-        return (Boolean) mSuperListeners.pop().call(upIntent);
+        return ((CallFun1<Boolean, Intent>) mSuperListeners.pop()).call(upIntent);
     }
 
     public boolean navigateUpToFromChild(final Activity child, final Intent upIntent) {
         verifyMethodCalledFromDelegate("navigateUpToFromChild(Activity, Intent)");
-        return (Boolean) mSuperListeners.pop().call(child, upIntent);
+        return ((CallFun2<Boolean, Activity, Intent>) mSuperListeners.pop()).call(child, upIntent);
     }
 
     public void onActionModeFinished(final android.view.ActionMode mode) {
         verifyMethodCalledFromDelegate("onActionModeFinished(android.view.ActionMode)");
-        mSuperListeners.pop().call(mode);
+        ((CallVoid1<android.view.ActionMode>) mSuperListeners.pop()).call(mode);
     }
 
     public void onActionModeStarted(final android.view.ActionMode mode) {
         verifyMethodCalledFromDelegate("onActionModeStarted(android.view.ActionMode)");
-        mSuperListeners.pop().call(mode);
+        ((CallVoid1<android.view.ActionMode>) mSuperListeners.pop()).call(mode);
     }
 
     public void onActivityReenter(final int resultCode, final Intent data) {
-        verifyMethodCalledFromDelegate("onActivityReenter(int, Intent)");
-        mSuperListeners.pop().call(resultCode, data);
+        verifyMethodCalledFromDelegate("onActivityReenter(Integer, Intent)");
+        ((CallVoid2<Integer, Intent>) mSuperListeners.pop()).call(resultCode, data);
     }
 
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        verifyMethodCalledFromDelegate("onActivityResult(int, int, Intent)");
-        mSuperListeners.pop().call(requestCode, resultCode, data);
+        verifyMethodCalledFromDelegate("onActivityResult(Integer, Integer, Intent)");
+        ((CallVoid3<Integer, Integer, Intent>) mSuperListeners.pop())
+                .call(requestCode, resultCode, data);
     }
 
     public void onApplyThemeResource(final Resources.Theme theme, final int resid,
             final boolean first) {
-        verifyMethodCalledFromDelegate("onApplyThemeResource(Resources.Theme, int, boolean)");
-        mSuperListeners.pop().call(theme, resid, first);
+        verifyMethodCalledFromDelegate("onApplyThemeResource(Resources.Theme, Integer, Boolean)");
+        ((CallVoid3<Resources.Theme, Integer, Boolean>) mSuperListeners.pop())
+                .call(theme, resid, first);
     }
 
     public void onAttachFragment(final Fragment fragment) {
         verifyMethodCalledFromDelegate("onAttachFragment(Fragment)");
-        mSuperListeners.pop().call(fragment);
+        ((CallVoid1<Fragment>) mSuperListeners.pop()).call(fragment);
     }
 
     public void onAttachFragment(final android.app.Fragment fragment) {
         verifyMethodCalledFromDelegate("onAttachFragment(android.app.Fragment)");
-        mSuperListeners.pop().call(fragment);
+        ((CallVoid1<android.app.Fragment>) mSuperListeners.pop()).call(fragment);
     }
 
     public void onAttachedToWindow() {
         verifyMethodCalledFromDelegate("onAttachedToWindow()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onBackPressed() {
         verifyMethodCalledFromDelegate("onBackPressed()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onChildTitleChanged(final Activity childActivity, final CharSequence title) {
         verifyMethodCalledFromDelegate("onChildTitleChanged(Activity, CharSequence)");
-        mSuperListeners.pop().call(childActivity, title);
+        ((CallVoid2<Activity, CharSequence>) mSuperListeners.pop()).call(childActivity, title);
     }
 
     public void onConfigurationChanged(final Configuration newConfig) {
         verifyMethodCalledFromDelegate("onConfigurationChanged(Configuration)");
-        mSuperListeners.pop().call(newConfig);
+        ((CallVoid1<Configuration>) mSuperListeners.pop()).call(newConfig);
     }
 
     public void onContentChanged() {
         verifyMethodCalledFromDelegate("onContentChanged()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean onContextItemSelected(final MenuItem item) {
         verifyMethodCalledFromDelegate("onContextItemSelected(MenuItem)");
-        return (Boolean) mSuperListeners.pop().call(item);
+        return ((CallFun1<Boolean, MenuItem>) mSuperListeners.pop()).call(item);
     }
 
     public void onContextMenuClosed(final Menu menu) {
         verifyMethodCalledFromDelegate("onContextMenuClosed(Menu)");
-        mSuperListeners.pop().call(menu);
+        ((CallVoid1<Menu>) mSuperListeners.pop()).call(menu);
     }
 
     public void onCreate(final Bundle savedInstanceState, final PersistableBundle persistentState) {
         verifyMethodCalledFromDelegate("onCreate(Bundle, PersistableBundle)");
-        mSuperListeners.pop().call(savedInstanceState, persistentState);
+        ((CallVoid2<Bundle, PersistableBundle>) mSuperListeners.pop())
+                .call(savedInstanceState, persistentState);
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onCreate(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo) {
         verifyMethodCalledFromDelegate(
                 "onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)");
-        mSuperListeners.pop().call(menu, v, menuInfo);
+        ((CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo>) mSuperListeners.pop())
+                .call(menu, v, menuInfo);
     }
 
     public CharSequence onCreateDescription() {
         verifyMethodCalledFromDelegate("onCreateDescription()");
-        return (CharSequence) mSuperListeners.pop().call();
+        return ((CallFun0<CharSequence>) mSuperListeners.pop()).call();
     }
 
     public Dialog onCreateDialog(final int id) {
-        verifyMethodCalledFromDelegate("onCreateDialog(int)");
-        return (Dialog) mSuperListeners.pop().call(id);
+        verifyMethodCalledFromDelegate("onCreateDialog(Integer)");
+        return ((CallFun1<Dialog, Integer>) mSuperListeners.pop()).call(id);
     }
 
     public Dialog onCreateDialog(final int id, final Bundle args) {
-        verifyMethodCalledFromDelegate("onCreateDialog(int, Bundle)");
-        return (Dialog) mSuperListeners.pop().call(id, args);
+        verifyMethodCalledFromDelegate("onCreateDialog(Integer, Bundle)");
+        return ((CallFun2<Dialog, Integer, Bundle>) mSuperListeners.pop()).call(id, args);
     }
 
     public void onCreateNavigateUpTaskStack(final TaskStackBuilder builder) {
         verifyMethodCalledFromDelegate("onCreateNavigateUpTaskStack(TaskStackBuilder)");
-        mSuperListeners.pop().call(builder);
+        ((CallVoid1<TaskStackBuilder>) mSuperListeners.pop()).call(builder);
     }
 
     public boolean onCreateOptionsMenu(final Menu menu) {
         verifyMethodCalledFromDelegate("onCreateOptionsMenu(Menu)");
-        return (Boolean) mSuperListeners.pop().call(menu);
+        return ((CallFun1<Boolean, Menu>) mSuperListeners.pop()).call(menu);
     }
 
     public boolean onCreatePanelMenu(final int featureId, final Menu menu) {
-        verifyMethodCalledFromDelegate("onCreatePanelMenu(int, Menu)");
-        return (Boolean) mSuperListeners.pop().call(featureId, menu);
+        verifyMethodCalledFromDelegate("onCreatePanelMenu(Integer, Menu)");
+        return ((CallFun2<Boolean, Integer, Menu>) mSuperListeners.pop()).call(featureId, menu);
     }
 
     public View onCreatePanelView(final int featureId) {
-        verifyMethodCalledFromDelegate("onCreatePanelView(int)");
-        return (View) mSuperListeners.pop().call(featureId);
+        verifyMethodCalledFromDelegate("onCreatePanelView(Integer)");
+        return ((CallFun1<View, Integer>) mSuperListeners.pop()).call(featureId);
     }
 
     public void onCreateSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
         verifyMethodCalledFromDelegate(
                 "onCreateSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)");
-        mSuperListeners.pop().call(builder);
+        ((CallVoid1<android.support.v4.app.TaskStackBuilder>) mSuperListeners.pop()).call(builder);
     }
 
     public boolean onCreateThumbnail(final Bitmap outBitmap, final Canvas canvas) {
         verifyMethodCalledFromDelegate("onCreateThumbnail(Bitmap, Canvas)");
-        return (Boolean) mSuperListeners.pop().call(outBitmap, canvas);
+        return ((CallFun2<Boolean, Bitmap, Canvas>) mSuperListeners.pop()).call(outBitmap, canvas);
     }
 
     public View onCreateView(final View parent, final String name, final Context context,
             final AttributeSet attrs) {
         verifyMethodCalledFromDelegate("onCreateView(View, String, Context, AttributeSet)");
-        return (View) mSuperListeners.pop().call(parent, name, context, attrs);
+        return ((CallFun4<View, View, String, Context, AttributeSet>) mSuperListeners.pop())
+                .call(parent, name, context, attrs);
     }
 
     public View onCreateView(final String name, final Context context, final AttributeSet attrs) {
         verifyMethodCalledFromDelegate("onCreateView(String, Context, AttributeSet)");
-        return (View) mSuperListeners.pop().call(name, context, attrs);
+        return ((CallFun3<View, String, Context, AttributeSet>) mSuperListeners.pop())
+                .call(name, context, attrs);
     }
 
     public void onDestroy() {
         verifyMethodCalledFromDelegate("onDestroy()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onDetachedFromWindow() {
         verifyMethodCalledFromDelegate("onDetachedFromWindow()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onEnterAnimationComplete() {
         verifyMethodCalledFromDelegate("onEnterAnimationComplete()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean onGenericMotionEvent(final MotionEvent event) {
         verifyMethodCalledFromDelegate("onGenericMotionEvent(MotionEvent)");
-        return (Boolean) mSuperListeners.pop().call(event);
+        return ((CallFun1<Boolean, MotionEvent>) mSuperListeners.pop()).call(event);
     }
 
     public boolean onKeyDown(final int keyCode, final KeyEvent event) {
-        verifyMethodCalledFromDelegate("onKeyDown(int, KeyEvent)");
-        return (Boolean) mSuperListeners.pop().call(keyCode, event);
+        verifyMethodCalledFromDelegate("onKeyDown(Integer, KeyEvent)");
+        return ((CallFun2<Boolean, Integer, KeyEvent>) mSuperListeners.pop()).call(keyCode, event);
     }
 
     public boolean onKeyLongPress(final int keyCode, final KeyEvent event) {
-        verifyMethodCalledFromDelegate("onKeyLongPress(int, KeyEvent)");
-        return (Boolean) mSuperListeners.pop().call(keyCode, event);
+        verifyMethodCalledFromDelegate("onKeyLongPress(Integer, KeyEvent)");
+        return ((CallFun2<Boolean, Integer, KeyEvent>) mSuperListeners.pop()).call(keyCode, event);
     }
 
     public boolean onKeyMultiple(final int keyCode, final int repeatCount, final KeyEvent event) {
-        verifyMethodCalledFromDelegate("onKeyMultiple(int, int, KeyEvent)");
-        return (Boolean) mSuperListeners.pop().call(keyCode, repeatCount, event);
+        verifyMethodCalledFromDelegate("onKeyMultiple(Integer, Integer, KeyEvent)");
+        return ((CallFun3<Boolean, Integer, Integer, KeyEvent>) mSuperListeners.pop())
+                .call(keyCode, repeatCount, event);
     }
 
     public boolean onKeyShortcut(final int keyCode, final KeyEvent event) {
-        verifyMethodCalledFromDelegate("onKeyShortcut(int, KeyEvent)");
-        return (Boolean) mSuperListeners.pop().call(keyCode, event);
+        verifyMethodCalledFromDelegate("onKeyShortcut(Integer, KeyEvent)");
+        return ((CallFun2<Boolean, Integer, KeyEvent>) mSuperListeners.pop()).call(keyCode, event);
     }
 
     public boolean onKeyUp(final int keyCode, final KeyEvent event) {
-        verifyMethodCalledFromDelegate("onKeyUp(int, KeyEvent)");
-        return (Boolean) mSuperListeners.pop().call(keyCode, event);
+        verifyMethodCalledFromDelegate("onKeyUp(Integer, KeyEvent)");
+        return ((CallFun2<Boolean, Integer, KeyEvent>) mSuperListeners.pop()).call(keyCode, event);
     }
 
     public void onLowMemory() {
         verifyMethodCalledFromDelegate("onLowMemory()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean onMenuOpened(final int featureId, final Menu menu) {
-        verifyMethodCalledFromDelegate("onMenuOpened(int, Menu)");
-        return (Boolean) mSuperListeners.pop().call(featureId, menu);
+        verifyMethodCalledFromDelegate("onMenuOpened(Integer, Menu)");
+        return ((CallFun2<Boolean, Integer, Menu>) mSuperListeners.pop()).call(featureId, menu);
     }
 
     public boolean onNavigateUp() {
         verifyMethodCalledFromDelegate("onNavigateUp()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean onNavigateUpFromChild(final Activity child) {
         verifyMethodCalledFromDelegate("onNavigateUpFromChild(Activity)");
-        return (Boolean) mSuperListeners.pop().call(child);
+        return ((CallFun1<Boolean, Activity>) mSuperListeners.pop()).call(child);
     }
 
     public void onNewIntent(final Intent intent) {
         verifyMethodCalledFromDelegate("onNewIntent(Intent)");
-        mSuperListeners.pop().call(intent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(intent);
     }
 
     public boolean onOptionsItemSelected(final MenuItem item) {
         verifyMethodCalledFromDelegate("onOptionsItemSelected(MenuItem)");
-        return (Boolean) mSuperListeners.pop().call(item);
+        return ((CallFun1<Boolean, MenuItem>) mSuperListeners.pop()).call(item);
     }
 
     public void onOptionsMenuClosed(final Menu menu) {
         verifyMethodCalledFromDelegate("onOptionsMenuClosed(Menu)");
-        mSuperListeners.pop().call(menu);
+        ((CallVoid1<Menu>) mSuperListeners.pop()).call(menu);
     }
 
     public void onPanelClosed(final int featureId, final Menu menu) {
-        verifyMethodCalledFromDelegate("onPanelClosed(int, Menu)");
-        mSuperListeners.pop().call(featureId, menu);
+        verifyMethodCalledFromDelegate("onPanelClosed(Integer, Menu)");
+        ((CallVoid2<Integer, Menu>) mSuperListeners.pop()).call(featureId, menu);
     }
 
     public void onPause() {
         verifyMethodCalledFromDelegate("onPause()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onPostCreate(final Bundle savedInstanceState,
             final PersistableBundle persistentState) {
         verifyMethodCalledFromDelegate("onPostCreate(Bundle, PersistableBundle)");
-        mSuperListeners.pop().call(savedInstanceState, persistentState);
+        ((CallVoid2<Bundle, PersistableBundle>) mSuperListeners.pop())
+                .call(savedInstanceState, persistentState);
     }
 
     public void onPostCreate(@Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onPostCreate(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public void onPostResume() {
         verifyMethodCalledFromDelegate("onPostResume()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onPrepareDialog(final int id, final Dialog dialog) {
-        verifyMethodCalledFromDelegate("onPrepareDialog(int, Dialog)");
-        mSuperListeners.pop().call(id, dialog);
+        verifyMethodCalledFromDelegate("onPrepareDialog(Integer, Dialog)");
+        ((CallVoid2<Integer, Dialog>) mSuperListeners.pop()).call(id, dialog);
     }
 
     public void onPrepareDialog(final int id, final Dialog dialog, final Bundle args) {
-        verifyMethodCalledFromDelegate("onPrepareDialog(int, Dialog, Bundle)");
-        mSuperListeners.pop().call(id, dialog, args);
+        verifyMethodCalledFromDelegate("onPrepareDialog(Integer, Dialog, Bundle)");
+        ((CallVoid3<Integer, Dialog, Bundle>) mSuperListeners.pop()).call(id, dialog, args);
     }
 
     public void onPrepareNavigateUpTaskStack(final TaskStackBuilder builder) {
         verifyMethodCalledFromDelegate("onPrepareNavigateUpTaskStack(TaskStackBuilder)");
-        mSuperListeners.pop().call(builder);
+        ((CallVoid1<TaskStackBuilder>) mSuperListeners.pop()).call(builder);
     }
 
     public boolean onPrepareOptionsMenu(final Menu menu) {
         verifyMethodCalledFromDelegate("onPrepareOptionsMenu(Menu)");
-        return (Boolean) mSuperListeners.pop().call(menu);
+        return ((CallFun1<Boolean, Menu>) mSuperListeners.pop()).call(menu);
     }
 
     public boolean onPrepareOptionsPanel(final View view, final Menu menu) {
         verifyMethodCalledFromDelegate("onPrepareOptionsPanel(View, Menu)");
-        return (Boolean) mSuperListeners.pop().call(view, menu);
+        return ((CallFun2<Boolean, View, Menu>) mSuperListeners.pop()).call(view, menu);
     }
 
     public boolean onPreparePanel(final int featureId, final View view, final Menu menu) {
-        verifyMethodCalledFromDelegate("onPreparePanel(int, View, Menu)");
-        return (Boolean) mSuperListeners.pop().call(featureId, view, menu);
+        verifyMethodCalledFromDelegate("onPreparePanel(Integer, View, Menu)");
+        return ((CallFun3<Boolean, Integer, View, Menu>) mSuperListeners.pop())
+                .call(featureId, view, menu);
     }
 
     public void onPrepareSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
         verifyMethodCalledFromDelegate(
                 "onPrepareSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)");
-        mSuperListeners.pop().call(builder);
+        ((CallVoid1<android.support.v4.app.TaskStackBuilder>) mSuperListeners.pop()).call(builder);
     }
 
     public void onProvideAssistContent(final AssistContent outContent) {
         verifyMethodCalledFromDelegate("onProvideAssistContent(AssistContent)");
-        mSuperListeners.pop().call(outContent);
+        ((CallVoid1<AssistContent>) mSuperListeners.pop()).call(outContent);
     }
 
     public void onProvideAssistData(final Bundle data) {
         verifyMethodCalledFromDelegate("onProvideAssistData(Bundle)");
-        mSuperListeners.pop().call(data);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(data);
     }
 
     public Uri onProvideReferrer() {
         verifyMethodCalledFromDelegate("onProvideReferrer()");
-        return (Uri) mSuperListeners.pop().call();
+        return ((CallFun0<Uri>) mSuperListeners.pop()).call();
     }
 
     public void onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        verifyMethodCalledFromDelegate("onRequestPermissionsResult(int, String[], int[])");
-        mSuperListeners.pop().call(requestCode, permissions, grantResults);
+        verifyMethodCalledFromDelegate("onRequestPermissionsResult(Integer, String[], int[])");
+        ((CallVoid3<Integer, String[], int[]>) mSuperListeners.pop())
+                .call(requestCode, permissions, grantResults);
     }
 
     public void onRestart() {
         verifyMethodCalledFromDelegate("onRestart()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onRestoreInstanceState(final Bundle savedInstanceState,
             final PersistableBundle persistentState) {
         verifyMethodCalledFromDelegate("onRestoreInstanceState(Bundle, PersistableBundle)");
-        mSuperListeners.pop().call(savedInstanceState, persistentState);
+        ((CallVoid2<Bundle, PersistableBundle>) mSuperListeners.pop())
+                .call(savedInstanceState, persistentState);
     }
 
     public void onRestoreInstanceState(final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onRestoreInstanceState(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public void onResume() {
         verifyMethodCalledFromDelegate("onResume()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onResumeFragments() {
         verifyMethodCalledFromDelegate("onResumeFragments()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public CompositeNonConfigurationInstance onRetainNonConfigurationInstance() {
@@ -1048,266 +1085,274 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
     public void onSaveInstanceState(final Bundle outState,
             final PersistableBundle outPersistentState) {
         verifyMethodCalledFromDelegate("onSaveInstanceState(Bundle, PersistableBundle)");
-        mSuperListeners.pop().call(outState, outPersistentState);
+        ((CallVoid2<Bundle, PersistableBundle>) mSuperListeners.pop())
+                .call(outState, outPersistentState);
     }
 
     public void onSaveInstanceState(final Bundle outState) {
         verifyMethodCalledFromDelegate("onSaveInstanceState(Bundle)");
-        mSuperListeners.pop().call(outState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(outState);
     }
 
     public boolean onSearchRequested(final SearchEvent searchEvent) {
         verifyMethodCalledFromDelegate("onSearchRequested(SearchEvent)");
-        return (Boolean) mSuperListeners.pop().call(searchEvent);
+        return ((CallFun1<Boolean, SearchEvent>) mSuperListeners.pop()).call(searchEvent);
     }
 
     public boolean onSearchRequested() {
         verifyMethodCalledFromDelegate("onSearchRequested()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public void onStart() {
         verifyMethodCalledFromDelegate("onStart()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onStateNotSaved() {
         verifyMethodCalledFromDelegate("onStateNotSaved()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onStop() {
         verifyMethodCalledFromDelegate("onStop()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onSupportActionModeFinished(@NonNull final ActionMode mode) {
         verifyMethodCalledFromDelegate("onSupportActionModeFinished(ActionMode)");
-        mSuperListeners.pop().call(mode);
+        ((CallVoid1<ActionMode>) mSuperListeners.pop()).call(mode);
     }
 
     public void onSupportActionModeStarted(@NonNull final ActionMode mode) {
         verifyMethodCalledFromDelegate("onSupportActionModeStarted(ActionMode)");
-        mSuperListeners.pop().call(mode);
+        ((CallVoid1<ActionMode>) mSuperListeners.pop()).call(mode);
     }
 
     public void onSupportContentChanged() {
         verifyMethodCalledFromDelegate("onSupportContentChanged()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean onSupportNavigateUp() {
         verifyMethodCalledFromDelegate("onSupportNavigateUp()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public void onTitleChanged(final CharSequence title, final int color) {
-        verifyMethodCalledFromDelegate("onTitleChanged(CharSequence, int)");
-        mSuperListeners.pop().call(title, color);
+        verifyMethodCalledFromDelegate("onTitleChanged(CharSequence, Integer)");
+        ((CallVoid2<CharSequence, Integer>) mSuperListeners.pop()).call(title, color);
     }
 
     public boolean onTouchEvent(final MotionEvent event) {
         verifyMethodCalledFromDelegate("onTouchEvent(MotionEvent)");
-        return (Boolean) mSuperListeners.pop().call(event);
+        return ((CallFun1<Boolean, MotionEvent>) mSuperListeners.pop()).call(event);
     }
 
     public boolean onTrackballEvent(final MotionEvent event) {
         verifyMethodCalledFromDelegate("onTrackballEvent(MotionEvent)");
-        return (Boolean) mSuperListeners.pop().call(event);
+        return ((CallFun1<Boolean, MotionEvent>) mSuperListeners.pop()).call(event);
     }
 
     public void onTrimMemory(final int level) {
-        verifyMethodCalledFromDelegate("onTrimMemory(int)");
-        mSuperListeners.pop().call(level);
+        verifyMethodCalledFromDelegate("onTrimMemory(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(level);
     }
 
     public void onUserInteraction() {
         verifyMethodCalledFromDelegate("onUserInteraction()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onUserLeaveHint() {
         verifyMethodCalledFromDelegate("onUserLeaveHint()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onVisibleBehindCanceled() {
         verifyMethodCalledFromDelegate("onVisibleBehindCanceled()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onWindowAttributesChanged(final WindowManager.LayoutParams params) {
         verifyMethodCalledFromDelegate("onWindowAttributesChanged(WindowManager.LayoutParams)");
-        mSuperListeners.pop().call(params);
+        ((CallVoid1<WindowManager.LayoutParams>) mSuperListeners.pop()).call(params);
     }
 
     public void onWindowFocusChanged(final boolean hasFocus) {
-        verifyMethodCalledFromDelegate("onWindowFocusChanged(boolean)");
-        mSuperListeners.pop().call(hasFocus);
+        verifyMethodCalledFromDelegate("onWindowFocusChanged(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(hasFocus);
     }
 
     public android.view.ActionMode onWindowStartingActionMode(
             final android.view.ActionMode.Callback callback) {
         verifyMethodCalledFromDelegate(
                 "onWindowStartingActionMode(android.view.ActionMode.Callback)");
-        return (android.view.ActionMode) mSuperListeners.pop().call(callback);
+        return ((CallFun1<android.view.ActionMode, android.view.ActionMode.Callback>) mSuperListeners
+                .pop()).call(callback);
     }
 
     public android.view.ActionMode onWindowStartingActionMode(
             final android.view.ActionMode.Callback callback, final int type) {
         verifyMethodCalledFromDelegate(
-                "onWindowStartingActionMode(android.view.ActionMode.Callback, int)");
-        return (android.view.ActionMode) mSuperListeners.pop().call(callback, type);
+                "onWindowStartingActionMode(android.view.ActionMode.Callback, Integer)");
+        return ((CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer>) mSuperListeners
+                .pop()).call(callback, type);
     }
 
     public ActionMode onWindowStartingSupportActionMode(
             @NonNull final ActionMode.Callback callback) {
         verifyMethodCalledFromDelegate("onWindowStartingSupportActionMode(ActionMode.Callback)");
-        return (ActionMode) mSuperListeners.pop().call(callback);
+        return ((CallFun1<ActionMode, ActionMode.Callback>) mSuperListeners.pop()).call(callback);
     }
 
     public void openContextMenu(final View view) {
         verifyMethodCalledFromDelegate("openContextMenu(View)");
-        mSuperListeners.pop().call(view);
+        ((CallVoid1<View>) mSuperListeners.pop()).call(view);
     }
 
     public FileInputStream openFileInput(final String name) throws FileNotFoundException {
         verifyMethodCalledFromDelegate("openFileInput(String)");
-        return (FileInputStream) mSuperListeners.pop().call(name);
+        return ((CallFun1<FileInputStream, String>) mSuperListeners.pop()).call(name);
     }
 
     public FileOutputStream openFileOutput(final String name, final int mode)
             throws FileNotFoundException {
-        verifyMethodCalledFromDelegate("openFileOutput(String, int)");
-        return (FileOutputStream) mSuperListeners.pop().call(name, mode);
+        verifyMethodCalledFromDelegate("openFileOutput(String, Integer)");
+        return ((CallFun2<FileOutputStream, String, Integer>) mSuperListeners.pop())
+                .call(name, mode);
     }
 
     public void openOptionsMenu() {
         verifyMethodCalledFromDelegate("openOptionsMenu()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory) {
         verifyMethodCalledFromDelegate(
-                "openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory)");
-        return (SQLiteDatabase) mSuperListeners.pop().call(name, mode, factory);
+                "openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory)");
+        return ((CallFun3<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory>) mSuperListeners
+                .pop()).call(name, mode, factory);
     }
 
     public SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler) {
         verifyMethodCalledFromDelegate(
-                "openOrCreateDatabase(String, int, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)");
-        return (SQLiteDatabase) mSuperListeners.pop().call(name, mode, factory, errorHandler);
+                "openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)");
+        return ((CallFun4<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler>) mSuperListeners
+                .pop()).call(name, mode, factory, errorHandler);
     }
 
     public void overridePendingTransition(final int enterAnim, final int exitAnim) {
-        verifyMethodCalledFromDelegate("overridePendingTransition(int, int)");
-        mSuperListeners.pop().call(enterAnim, exitAnim);
+        verifyMethodCalledFromDelegate("overridePendingTransition(Integer, Integer)");
+        ((CallVoid2<Integer, Integer>) mSuperListeners.pop()).call(enterAnim, exitAnim);
     }
 
     public Drawable peekWallpaper() {
         verifyMethodCalledFromDelegate("peekWallpaper()");
-        return (Drawable) mSuperListeners.pop().call();
+        return ((CallFun0<Drawable>) mSuperListeners.pop()).call();
     }
 
     public void postponeEnterTransition() {
         verifyMethodCalledFromDelegate("postponeEnterTransition()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void recreate() {
         verifyMethodCalledFromDelegate("recreate()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void registerComponentCallbacks(final ComponentCallbacks callback) {
         verifyMethodCalledFromDelegate("registerComponentCallbacks(ComponentCallbacks)");
-        mSuperListeners.pop().call(callback);
+        ((CallVoid1<ComponentCallbacks>) mSuperListeners.pop()).call(callback);
     }
 
     public void registerForContextMenu(final View view) {
         verifyMethodCalledFromDelegate("registerForContextMenu(View)");
-        mSuperListeners.pop().call(view);
+        ((CallVoid1<View>) mSuperListeners.pop()).call(view);
     }
 
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter) {
         verifyMethodCalledFromDelegate("registerReceiver(BroadcastReceiver, IntentFilter)");
-        return (Intent) mSuperListeners.pop().call(receiver, filter);
+        return ((CallFun2<Intent, BroadcastReceiver, IntentFilter>) mSuperListeners.pop())
+                .call(receiver, filter);
     }
 
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter,
             final String broadcastPermission, final Handler scheduler) {
         verifyMethodCalledFromDelegate(
                 "registerReceiver(BroadcastReceiver, IntentFilter, String, Handler)");
-        return (Intent) mSuperListeners.pop()
-                .call(receiver, filter, broadcastPermission, scheduler);
+        return ((CallFun4<Intent, BroadcastReceiver, IntentFilter, String, Handler>) mSuperListeners
+                .pop()).call(receiver, filter, broadcastPermission, scheduler);
     }
 
     public boolean releaseInstance() {
         verifyMethodCalledFromDelegate("releaseInstance()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public void removeStickyBroadcast(final Intent intent) {
         verifyMethodCalledFromDelegate("removeStickyBroadcast(Intent)");
-        mSuperListeners.pop().call(intent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(intent);
     }
 
     public void removeStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
         verifyMethodCalledFromDelegate("removeStickyBroadcastAsUser(Intent, UserHandle)");
-        mSuperListeners.pop().call(intent, user);
+        ((CallVoid2<Intent, UserHandle>) mSuperListeners.pop()).call(intent, user);
     }
 
     public void reportFullyDrawn() {
         verifyMethodCalledFromDelegate("reportFullyDrawn()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean requestVisibleBehind(final boolean visible) {
-        verifyMethodCalledFromDelegate("requestVisibleBehind(boolean)");
-        return (Boolean) mSuperListeners.pop().call(visible);
+        verifyMethodCalledFromDelegate("requestVisibleBehind(Boolean)");
+        return ((CallFun1<Boolean, Boolean>) mSuperListeners.pop()).call(visible);
     }
 
     public void revokeUriPermission(final Uri uri, final int modeFlags) {
-        verifyMethodCalledFromDelegate("revokeUriPermission(Uri, int)");
-        mSuperListeners.pop().call(uri, modeFlags);
+        verifyMethodCalledFromDelegate("revokeUriPermission(Uri, Integer)");
+        ((CallVoid2<Uri, Integer>) mSuperListeners.pop()).call(uri, modeFlags);
     }
 
     public void sendBroadcast(final Intent intent) {
         verifyMethodCalledFromDelegate("sendBroadcast(Intent)");
-        mSuperListeners.pop().call(intent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(intent);
     }
 
     public void sendBroadcast(final Intent intent, final String receiverPermission) {
         verifyMethodCalledFromDelegate("sendBroadcast(Intent, String)");
-        mSuperListeners.pop().call(intent, receiverPermission);
+        ((CallVoid2<Intent, String>) mSuperListeners.pop()).call(intent, receiverPermission);
     }
 
     public void sendBroadcastAsUser(final Intent intent, final UserHandle user) {
         verifyMethodCalledFromDelegate("sendBroadcastAsUser(Intent, UserHandle)");
-        mSuperListeners.pop().call(intent, user);
+        ((CallVoid2<Intent, UserHandle>) mSuperListeners.pop()).call(intent, user);
     }
 
     public void sendBroadcastAsUser(final Intent intent, final UserHandle user,
             final String receiverPermission) {
         verifyMethodCalledFromDelegate("sendBroadcastAsUser(Intent, UserHandle, String)");
-        mSuperListeners.pop().call(intent, user, receiverPermission);
+        ((CallVoid3<Intent, UserHandle, String>) mSuperListeners.pop())
+                .call(intent, user, receiverPermission);
     }
 
     public void sendOrderedBroadcast(final Intent intent, final String receiverPermission) {
         verifyMethodCalledFromDelegate("sendOrderedBroadcast(Intent, String)");
-        mSuperListeners.pop().call(intent, receiverPermission);
+        ((CallVoid2<Intent, String>) mSuperListeners.pop()).call(intent, receiverPermission);
     }
 
     public void sendOrderedBroadcast(final Intent intent, final String receiverPermission,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
         verifyMethodCalledFromDelegate(
-                "sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, int, String, Bundle)");
-        mSuperListeners.pop()
-                .call(intent, receiverPermission, resultReceiver, scheduler, initialCode,
-                        initialData, initialExtras);
+                "sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle)");
+        ((CallVoid7<Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle>) mSuperListeners
+                .pop()).call(intent, receiverPermission, resultReceiver, scheduler, initialCode,
+                initialData, initialExtras);
     }
 
     public void sendOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
@@ -1315,28 +1360,30 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
             final Handler scheduler, final int initialCode, final String initialData,
             final Bundle initialExtras) {
         verifyMethodCalledFromDelegate(
-                "sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, int, String, Bundle)");
-        mSuperListeners.pop()
+                "sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle)");
+        ((CallVoid8<Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle>) mSuperListeners
+                .pop())
                 .call(intent, user, receiverPermission, resultReceiver, scheduler, initialCode,
                         initialData, initialExtras);
     }
 
     public void sendStickyBroadcast(final Intent intent) {
         verifyMethodCalledFromDelegate("sendStickyBroadcast(Intent)");
-        mSuperListeners.pop().call(intent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(intent);
     }
 
     public void sendStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
         verifyMethodCalledFromDelegate("sendStickyBroadcastAsUser(Intent, UserHandle)");
-        mSuperListeners.pop().call(intent, user);
+        ((CallVoid2<Intent, UserHandle>) mSuperListeners.pop()).call(intent, user);
     }
 
     public void sendStickyOrderedBroadcast(final Intent intent,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
         verifyMethodCalledFromDelegate(
-                "sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, int, String, Bundle)");
-        mSuperListeners.pop()
+                "sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, Integer, String, Bundle)");
+        ((CallVoid6<Intent, BroadcastReceiver, Handler, Integer, String, Bundle>) mSuperListeners
+                .pop())
                 .call(intent, resultReceiver, scheduler, initialCode, initialData, initialExtras);
     }
 
@@ -1344,275 +1391,291 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
         verifyMethodCalledFromDelegate(
-                "sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, int, String, Bundle)");
-        mSuperListeners.pop()
-                .call(intent, user, resultReceiver, scheduler, initialCode, initialData,
-                        initialExtras);
+                "sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle)");
+        ((CallVoid7<Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle>) mSuperListeners
+                .pop()).call(intent, user, resultReceiver, scheduler, initialCode, initialData,
+                initialExtras);
     }
 
     public void setActionBar(final Toolbar toolbar) {
         verifyMethodCalledFromDelegate("setActionBar(Toolbar)");
-        mSuperListeners.pop().call(toolbar);
+        ((CallVoid1<Toolbar>) mSuperListeners.pop()).call(toolbar);
     }
 
     public void setContentTransitionManager(final TransitionManager tm) {
         verifyMethodCalledFromDelegate("setContentTransitionManager(TransitionManager)");
-        mSuperListeners.pop().call(tm);
+        ((CallVoid1<TransitionManager>) mSuperListeners.pop()).call(tm);
     }
 
     public void setContentView(@LayoutRes final int layoutResID) {
-        verifyMethodCalledFromDelegate("setContentView(int)");
-        mSuperListeners.pop().call(layoutResID);
+        verifyMethodCalledFromDelegate("setContentView(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(layoutResID);
     }
 
     public void setContentView(final View view) {
         verifyMethodCalledFromDelegate("setContentView(View)");
-        mSuperListeners.pop().call(view);
+        ((CallVoid1<View>) mSuperListeners.pop()).call(view);
     }
 
     public void setContentView(final View view, final ViewGroup.LayoutParams params) {
         verifyMethodCalledFromDelegate("setContentView(View, ViewGroup.LayoutParams)");
-        mSuperListeners.pop().call(view, params);
+        ((CallVoid2<View, ViewGroup.LayoutParams>) mSuperListeners.pop()).call(view, params);
     }
 
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
         verifyMethodCalledFromDelegate("setEnterSharedElementCallback(SharedElementCallback)");
-        mSuperListeners.pop().call(callback);
+        ((CallVoid1<SharedElementCallback>) mSuperListeners.pop()).call(callback);
     }
 
     public void setEnterSharedElementCallback(final android.app.SharedElementCallback callback) {
         verifyMethodCalledFromDelegate(
                 "setEnterSharedElementCallback(android.app.SharedElementCallback)");
-        mSuperListeners.pop().call(callback);
+        ((CallVoid1<android.app.SharedElementCallback>) mSuperListeners.pop()).call(callback);
     }
 
     public void setExitSharedElementCallback(final SharedElementCallback listener) {
         verifyMethodCalledFromDelegate("setExitSharedElementCallback(SharedElementCallback)");
-        mSuperListeners.pop().call(listener);
+        ((CallVoid1<SharedElementCallback>) mSuperListeners.pop()).call(listener);
     }
 
     public void setExitSharedElementCallback(final android.app.SharedElementCallback callback) {
         verifyMethodCalledFromDelegate(
                 "setExitSharedElementCallback(android.app.SharedElementCallback)");
-        mSuperListeners.pop().call(callback);
+        ((CallVoid1<android.app.SharedElementCallback>) mSuperListeners.pop()).call(callback);
     }
 
     public void setFinishOnTouchOutside(final boolean finish) {
-        verifyMethodCalledFromDelegate("setFinishOnTouchOutside(boolean)");
-        mSuperListeners.pop().call(finish);
+        verifyMethodCalledFromDelegate("setFinishOnTouchOutside(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(finish);
     }
 
     public void setImmersive(final boolean i) {
-        verifyMethodCalledFromDelegate("setImmersive(boolean)");
-        mSuperListeners.pop().call(i);
+        verifyMethodCalledFromDelegate("setImmersive(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(i);
     }
 
     public void setIntent(final Intent newIntent) {
         verifyMethodCalledFromDelegate("setIntent(Intent)");
-        mSuperListeners.pop().call(newIntent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(newIntent);
     }
 
     public void setRequestedOrientation(final int requestedOrientation) {
-        verifyMethodCalledFromDelegate("setRequestedOrientation(int)");
-        mSuperListeners.pop().call(requestedOrientation);
+        verifyMethodCalledFromDelegate("setRequestedOrientation(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(requestedOrientation);
     }
 
     public void setSupportActionBar(@Nullable final android.support.v7.widget.Toolbar toolbar) {
         verifyMethodCalledFromDelegate("setSupportActionBar(android.support.v7.widget.Toolbar)");
-        mSuperListeners.pop().call(toolbar);
+        ((CallVoid1<android.support.v7.widget.Toolbar>) mSuperListeners.pop()).call(toolbar);
     }
 
     public void setSupportProgress(final int progress) {
-        verifyMethodCalledFromDelegate("setSupportProgress(int)");
-        mSuperListeners.pop().call(progress);
+        verifyMethodCalledFromDelegate("setSupportProgress(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(progress);
     }
 
     public void setSupportProgressBarIndeterminate(final boolean indeterminate) {
-        verifyMethodCalledFromDelegate("setSupportProgressBarIndeterminate(boolean)");
-        mSuperListeners.pop().call(indeterminate);
+        verifyMethodCalledFromDelegate("setSupportProgressBarIndeterminate(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(indeterminate);
     }
 
     public void setSupportProgressBarIndeterminateVisibility(final boolean visible) {
-        verifyMethodCalledFromDelegate("setSupportProgressBarIndeterminateVisibility(boolean)");
-        mSuperListeners.pop().call(visible);
+        verifyMethodCalledFromDelegate("setSupportProgressBarIndeterminateVisibility(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(visible);
     }
 
     public void setSupportProgressBarVisibility(final boolean visible) {
-        verifyMethodCalledFromDelegate("setSupportProgressBarVisibility(boolean)");
-        mSuperListeners.pop().call(visible);
+        verifyMethodCalledFromDelegate("setSupportProgressBarVisibility(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(visible);
     }
 
     public void setTaskDescription(final ActivityManager.TaskDescription taskDescription) {
         verifyMethodCalledFromDelegate("setTaskDescription(ActivityManager.TaskDescription)");
-        mSuperListeners.pop().call(taskDescription);
+        ((CallVoid1<ActivityManager.TaskDescription>) mSuperListeners.pop()).call(taskDescription);
     }
 
     public void setTheme(@StyleRes final int resid) {
-        verifyMethodCalledFromDelegate("setTheme(int)");
-        mSuperListeners.pop().call(resid);
+        verifyMethodCalledFromDelegate("setTheme(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(resid);
     }
 
     public void setTitle(final CharSequence title) {
         verifyMethodCalledFromDelegate("setTitle(CharSequence)");
-        mSuperListeners.pop().call(title);
+        ((CallVoid1<CharSequence>) mSuperListeners.pop()).call(title);
     }
 
     public void setTitle(final int titleId) {
-        verifyMethodCalledFromDelegate("setTitle(int)");
-        mSuperListeners.pop().call(titleId);
+        verifyMethodCalledFromDelegate("setTitle(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(titleId);
     }
 
     public void setTitleColor(final int textColor) {
-        verifyMethodCalledFromDelegate("setTitleColor(int)");
-        mSuperListeners.pop().call(textColor);
+        verifyMethodCalledFromDelegate("setTitleColor(Integer)");
+        ((CallVoid1<Integer>) mSuperListeners.pop()).call(textColor);
     }
 
     public void setVisible(final boolean visible) {
-        verifyMethodCalledFromDelegate("setVisible(boolean)");
-        mSuperListeners.pop().call(visible);
+        verifyMethodCalledFromDelegate("setVisible(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(visible);
     }
 
     public void setWallpaper(final Bitmap bitmap) throws IOException {
         verifyMethodCalledFromDelegate("setWallpaper(Bitmap)");
-        mSuperListeners.pop().call(bitmap);
+        ((CallVoid1<Bitmap>) mSuperListeners.pop()).call(bitmap);
     }
 
     public void setWallpaper(final InputStream data) throws IOException {
         verifyMethodCalledFromDelegate("setWallpaper(InputStream)");
-        mSuperListeners.pop().call(data);
+        ((CallVoid1<InputStream>) mSuperListeners.pop()).call(data);
     }
 
     public boolean shouldShowRequestPermissionRationale(final String permission) {
         verifyMethodCalledFromDelegate("shouldShowRequestPermissionRationale(String)");
-        return (Boolean) mSuperListeners.pop().call(permission);
+        return ((CallFun1<Boolean, String>) mSuperListeners.pop()).call(permission);
     }
 
     public boolean shouldUpRecreateTask(final Intent targetIntent) {
         verifyMethodCalledFromDelegate("shouldUpRecreateTask(Intent)");
-        return (Boolean) mSuperListeners.pop().call(targetIntent);
+        return ((CallFun1<Boolean, Intent>) mSuperListeners.pop()).call(targetIntent);
     }
 
     public boolean showAssist(final Bundle args) {
         verifyMethodCalledFromDelegate("showAssist(Bundle)");
-        return (Boolean) mSuperListeners.pop().call(args);
+        return ((CallFun1<Boolean, Bundle>) mSuperListeners.pop()).call(args);
     }
 
     public void showLockTaskEscapeMessage() {
         verifyMethodCalledFromDelegate("showLockTaskEscapeMessage()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public android.view.ActionMode startActionMode(
             final android.view.ActionMode.Callback callback) {
         verifyMethodCalledFromDelegate("startActionMode(android.view.ActionMode.Callback)");
-        return (android.view.ActionMode) mSuperListeners.pop().call(callback);
+        return ((CallFun1<android.view.ActionMode, android.view.ActionMode.Callback>) mSuperListeners
+                .pop()).call(callback);
     }
 
     public android.view.ActionMode startActionMode(final android.view.ActionMode.Callback callback,
             final int type) {
-        verifyMethodCalledFromDelegate("startActionMode(android.view.ActionMode.Callback, int)");
-        return (android.view.ActionMode) mSuperListeners.pop().call(callback, type);
+        verifyMethodCalledFromDelegate(
+                "startActionMode(android.view.ActionMode.Callback, Integer)");
+        return ((CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer>) mSuperListeners
+                .pop()).call(callback, type);
     }
 
     public void startActivities(final Intent[] intents) {
         verifyMethodCalledFromDelegate("startActivities(Intent[])");
-        mSuperListeners.pop().call(intents);
+        ((CallVoid1<Intent[]>) mSuperListeners.pop()).call(intents);
     }
 
     public void startActivities(final Intent[] intents, final Bundle options) {
         verifyMethodCalledFromDelegate("startActivities(Intent[], Bundle)");
-        mSuperListeners.pop().call(intents, options);
+        ((CallVoid2<Intent[], Bundle>) mSuperListeners.pop()).call(intents, options);
     }
 
     public void startActivity(final Intent intent) {
         verifyMethodCalledFromDelegate("startActivity(Intent)");
-        mSuperListeners.pop().call(intent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(intent);
     }
 
     public void startActivity(final Intent intent, final Bundle options) {
         verifyMethodCalledFromDelegate("startActivity(Intent, Bundle)");
-        mSuperListeners.pop().call(intent, options);
+        ((CallVoid2<Intent, Bundle>) mSuperListeners.pop()).call(intent, options);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode) {
-        verifyMethodCalledFromDelegate("startActivityForResult(Intent, int)");
-        mSuperListeners.pop().call(intent, requestCode);
+        verifyMethodCalledFromDelegate("startActivityForResult(Intent, Integer)");
+        ((CallVoid2<Intent, Integer>) mSuperListeners.pop()).call(intent, requestCode);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode,
             final Bundle options) {
-        verifyMethodCalledFromDelegate("startActivityForResult(Intent, int, Bundle)");
-        mSuperListeners.pop().call(intent, requestCode, options);
+        verifyMethodCalledFromDelegate("startActivityForResult(Intent, Integer, Bundle)");
+        ((CallVoid3<Intent, Integer, Bundle>) mSuperListeners.pop())
+                .call(intent, requestCode, options);
     }
 
     public void startActivityFromChild(final Activity child, final Intent intent,
             final int requestCode) {
-        verifyMethodCalledFromDelegate("startActivityFromChild(Activity, Intent, int)");
-        mSuperListeners.pop().call(child, intent, requestCode);
+        verifyMethodCalledFromDelegate("startActivityFromChild(Activity, Intent, Integer)");
+        ((CallVoid3<Activity, Intent, Integer>) mSuperListeners.pop())
+                .call(child, intent, requestCode);
     }
 
     public void startActivityFromChild(final Activity child, final Intent intent,
             final int requestCode, final Bundle options) {
-        verifyMethodCalledFromDelegate("startActivityFromChild(Activity, Intent, int, Bundle)");
-        mSuperListeners.pop().call(child, intent, requestCode, options);
+        verifyMethodCalledFromDelegate("startActivityFromChild(Activity, Intent, Integer, Bundle)");
+        ((CallVoid4<Activity, Intent, Integer, Bundle>) mSuperListeners.pop())
+                .call(child, intent, requestCode, options);
     }
 
     public void startActivityFromFragment(final Fragment fragment, final Intent intent,
             final int requestCode) {
-        verifyMethodCalledFromDelegate("startActivityFromFragment(Fragment, Intent, int)");
-        mSuperListeners.pop().call(fragment, intent, requestCode);
+        verifyMethodCalledFromDelegate("startActivityFromFragment(Fragment, Intent, Integer)");
+        ((CallVoid3<Fragment, Intent, Integer>) mSuperListeners.pop())
+                .call(fragment, intent, requestCode);
     }
 
     public void startActivityFromFragment(final Fragment fragment, final Intent intent,
             final int requestCode, @Nullable final Bundle options) {
-        verifyMethodCalledFromDelegate("startActivityFromFragment(Fragment, Intent, int, Bundle)");
-        mSuperListeners.pop().call(fragment, intent, requestCode, options);
+        verifyMethodCalledFromDelegate(
+                "startActivityFromFragment(Fragment, Intent, Integer, Bundle)");
+        ((CallVoid4<Fragment, Intent, Integer, Bundle>) mSuperListeners.pop())
+                .call(fragment, intent, requestCode, options);
     }
 
     public void startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
             final int requestCode) {
         verifyMethodCalledFromDelegate(
-                "startActivityFromFragment(android.app.Fragment, Intent, int)");
-        mSuperListeners.pop().call(fragment, intent, requestCode);
+                "startActivityFromFragment(android.app.Fragment, Intent, Integer)");
+        ((CallVoid3<android.app.Fragment, Intent, Integer>) mSuperListeners.pop())
+                .call(fragment, intent, requestCode);
     }
 
     public void startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
             final int requestCode, final Bundle options) {
         verifyMethodCalledFromDelegate(
-                "startActivityFromFragment(android.app.Fragment, Intent, int, Bundle)");
-        mSuperListeners.pop().call(fragment, intent, requestCode, options);
+                "startActivityFromFragment(android.app.Fragment, Intent, Integer, Bundle)");
+        ((CallVoid4<android.app.Fragment, Intent, Integer, Bundle>) mSuperListeners.pop())
+                .call(fragment, intent, requestCode, options);
     }
 
     public boolean startActivityIfNeeded(final Intent intent, final int requestCode) {
-        verifyMethodCalledFromDelegate("startActivityIfNeeded(Intent, int)");
-        return (Boolean) mSuperListeners.pop().call(intent, requestCode);
+        verifyMethodCalledFromDelegate("startActivityIfNeeded(Intent, Integer)");
+        return ((CallFun2<Boolean, Intent, Integer>) mSuperListeners.pop())
+                .call(intent, requestCode);
     }
 
     public boolean startActivityIfNeeded(final Intent intent, final int requestCode,
             final Bundle options) {
-        verifyMethodCalledFromDelegate("startActivityIfNeeded(Intent, int, Bundle)");
-        return (Boolean) mSuperListeners.pop().call(intent, requestCode, options);
+        verifyMethodCalledFromDelegate("startActivityIfNeeded(Intent, Integer, Bundle)");
+        return ((CallFun3<Boolean, Intent, Integer, Bundle>) mSuperListeners.pop())
+                .call(intent, requestCode, options);
     }
 
     public boolean startInstrumentation(final ComponentName className, final String profileFile,
             final Bundle arguments) {
         verifyMethodCalledFromDelegate("startInstrumentation(ComponentName, String, Bundle)");
-        return (Boolean) mSuperListeners.pop().call(className, profileFile, arguments);
+        return ((CallFun3<Boolean, ComponentName, String, Bundle>) mSuperListeners.pop())
+                .call(className, profileFile, arguments);
     }
 
     public void startIntentSender(final IntentSender intent, final Intent fillInIntent,
             final int flagsMask, final int flagsValues, final int extraFlags)
             throws IntentSender.SendIntentException {
-        verifyMethodCalledFromDelegate("startIntentSender(IntentSender, Intent, int, int, int)");
-        mSuperListeners.pop().call(intent, fillInIntent, flagsMask, flagsValues, extraFlags);
+        verifyMethodCalledFromDelegate(
+                "startIntentSender(IntentSender, Intent, Integer, Integer, Integer)");
+        ((CallVoid5<IntentSender, Intent, Integer, Integer, Integer>) mSuperListeners.pop())
+                .call(intent, fillInIntent, flagsMask, flagsValues, extraFlags);
     }
 
     public void startIntentSender(final IntentSender intent, final Intent fillInIntent,
             final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException {
         verifyMethodCalledFromDelegate(
-                "startIntentSender(IntentSender, Intent, int, int, int, Bundle)");
-        mSuperListeners.pop()
+                "startIntentSender(IntentSender, Intent, Integer, Integer, Integer, Bundle)");
+        ((CallVoid6<IntentSender, Intent, Integer, Integer, Integer, Bundle>) mSuperListeners.pop())
                 .call(intent, fillInIntent, flagsMask, flagsValues, extraFlags, options);
     }
 
@@ -1620,27 +1683,28 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
             final Intent fillInIntent, final int flagsMask, final int flagsValues,
             final int extraFlags) throws IntentSender.SendIntentException {
         verifyMethodCalledFromDelegate(
-                "startIntentSenderForResult(IntentSender, int, Intent, int, int, int)");
-        mSuperListeners.pop()
-                .call(intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags);
+                "startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer)");
+        ((CallVoid6<IntentSender, Integer, Intent, Integer, Integer, Integer>) mSuperListeners
+                .pop()).call(intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags);
     }
 
     public void startIntentSenderForResult(final IntentSender intent, final int requestCode,
             final Intent fillInIntent, final int flagsMask, final int flagsValues,
             final int extraFlags, final Bundle options) throws IntentSender.SendIntentException {
         verifyMethodCalledFromDelegate(
-                "startIntentSenderForResult(IntentSender, int, Intent, int, int, int, Bundle)");
-        mSuperListeners.pop()
-                .call(intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags,
-                        options);
+                "startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)");
+        ((CallVoid7<IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle>) mSuperListeners
+                .pop()).call(intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags,
+                options);
     }
 
     public void startIntentSenderFromChild(final Activity child, final IntentSender intent,
             final int requestCode, final Intent fillInIntent, final int flagsMask,
             final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException {
         verifyMethodCalledFromDelegate(
-                "startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int)");
-        mSuperListeners.pop()
+                "startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer)");
+        ((CallVoid7<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer>) mSuperListeners
+                .pop())
                 .call(child, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags);
     }
 
@@ -1649,134 +1713,136 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
             final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException {
         verifyMethodCalledFromDelegate(
-                "startIntentSenderFromChild(Activity, IntentSender, int, Intent, int, int, int, Bundle)");
-        mSuperListeners.pop()
+                "startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)");
+        ((CallVoid8<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle>) mSuperListeners
+                .pop())
                 .call(child, intent, requestCode, fillInIntent, flagsMask, flagsValues, extraFlags,
                         options);
     }
 
     public void startLockTask() {
         verifyMethodCalledFromDelegate("startLockTask()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void startManagingCursor(final Cursor c) {
         verifyMethodCalledFromDelegate("startManagingCursor(Cursor)");
-        mSuperListeners.pop().call(c);
+        ((CallVoid1<Cursor>) mSuperListeners.pop()).call(c);
     }
 
     public boolean startNextMatchingActivity(final Intent intent) {
         verifyMethodCalledFromDelegate("startNextMatchingActivity(Intent)");
-        return (Boolean) mSuperListeners.pop().call(intent);
+        return ((CallFun1<Boolean, Intent>) mSuperListeners.pop()).call(intent);
     }
 
     public boolean startNextMatchingActivity(final Intent intent, final Bundle options) {
         verifyMethodCalledFromDelegate("startNextMatchingActivity(Intent, Bundle)");
-        return (Boolean) mSuperListeners.pop().call(intent, options);
+        return ((CallFun2<Boolean, Intent, Bundle>) mSuperListeners.pop()).call(intent, options);
     }
 
     public void startPostponedEnterTransition() {
         verifyMethodCalledFromDelegate("startPostponedEnterTransition()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void startSearch(final String initialQuery, final boolean selectInitialQuery,
             final Bundle appSearchData, final boolean globalSearch) {
-        verifyMethodCalledFromDelegate("startSearch(String, boolean, Bundle, boolean)");
-        mSuperListeners.pop().call(initialQuery, selectInitialQuery, appSearchData, globalSearch);
+        verifyMethodCalledFromDelegate("startSearch(String, Boolean, Bundle, Boolean)");
+        ((CallVoid4<String, Boolean, Bundle, Boolean>) mSuperListeners.pop())
+                .call(initialQuery, selectInitialQuery, appSearchData, globalSearch);
     }
 
     public ComponentName startService(final Intent service) {
         verifyMethodCalledFromDelegate("startService(Intent)");
-        return (ComponentName) mSuperListeners.pop().call(service);
+        return ((CallFun1<ComponentName, Intent>) mSuperListeners.pop()).call(service);
     }
 
     public ActionMode startSupportActionMode(@NonNull final ActionMode.Callback callback) {
         verifyMethodCalledFromDelegate("startSupportActionMode(ActionMode.Callback)");
-        return (ActionMode) mSuperListeners.pop().call(callback);
+        return ((CallFun1<ActionMode, ActionMode.Callback>) mSuperListeners.pop()).call(callback);
     }
 
     public void stopLockTask() {
         verifyMethodCalledFromDelegate("stopLockTask()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void stopManagingCursor(final Cursor c) {
         verifyMethodCalledFromDelegate("stopManagingCursor(Cursor)");
-        mSuperListeners.pop().call(c);
+        ((CallVoid1<Cursor>) mSuperListeners.pop()).call(c);
     }
 
     public boolean stopService(final Intent name) {
         verifyMethodCalledFromDelegate("stopService(Intent)");
-        return (Boolean) mSuperListeners.pop().call(name);
+        return ((CallFun1<Boolean, Intent>) mSuperListeners.pop()).call(name);
     }
 
     public void supportFinishAfterTransition() {
         verifyMethodCalledFromDelegate("supportFinishAfterTransition()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void supportInvalidateOptionsMenu() {
         verifyMethodCalledFromDelegate("supportInvalidateOptionsMenu()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void supportNavigateUpTo(@NonNull final Intent upIntent) {
         verifyMethodCalledFromDelegate("supportNavigateUpTo(Intent)");
-        mSuperListeners.pop().call(upIntent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(upIntent);
     }
 
     public void supportPostponeEnterTransition() {
         verifyMethodCalledFromDelegate("supportPostponeEnterTransition()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean supportRequestWindowFeature(final int featureId) {
-        verifyMethodCalledFromDelegate("supportRequestWindowFeature(int)");
-        return (Boolean) mSuperListeners.pop().call(featureId);
+        verifyMethodCalledFromDelegate("supportRequestWindowFeature(Integer)");
+        return ((CallFun1<Boolean, Integer>) mSuperListeners.pop()).call(featureId);
     }
 
     public boolean supportShouldUpRecreateTask(@NonNull final Intent targetIntent) {
         verifyMethodCalledFromDelegate("supportShouldUpRecreateTask(Intent)");
-        return (Boolean) mSuperListeners.pop().call(targetIntent);
+        return ((CallFun1<Boolean, Intent>) mSuperListeners.pop()).call(targetIntent);
     }
 
     public void supportStartPostponedEnterTransition() {
         verifyMethodCalledFromDelegate("supportStartPostponedEnterTransition()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void takeKeyEvents(final boolean get) {
-        verifyMethodCalledFromDelegate("takeKeyEvents(boolean)");
-        mSuperListeners.pop().call(get);
+        verifyMethodCalledFromDelegate("takeKeyEvents(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(get);
     }
 
     public void triggerSearch(final String query, final Bundle appSearchData) {
         verifyMethodCalledFromDelegate("triggerSearch(String, Bundle)");
-        mSuperListeners.pop().call(query, appSearchData);
+        ((CallVoid2<String, Bundle>) mSuperListeners.pop()).call(query, appSearchData);
     }
 
     public void unbindService(final ServiceConnection conn) {
         verifyMethodCalledFromDelegate("unbindService(ServiceConnection)");
-        mSuperListeners.pop().call(conn);
+        ((CallVoid1<ServiceConnection>) mSuperListeners.pop()).call(conn);
     }
 
     public void unregisterComponentCallbacks(final ComponentCallbacks callback) {
         verifyMethodCalledFromDelegate("unregisterComponentCallbacks(ComponentCallbacks)");
-        mSuperListeners.pop().call(callback);
+        ((CallVoid1<ComponentCallbacks>) mSuperListeners.pop()).call(callback);
     }
 
     public void unregisterForContextMenu(final View view) {
         verifyMethodCalledFromDelegate("unregisterForContextMenu(View)");
-        mSuperListeners.pop().call(view);
+        ((CallVoid1<View>) mSuperListeners.pop()).call(view);
     }
 
     public void unregisterReceiver(final BroadcastReceiver receiver) {
         verifyMethodCalledFromDelegate("unregisterReceiver(BroadcastReceiver)");
-        mSuperListeners.pop().call(receiver);
+        ((CallVoid1<BroadcastReceiver>) mSuperListeners.pop()).call(receiver);
     }
 
-    void addContentView(final NamedSuperCall<Void> superCall, final View view,
+    void addContentView(final CallVoid2<View, ViewGroup.LayoutParams> superCall, final View view,
             final ViewGroup.LayoutParams params) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1784,7 +1850,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void applyOverrideConfiguration(final NamedSuperCall<Void> superCall,
+    void applyOverrideConfiguration(final CallVoid1<Configuration> superCall,
             final Configuration overrideConfiguration) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1792,22 +1858,22 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void attachBaseContext(final NamedSuperCall<Void> superCall, final Context newBase) {
+    void attachBaseContext(final CallVoid1<Context> superCall, final Context newBase) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             attachBaseContext(newBase);
         }
     }
 
-    boolean bindService(final NamedSuperCall<Boolean> superCall, final Intent service,
-            final ServiceConnection conn, final int flags) {
+    boolean bindService(final CallFun3<Boolean, Intent, ServiceConnection, Integer> superCall,
+            final Intent service, final ServiceConnection conn, final int flags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return bindService(service, conn, flags);
         }
     }
 
-    int checkCallingOrSelfPermission(final NamedSuperCall<Integer> superCall,
+    int checkCallingOrSelfPermission(final CallFun1<Integer, String> superCall,
             final String permission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1815,22 +1881,22 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    int checkCallingOrSelfUriPermission(final NamedSuperCall<Integer> superCall, final Uri uri,
-            final int modeFlags) {
+    int checkCallingOrSelfUriPermission(final CallFun2<Integer, Uri, Integer> superCall,
+            final Uri uri, final int modeFlags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return checkCallingOrSelfUriPermission(uri, modeFlags);
         }
     }
 
-    int checkCallingPermission(final NamedSuperCall<Integer> superCall, final String permission) {
+    int checkCallingPermission(final CallFun1<Integer, String> superCall, final String permission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return checkCallingPermission(permission);
         }
     }
 
-    int checkCallingUriPermission(final NamedSuperCall<Integer> superCall, final Uri uri,
+    int checkCallingUriPermission(final CallFun2<Integer, Uri, Integer> superCall, final Uri uri,
             final int modeFlags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1838,60 +1904,61 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    int checkPermission(final NamedSuperCall<Integer> superCall, final String permission,
-            final int pid, final int uid) {
+    int checkPermission(final CallFun3<Integer, String, Integer, Integer> superCall,
+            final String permission, final int pid, final int uid) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return checkPermission(permission, pid, uid);
         }
     }
 
-    int checkSelfPermission(final NamedSuperCall<Integer> superCall, final String permission) {
+    int checkSelfPermission(final CallFun1<Integer, String> superCall, final String permission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return checkSelfPermission(permission);
         }
     }
 
-    int checkUriPermission(final NamedSuperCall<Integer> superCall, final Uri uri, final int pid,
-            final int uid, final int modeFlags) {
+    int checkUriPermission(final CallFun4<Integer, Uri, Integer, Integer, Integer> superCall,
+            final Uri uri, final int pid, final int uid, final int modeFlags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return checkUriPermission(uri, pid, uid, modeFlags);
         }
     }
 
-    int checkUriPermission(final NamedSuperCall<Integer> superCall, final Uri uri,
-            final String readPermission, final String writePermission, final int pid, final int uid,
-            final int modeFlags) {
+    int checkUriPermission(
+            final CallFun6<Integer, Uri, String, String, Integer, Integer, Integer> superCall,
+            final Uri uri, final String readPermission, final String writePermission, final int pid,
+            final int uid, final int modeFlags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return checkUriPermission(uri, readPermission, writePermission, pid, uid, modeFlags);
         }
     }
 
-    void clearWallpaper(final NamedSuperCall<Void> superCall) throws IOException {
+    void clearWallpaper(final CallVoid0 superCall) throws IOException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             clearWallpaper();
         }
     }
 
-    void closeContextMenu(final NamedSuperCall<Void> superCall) {
+    void closeContextMenu(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             closeContextMenu();
         }
     }
 
-    void closeOptionsMenu(final NamedSuperCall<Void> superCall) {
+    void closeOptionsMenu(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             closeOptionsMenu();
         }
     }
 
-    Context createConfigurationContext(final NamedSuperCall<Context> superCall,
+    Context createConfigurationContext(final CallFun1<Context, Configuration> superCall,
             final Configuration overrideConfiguration) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1899,22 +1966,24 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    Context createDisplayContext(final NamedSuperCall<Context> superCall, final Display display) {
+    Context createDisplayContext(final CallFun1<Context, Display> superCall,
+            final Display display) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return createDisplayContext(display);
         }
     }
 
-    Context createPackageContext(final NamedSuperCall<Context> superCall, final String packageName,
-            final int flags) throws PackageManager.NameNotFoundException {
+    Context createPackageContext(final CallFun2<Context, String, Integer> superCall,
+            final String packageName, final int flags) throws PackageManager.NameNotFoundException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return createPackageContext(packageName, flags);
         }
     }
 
-    PendingIntent createPendingResult(final NamedSuperCall<PendingIntent> superCall,
+    PendingIntent createPendingResult(
+            final CallFun3<PendingIntent, Integer, Intent, Integer> superCall,
             final int requestCode, final Intent data, final int flags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1922,28 +1991,28 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    String[] databaseList(final NamedSuperCall<String[]> superCall) {
+    String[] databaseList(final CallFun0<String[]> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return databaseList();
         }
     }
 
-    boolean deleteDatabase(final NamedSuperCall<Boolean> superCall, final String name) {
+    boolean deleteDatabase(final CallFun1<Boolean, String> superCall, final String name) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return deleteDatabase(name);
         }
     }
 
-    boolean deleteFile(final NamedSuperCall<Boolean> superCall, final String name) {
+    boolean deleteFile(final CallFun1<Boolean, String> superCall, final String name) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return deleteFile(name);
         }
     }
 
-    boolean dispatchGenericMotionEvent(final NamedSuperCall<Boolean> superCall,
+    boolean dispatchGenericMotionEvent(final CallFun1<Boolean, MotionEvent> superCall,
             final MotionEvent ev) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1951,14 +2020,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean dispatchKeyEvent(final NamedSuperCall<Boolean> superCall, final KeyEvent event) {
+    boolean dispatchKeyEvent(final CallFun1<Boolean, KeyEvent> superCall, final KeyEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return dispatchKeyEvent(event);
         }
     }
 
-    boolean dispatchKeyShortcutEvent(final NamedSuperCall<Boolean> superCall,
+    boolean dispatchKeyShortcutEvent(final CallFun1<Boolean, KeyEvent> superCall,
             final KeyEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -1966,37 +2035,40 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean dispatchPopulateAccessibilityEvent(final NamedSuperCall<Boolean> superCall,
-            final AccessibilityEvent event) {
+    boolean dispatchPopulateAccessibilityEvent(
+            final CallFun1<Boolean, AccessibilityEvent> superCall, final AccessibilityEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return dispatchPopulateAccessibilityEvent(event);
         }
     }
 
-    boolean dispatchTouchEvent(final NamedSuperCall<Boolean> superCall, final MotionEvent ev) {
+    boolean dispatchTouchEvent(final CallFun1<Boolean, MotionEvent> superCall,
+            final MotionEvent ev) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return dispatchTouchEvent(ev);
         }
     }
 
-    boolean dispatchTrackballEvent(final NamedSuperCall<Boolean> superCall, final MotionEvent ev) {
+    boolean dispatchTrackballEvent(final CallFun1<Boolean, MotionEvent> superCall,
+            final MotionEvent ev) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return dispatchTrackballEvent(ev);
         }
     }
 
-    void dump(final NamedSuperCall<Void> superCall, final String prefix, final FileDescriptor fd,
-            final PrintWriter writer, final String[] args) {
+    void dump(final CallVoid4<String, FileDescriptor, PrintWriter, String[]> superCall,
+            final String prefix, final FileDescriptor fd, final PrintWriter writer,
+            final String[] args) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             dump(prefix, fd, writer, args);
         }
     }
 
-    void enforceCallingOrSelfPermission(final NamedSuperCall<Void> superCall,
+    void enforceCallingOrSelfPermission(final CallVoid2<String, String> superCall,
             final String permission, final String message) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2004,23 +2076,23 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void enforceCallingOrSelfUriPermission(final NamedSuperCall<Void> superCall, final Uri uri,
-            final int modeFlags, final String message) {
+    void enforceCallingOrSelfUriPermission(final CallVoid3<Uri, Integer, String> superCall,
+            final Uri uri, final int modeFlags, final String message) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             enforceCallingOrSelfUriPermission(uri, modeFlags, message);
         }
     }
 
-    void enforceCallingPermission(final NamedSuperCall<Void> superCall, final String permission,
-            final String message) {
+    void enforceCallingPermission(final CallVoid2<String, String> superCall,
+            final String permission, final String message) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             enforceCallingPermission(permission, message);
         }
     }
 
-    void enforceCallingUriPermission(final NamedSuperCall<Void> superCall, final Uri uri,
+    void enforceCallingUriPermission(final CallVoid3<Uri, Integer, String> superCall, final Uri uri,
             final int modeFlags, final String message) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2028,25 +2100,27 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void enforcePermission(final NamedSuperCall<Void> superCall, final String permission,
-            final int pid, final int uid, final String message) {
+    void enforcePermission(final CallVoid4<String, Integer, Integer, String> superCall,
+            final String permission, final int pid, final int uid, final String message) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             enforcePermission(permission, pid, uid, message);
         }
     }
 
-    void enforceUriPermission(final NamedSuperCall<Void> superCall, final Uri uri, final int pid,
-            final int uid, final int modeFlags, final String message) {
+    void enforceUriPermission(final CallVoid5<Uri, Integer, Integer, Integer, String> superCall,
+            final Uri uri, final int pid, final int uid, final int modeFlags,
+            final String message) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             enforceUriPermission(uri, pid, uid, modeFlags, message);
         }
     }
 
-    void enforceUriPermission(final NamedSuperCall<Void> superCall, final Uri uri,
-            final String readPermission, final String writePermission, final int pid, final int uid,
-            final int modeFlags, final String message) {
+    void enforceUriPermission(
+            final CallVoid7<Uri, String, String, Integer, Integer, Integer, String> superCall,
+            final Uri uri, final String readPermission, final String writePermission, final int pid,
+            final int uid, final int modeFlags, final String message) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             enforceUriPermission(uri, readPermission, writePermission, pid, uid, modeFlags,
@@ -2054,35 +2128,35 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    String[] fileList(final NamedSuperCall<String[]> superCall) {
+    String[] fileList(final CallFun0<String[]> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return fileList();
         }
     }
 
-    View findViewById(final NamedSuperCall<View> superCall, @IdRes final int id) {
+    View findViewById(final CallFun1<View, Integer> superCall, @IdRes final int id) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return findViewById(id);
         }
     }
 
-    void finish(final NamedSuperCall<Void> superCall) {
+    void finish(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             finish();
         }
     }
 
-    void finishActivity(final NamedSuperCall<Void> superCall, final int requestCode) {
+    void finishActivity(final CallVoid1<Integer> superCall, final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             finishActivity(requestCode);
         }
     }
 
-    void finishActivityFromChild(final NamedSuperCall<Void> superCall, final Activity child,
+    void finishActivityFromChild(final CallVoid2<Activity, Integer> superCall, final Activity child,
             final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2090,162 +2164,162 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void finishAffinity(final NamedSuperCall<Void> superCall) {
+    void finishAffinity(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             finishAffinity();
         }
     }
 
-    void finishAfterTransition(final NamedSuperCall<Void> superCall) {
+    void finishAfterTransition(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             finishAfterTransition();
         }
     }
 
-    void finishAndRemoveTask(final NamedSuperCall<Void> superCall) {
+    void finishAndRemoveTask(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             finishAndRemoveTask();
         }
     }
 
-    void finishFromChild(final NamedSuperCall<Void> superCall, final Activity child) {
+    void finishFromChild(final CallVoid1<Activity> superCall, final Activity child) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             finishFromChild(child);
         }
     }
 
-    android.app.ActionBar getActionBar(final NamedSuperCall<android.app.ActionBar> superCall) {
+    android.app.ActionBar getActionBar(final CallFun0<android.app.ActionBar> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getActionBar();
         }
     }
 
-    Context getApplicationContext(final NamedSuperCall<Context> superCall) {
+    Context getApplicationContext(final CallFun0<Context> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getApplicationContext();
         }
     }
 
-    ApplicationInfo getApplicationInfo(final NamedSuperCall<ApplicationInfo> superCall) {
+    ApplicationInfo getApplicationInfo(final CallFun0<ApplicationInfo> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getApplicationInfo();
         }
     }
 
-    AssetManager getAssets(final NamedSuperCall<AssetManager> superCall) {
+    AssetManager getAssets(final CallFun0<AssetManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getAssets();
         }
     }
 
-    Context getBaseContext(final NamedSuperCall<Context> superCall) {
+    Context getBaseContext(final CallFun0<Context> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getBaseContext();
         }
     }
 
-    File getCacheDir(final NamedSuperCall<File> superCall) {
+    File getCacheDir(final CallFun0<File> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getCacheDir();
         }
     }
 
-    ComponentName getCallingActivity(final NamedSuperCall<ComponentName> superCall) {
+    ComponentName getCallingActivity(final CallFun0<ComponentName> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getCallingActivity();
         }
     }
 
-    String getCallingPackage(final NamedSuperCall<String> superCall) {
+    String getCallingPackage(final CallFun0<String> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getCallingPackage();
         }
     }
 
-    int getChangingConfigurations(final NamedSuperCall<Integer> superCall) {
+    int getChangingConfigurations(final CallFun0<Integer> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getChangingConfigurations();
         }
     }
 
-    ClassLoader getClassLoader(final NamedSuperCall<ClassLoader> superCall) {
+    ClassLoader getClassLoader(final CallFun0<ClassLoader> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getClassLoader();
         }
     }
 
-    File getCodeCacheDir(final NamedSuperCall<File> superCall) {
+    File getCodeCacheDir(final CallFun0<File> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getCodeCacheDir();
         }
     }
 
-    ComponentName getComponentName(final NamedSuperCall<ComponentName> superCall) {
+    ComponentName getComponentName(final CallFun0<ComponentName> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getComponentName();
         }
     }
 
-    ContentResolver getContentResolver(final NamedSuperCall<ContentResolver> superCall) {
+    ContentResolver getContentResolver(final CallFun0<ContentResolver> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getContentResolver();
         }
     }
 
-    Scene getContentScene(final NamedSuperCall<Scene> superCall) {
+    Scene getContentScene(final CallFun0<Scene> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getContentScene();
         }
     }
 
-    TransitionManager getContentTransitionManager(
-            final NamedSuperCall<TransitionManager> superCall) {
+    TransitionManager getContentTransitionManager(final CallFun0<TransitionManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getContentTransitionManager();
         }
     }
 
-    View getCurrentFocus(final NamedSuperCall<View> superCall) {
+    View getCurrentFocus(final CallFun0<View> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getCurrentFocus();
         }
     }
 
-    File getDatabasePath(final NamedSuperCall<File> superCall, final String name) {
+    File getDatabasePath(final CallFun1<File, String> superCall, final String name) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getDatabasePath(name);
         }
     }
 
-    AppCompatDelegate getDelegate(final NamedSuperCall<AppCompatDelegate> superCall) {
+    AppCompatDelegate getDelegate(final CallFun0<AppCompatDelegate> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getDelegate();
         }
     }
 
-    File getDir(final NamedSuperCall<File> superCall, final String name, final int mode) {
+    File getDir(final CallFun2<File, String, Integer> superCall, final String name,
+            final int mode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getDir(name, mode);
@@ -2253,56 +2327,56 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
     }
 
     ActionBarDrawerToggle.Delegate getDrawerToggleDelegate(
-            final NamedSuperCall<ActionBarDrawerToggle.Delegate> superCall) {
+            final CallFun0<ActionBarDrawerToggle.Delegate> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getDrawerToggleDelegate();
         }
     }
 
-    File getExternalCacheDir(final NamedSuperCall<File> superCall) {
+    File getExternalCacheDir(final CallFun0<File> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getExternalCacheDir();
         }
     }
 
-    File[] getExternalCacheDirs(final NamedSuperCall<File[]> superCall) {
+    File[] getExternalCacheDirs(final CallFun0<File[]> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getExternalCacheDirs();
         }
     }
 
-    File getExternalFilesDir(final NamedSuperCall<File> superCall, final String type) {
+    File getExternalFilesDir(final CallFun1<File, String> superCall, final String type) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getExternalFilesDir(type);
         }
     }
 
-    File[] getExternalFilesDirs(final NamedSuperCall<File[]> superCall, final String type) {
+    File[] getExternalFilesDirs(final CallFun1<File[], String> superCall, final String type) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getExternalFilesDirs(type);
         }
     }
 
-    File[] getExternalMediaDirs(final NamedSuperCall<File[]> superCall) {
+    File[] getExternalMediaDirs(final CallFun0<File[]> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getExternalMediaDirs();
         }
     }
 
-    File getFileStreamPath(final NamedSuperCall<File> superCall, final String name) {
+    File getFileStreamPath(final CallFun1<File, String> superCall, final String name) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getFileStreamPath(name);
         }
     }
 
-    File getFilesDir(final NamedSuperCall<File> superCall) {
+    File getFilesDir(final CallFun0<File> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getFilesDir();
@@ -2310,21 +2384,21 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
     }
 
     android.app.FragmentManager getFragmentManager(
-            final NamedSuperCall<android.app.FragmentManager> superCall) {
+            final CallFun0<android.app.FragmentManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getFragmentManager();
         }
     }
 
-    Intent getIntent(final NamedSuperCall<Intent> superCall) {
+    Intent getIntent(final CallFun0<Intent> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getIntent();
         }
     }
 
-    LayoutInflater getLayoutInflater(final NamedSuperCall<LayoutInflater> superCall) {
+    LayoutInflater getLayoutInflater(final CallFun0<LayoutInflater> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getLayoutInflater();
@@ -2332,91 +2406,91 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
     }
 
     android.app.LoaderManager getLoaderManager(
-            final NamedSuperCall<android.app.LoaderManager> superCall) {
+            final CallFun0<android.app.LoaderManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getLoaderManager();
         }
     }
 
-    String getLocalClassName(final NamedSuperCall<String> superCall) {
+    String getLocalClassName(final CallFun0<String> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getLocalClassName();
         }
     }
 
-    Looper getMainLooper(final NamedSuperCall<Looper> superCall) {
+    Looper getMainLooper(final CallFun0<Looper> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getMainLooper();
         }
     }
 
-    MenuInflater getMenuInflater(final NamedSuperCall<MenuInflater> superCall) {
+    MenuInflater getMenuInflater(final CallFun0<MenuInflater> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getMenuInflater();
         }
     }
 
-    File getNoBackupFilesDir(final NamedSuperCall<File> superCall) {
+    File getNoBackupFilesDir(final CallFun0<File> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getNoBackupFilesDir();
         }
     }
 
-    File getObbDir(final NamedSuperCall<File> superCall) {
+    File getObbDir(final CallFun0<File> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getObbDir();
         }
     }
 
-    File[] getObbDirs(final NamedSuperCall<File[]> superCall) {
+    File[] getObbDirs(final CallFun0<File[]> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getObbDirs();
         }
     }
 
-    String getPackageCodePath(final NamedSuperCall<String> superCall) {
+    String getPackageCodePath(final CallFun0<String> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getPackageCodePath();
         }
     }
 
-    PackageManager getPackageManager(final NamedSuperCall<PackageManager> superCall) {
+    PackageManager getPackageManager(final CallFun0<PackageManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getPackageManager();
         }
     }
 
-    String getPackageName(final NamedSuperCall<String> superCall) {
+    String getPackageName(final CallFun0<String> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getPackageName();
         }
     }
 
-    String getPackageResourcePath(final NamedSuperCall<String> superCall) {
+    String getPackageResourcePath(final CallFun0<String> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getPackageResourcePath();
         }
     }
 
-    Intent getParentActivityIntent(final NamedSuperCall<Intent> superCall) {
+    Intent getParentActivityIntent(final CallFun0<Intent> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getParentActivityIntent();
         }
     }
 
-    SharedPreferences getPreferences(final NamedSuperCall<SharedPreferences> superCall,
+    SharedPreferences getPreferences(final CallFun1<SharedPreferences, Integer> superCall,
             final int mode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2424,71 +2498,72 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    Uri getReferrer(final NamedSuperCall<Uri> superCall) {
+    Uri getReferrer(final CallFun0<Uri> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getReferrer();
         }
     }
 
-    int getRequestedOrientation(final NamedSuperCall<Integer> superCall) {
+    int getRequestedOrientation(final CallFun0<Integer> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getRequestedOrientation();
         }
     }
 
-    Resources getResources(final NamedSuperCall<Resources> superCall) {
+    Resources getResources(final CallFun0<Resources> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getResources();
         }
     }
 
-    SharedPreferences getSharedPreferences(final NamedSuperCall<SharedPreferences> superCall,
-            final String name, final int mode) {
+    SharedPreferences getSharedPreferences(
+            final CallFun2<SharedPreferences, String, Integer> superCall, final String name,
+            final int mode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSharedPreferences(name, mode);
         }
     }
 
-    ActionBar getSupportActionBar(final NamedSuperCall<ActionBar> superCall) {
+    ActionBar getSupportActionBar(final CallFun0<ActionBar> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSupportActionBar();
         }
     }
 
-    FragmentManager getSupportFragmentManager(final NamedSuperCall<FragmentManager> superCall) {
+    FragmentManager getSupportFragmentManager(final CallFun0<FragmentManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSupportFragmentManager();
         }
     }
 
-    LoaderManager getSupportLoaderManager(final NamedSuperCall<LoaderManager> superCall) {
+    LoaderManager getSupportLoaderManager(final CallFun0<LoaderManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSupportLoaderManager();
         }
     }
 
-    Intent getSupportParentActivityIntent(final NamedSuperCall<Intent> superCall) {
+    Intent getSupportParentActivityIntent(final CallFun0<Intent> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSupportParentActivityIntent();
         }
     }
 
-    Object getSystemService(final NamedSuperCall<Object> superCall, final String name) {
+    Object getSystemService(final CallFun1<Object, String> superCall, final String name) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSystemService(name);
         }
     }
 
-    String getSystemServiceName(final NamedSuperCall<String> superCall,
+    String getSystemServiceName(final CallFun1<String, Class<?>> superCall,
             final Class<?> serviceClass) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2496,63 +2571,63 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    int getTaskId(final NamedSuperCall<Integer> superCall) {
+    int getTaskId(final CallFun0<Integer> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getTaskId();
         }
     }
 
-    Resources.Theme getTheme(final NamedSuperCall<Resources.Theme> superCall) {
+    Resources.Theme getTheme(final CallFun0<Resources.Theme> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getTheme();
         }
     }
 
-    VoiceInteractor getVoiceInteractor(final NamedSuperCall<VoiceInteractor> superCall) {
+    VoiceInteractor getVoiceInteractor(final CallFun0<VoiceInteractor> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getVoiceInteractor();
         }
     }
 
-    Drawable getWallpaper(final NamedSuperCall<Drawable> superCall) {
+    Drawable getWallpaper(final CallFun0<Drawable> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getWallpaper();
         }
     }
 
-    int getWallpaperDesiredMinimumHeight(final NamedSuperCall<Integer> superCall) {
+    int getWallpaperDesiredMinimumHeight(final CallFun0<Integer> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getWallpaperDesiredMinimumHeight();
         }
     }
 
-    int getWallpaperDesiredMinimumWidth(final NamedSuperCall<Integer> superCall) {
+    int getWallpaperDesiredMinimumWidth(final CallFun0<Integer> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getWallpaperDesiredMinimumWidth();
         }
     }
 
-    Window getWindow(final NamedSuperCall<Window> superCall) {
+    Window getWindow(final CallFun0<Window> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getWindow();
         }
     }
 
-    WindowManager getWindowManager(final NamedSuperCall<WindowManager> superCall) {
+    WindowManager getWindowManager(final CallFun0<WindowManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getWindowManager();
         }
     }
 
-    void grantUriPermission(final NamedSuperCall<Void> superCall, final String toPackage,
+    void grantUriPermission(final CallVoid3<String, Uri, Integer> superCall, final String toPackage,
             final Uri uri, final int modeFlags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2560,99 +2635,99 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean hasWindowFocus(final NamedSuperCall<Boolean> superCall) {
+    boolean hasWindowFocus(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return hasWindowFocus();
         }
     }
 
-    void invalidateOptionsMenu(final NamedSuperCall<Void> superCall) {
+    void invalidateOptionsMenu(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             invalidateOptionsMenu();
         }
     }
 
-    boolean isChangingConfigurations(final NamedSuperCall<Boolean> superCall) {
+    boolean isChangingConfigurations(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isChangingConfigurations();
         }
     }
 
-    boolean isDestroyed(final NamedSuperCall<Boolean> superCall) {
+    boolean isDestroyed(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isDestroyed();
         }
     }
 
-    boolean isFinishing(final NamedSuperCall<Boolean> superCall) {
+    boolean isFinishing(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isFinishing();
         }
     }
 
-    boolean isImmersive(final NamedSuperCall<Boolean> superCall) {
+    boolean isImmersive(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isImmersive();
         }
     }
 
-    boolean isRestricted(final NamedSuperCall<Boolean> superCall) {
+    boolean isRestricted(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isRestricted();
         }
     }
 
-    boolean isTaskRoot(final NamedSuperCall<Boolean> superCall) {
+    boolean isTaskRoot(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isTaskRoot();
         }
     }
 
-    boolean isVoiceInteraction(final NamedSuperCall<Boolean> superCall) {
+    boolean isVoiceInteraction(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isVoiceInteraction();
         }
     }
 
-    boolean isVoiceInteractionRoot(final NamedSuperCall<Boolean> superCall) {
+    boolean isVoiceInteractionRoot(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isVoiceInteractionRoot();
         }
     }
 
-    boolean moveTaskToBack(final NamedSuperCall<Boolean> superCall, final boolean nonRoot) {
+    boolean moveTaskToBack(final CallFun1<Boolean, Boolean> superCall, final boolean nonRoot) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return moveTaskToBack(nonRoot);
         }
     }
 
-    boolean navigateUpTo(final NamedSuperCall<Boolean> superCall, final Intent upIntent) {
+    boolean navigateUpTo(final CallFun1<Boolean, Intent> superCall, final Intent upIntent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return navigateUpTo(upIntent);
         }
     }
 
-    boolean navigateUpToFromChild(final NamedSuperCall<Boolean> superCall, final Activity child,
-            final Intent upIntent) {
+    boolean navigateUpToFromChild(final CallFun2<Boolean, Activity, Intent> superCall,
+            final Activity child, final Intent upIntent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return navigateUpToFromChild(child, upIntent);
         }
     }
 
-    void onActionModeFinished(final NamedSuperCall<Void> superCall,
+    void onActionModeFinished(final CallVoid1<android.view.ActionMode> superCall,
             final android.view.ActionMode mode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2660,7 +2735,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onActionModeStarted(final NamedSuperCall<Void> superCall,
+    void onActionModeStarted(final CallVoid1<android.view.ActionMode> superCall,
             final android.view.ActionMode mode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2668,7 +2743,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onActivityReenter(final NamedSuperCall<Void> superCall, final int resultCode,
+    void onActivityReenter(final CallVoid2<Integer, Intent> superCall, final int resultCode,
             final Intent data) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2676,30 +2751,30 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onActivityResult(final NamedSuperCall<Void> superCall, final int requestCode,
-            final int resultCode, final Intent data) {
+    void onActivityResult(final CallVoid3<Integer, Integer, Intent> superCall,
+            final int requestCode, final int resultCode, final Intent data) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onActivityResult(requestCode, resultCode, data);
         }
     }
 
-    void onApplyThemeResource(final NamedSuperCall<Void> superCall, final Resources.Theme theme,
-            final int resid, final boolean first) {
+    void onApplyThemeResource(final CallVoid3<Resources.Theme, Integer, Boolean> superCall,
+            final Resources.Theme theme, final int resid, final boolean first) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onApplyThemeResource(theme, resid, first);
         }
     }
 
-    void onAttachFragment(final NamedSuperCall<Void> superCall, final Fragment fragment) {
+    void onAttachFragment(final CallVoid1<Fragment> superCall, final Fragment fragment) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onAttachFragment(fragment);
         }
     }
 
-    void onAttachFragment(final NamedSuperCall<Void> superCall,
+    void onAttachFragment(final CallVoid1<android.app.Fragment> superCall,
             final android.app.Fragment fragment) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2707,29 +2782,29 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onAttachedToWindow(final NamedSuperCall<Void> superCall) {
+    void onAttachedToWindow(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onAttachedToWindow();
         }
     }
 
-    void onBackPressed(final NamedSuperCall<Void> superCall) {
+    void onBackPressed(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onBackPressed();
         }
     }
 
-    void onChildTitleChanged(final NamedSuperCall<Void> superCall, final Activity childActivity,
-            final CharSequence title) {
+    void onChildTitleChanged(final CallVoid2<Activity, CharSequence> superCall,
+            final Activity childActivity, final CharSequence title) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onChildTitleChanged(childActivity, title);
         }
     }
 
-    void onConfigurationChanged(final NamedSuperCall<Void> superCall,
+    void onConfigurationChanged(final CallVoid1<Configuration> superCall,
             final Configuration newConfig) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2737,72 +2812,75 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onContentChanged(final NamedSuperCall<Void> superCall) {
+    void onContentChanged(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onContentChanged();
         }
     }
 
-    boolean onContextItemSelected(final NamedSuperCall<Boolean> superCall, final MenuItem item) {
+    boolean onContextItemSelected(final CallFun1<Boolean, MenuItem> superCall,
+            final MenuItem item) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onContextItemSelected(item);
         }
     }
 
-    void onContextMenuClosed(final NamedSuperCall<Void> superCall, final Menu menu) {
+    void onContextMenuClosed(final CallVoid1<Menu> superCall, final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onContextMenuClosed(menu);
         }
     }
 
-    void onCreate(final NamedSuperCall<Void> superCall, final Bundle savedInstanceState,
-            final PersistableBundle persistentState) {
+    void onCreate(final CallVoid2<Bundle, PersistableBundle> superCall,
+            final Bundle savedInstanceState, final PersistableBundle persistentState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onCreate(savedInstanceState, persistentState);
         }
     }
 
-    void onCreate(final NamedSuperCall<Void> superCall, @Nullable final Bundle savedInstanceState) {
+    void onCreate(final CallVoid1<Bundle> superCall, @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onCreate(savedInstanceState);
         }
     }
 
-    void onCreateContextMenu(final NamedSuperCall<Void> superCall, final ContextMenu menu,
-            final View v, final ContextMenu.ContextMenuInfo menuInfo) {
+    void onCreateContextMenu(
+            final CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo> superCall,
+            final ContextMenu menu, final View v, final ContextMenu.ContextMenuInfo menuInfo) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onCreateContextMenu(menu, v, menuInfo);
         }
     }
 
-    CharSequence onCreateDescription(final NamedSuperCall<CharSequence> superCall) {
+    CharSequence onCreateDescription(final CallFun0<CharSequence> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateDescription();
         }
     }
 
-    Dialog onCreateDialog(final NamedSuperCall<Dialog> superCall, final int id) {
+    Dialog onCreateDialog(final CallFun1<Dialog, Integer> superCall, final int id) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateDialog(id);
         }
     }
 
-    Dialog onCreateDialog(final NamedSuperCall<Dialog> superCall, final int id, final Bundle args) {
+    Dialog onCreateDialog(final CallFun2<Dialog, Integer, Bundle> superCall, final int id,
+            final Bundle args) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateDialog(id, args);
         }
     }
 
-    void onCreateNavigateUpTaskStack(final NamedSuperCall<Void> superCall,
+    void onCreateNavigateUpTaskStack(final CallVoid1<TaskStackBuilder> superCall,
             final TaskStackBuilder builder) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2810,14 +2888,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onCreateOptionsMenu(final NamedSuperCall<Boolean> superCall, final Menu menu) {
+    boolean onCreateOptionsMenu(final CallFun1<Boolean, Menu> superCall, final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateOptionsMenu(menu);
         }
     }
 
-    boolean onCreatePanelMenu(final NamedSuperCall<Boolean> superCall, final int featureId,
+    boolean onCreatePanelMenu(final CallFun2<Boolean, Integer, Menu> superCall, final int featureId,
             final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2825,14 +2903,15 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    View onCreatePanelView(final NamedSuperCall<View> superCall, final int featureId) {
+    View onCreatePanelView(final CallFun1<View, Integer> superCall, final int featureId) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreatePanelView(featureId);
         }
     }
 
-    void onCreateSupportNavigateUpTaskStack(final NamedSuperCall<Void> superCall,
+    void onCreateSupportNavigateUpTaskStack(
+            final CallVoid1<android.support.v4.app.TaskStackBuilder> superCall,
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2840,59 +2919,60 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onCreateThumbnail(final NamedSuperCall<Boolean> superCall, final Bitmap outBitmap,
-            final Canvas canvas) {
+    boolean onCreateThumbnail(final CallFun2<Boolean, Bitmap, Canvas> superCall,
+            final Bitmap outBitmap, final Canvas canvas) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateThumbnail(outBitmap, canvas);
         }
     }
 
-    View onCreateView(final NamedSuperCall<View> superCall, final View parent, final String name,
-            final Context context, final AttributeSet attrs) {
+    View onCreateView(final CallFun4<View, View, String, Context, AttributeSet> superCall,
+            final View parent, final String name, final Context context, final AttributeSet attrs) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateView(parent, name, context, attrs);
         }
     }
 
-    View onCreateView(final NamedSuperCall<View> superCall, final String name,
-            final Context context, final AttributeSet attrs) {
+    View onCreateView(final CallFun3<View, String, Context, AttributeSet> superCall,
+            final String name, final Context context, final AttributeSet attrs) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateView(name, context, attrs);
         }
     }
 
-    void onDestroy(final NamedSuperCall<Void> superCall) {
+    void onDestroy(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDestroy();
         }
     }
 
-    void onDetachedFromWindow(final NamedSuperCall<Void> superCall) {
+    void onDetachedFromWindow(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDetachedFromWindow();
         }
     }
 
-    void onEnterAnimationComplete(final NamedSuperCall<Void> superCall) {
+    void onEnterAnimationComplete(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onEnterAnimationComplete();
         }
     }
 
-    boolean onGenericMotionEvent(final NamedSuperCall<Boolean> superCall, final MotionEvent event) {
+    boolean onGenericMotionEvent(final CallFun1<Boolean, MotionEvent> superCall,
+            final MotionEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onGenericMotionEvent(event);
         }
     }
 
-    boolean onKeyDown(final NamedSuperCall<Boolean> superCall, final int keyCode,
+    boolean onKeyDown(final CallFun2<Boolean, Integer, KeyEvent> superCall, final int keyCode,
             final KeyEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2900,7 +2980,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onKeyLongPress(final NamedSuperCall<Boolean> superCall, final int keyCode,
+    boolean onKeyLongPress(final CallFun2<Boolean, Integer, KeyEvent> superCall, final int keyCode,
             final KeyEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2908,15 +2988,15 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onKeyMultiple(final NamedSuperCall<Boolean> superCall, final int keyCode,
-            final int repeatCount, final KeyEvent event) {
+    boolean onKeyMultiple(final CallFun3<Boolean, Integer, Integer, KeyEvent> superCall,
+            final int keyCode, final int repeatCount, final KeyEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onKeyMultiple(keyCode, repeatCount, event);
         }
     }
 
-    boolean onKeyShortcut(final NamedSuperCall<Boolean> superCall, final int keyCode,
+    boolean onKeyShortcut(final CallFun2<Boolean, Integer, KeyEvent> superCall, final int keyCode,
             final KeyEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2924,7 +3004,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onKeyUp(final NamedSuperCall<Boolean> superCall, final int keyCode,
+    boolean onKeyUp(final CallFun2<Boolean, Integer, KeyEvent> superCall, final int keyCode,
             final KeyEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2932,14 +3012,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onLowMemory(final NamedSuperCall<Void> superCall) {
+    void onLowMemory(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onLowMemory();
         }
     }
 
-    boolean onMenuOpened(final NamedSuperCall<Boolean> superCall, final int featureId,
+    boolean onMenuOpened(final CallFun2<Boolean, Integer, Menu> superCall, final int featureId,
             final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -2947,64 +3027,67 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onNavigateUp(final NamedSuperCall<Boolean> superCall) {
+    boolean onNavigateUp(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onNavigateUp();
         }
     }
 
-    boolean onNavigateUpFromChild(final NamedSuperCall<Boolean> superCall, final Activity child) {
+    boolean onNavigateUpFromChild(final CallFun1<Boolean, Activity> superCall,
+            final Activity child) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onNavigateUpFromChild(child);
         }
     }
 
-    void onNewIntent(final NamedSuperCall<Void> superCall, final Intent intent) {
+    void onNewIntent(final CallVoid1<Intent> superCall, final Intent intent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onNewIntent(intent);
         }
     }
 
-    boolean onOptionsItemSelected(final NamedSuperCall<Boolean> superCall, final MenuItem item) {
+    boolean onOptionsItemSelected(final CallFun1<Boolean, MenuItem> superCall,
+            final MenuItem item) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onOptionsItemSelected(item);
         }
     }
 
-    void onOptionsMenuClosed(final NamedSuperCall<Void> superCall, final Menu menu) {
+    void onOptionsMenuClosed(final CallVoid1<Menu> superCall, final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onOptionsMenuClosed(menu);
         }
     }
 
-    void onPanelClosed(final NamedSuperCall<Void> superCall, final int featureId, final Menu menu) {
+    void onPanelClosed(final CallVoid2<Integer, Menu> superCall, final int featureId,
+            final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPanelClosed(featureId, menu);
         }
     }
 
-    void onPause(final NamedSuperCall<Void> superCall) {
+    void onPause(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPause();
         }
     }
 
-    void onPostCreate(final NamedSuperCall<Void> superCall, final Bundle savedInstanceState,
-            final PersistableBundle persistentState) {
+    void onPostCreate(final CallVoid2<Bundle, PersistableBundle> superCall,
+            final Bundle savedInstanceState, final PersistableBundle persistentState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPostCreate(savedInstanceState, persistentState);
         }
     }
 
-    void onPostCreate(final NamedSuperCall<Void> superCall,
+    void onPostCreate(final CallVoid1<Bundle> superCall,
             @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3012,29 +3095,30 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onPostResume(final NamedSuperCall<Void> superCall) {
+    void onPostResume(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPostResume();
         }
     }
 
-    void onPrepareDialog(final NamedSuperCall<Void> superCall, final int id, final Dialog dialog) {
+    void onPrepareDialog(final CallVoid2<Integer, Dialog> superCall, final int id,
+            final Dialog dialog) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPrepareDialog(id, dialog);
         }
     }
 
-    void onPrepareDialog(final NamedSuperCall<Void> superCall, final int id, final Dialog dialog,
-            final Bundle args) {
+    void onPrepareDialog(final CallVoid3<Integer, Dialog, Bundle> superCall, final int id,
+            final Dialog dialog, final Bundle args) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPrepareDialog(id, dialog, args);
         }
     }
 
-    void onPrepareNavigateUpTaskStack(final NamedSuperCall<Void> superCall,
+    void onPrepareNavigateUpTaskStack(final CallVoid1<TaskStackBuilder> superCall,
             final TaskStackBuilder builder) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3042,14 +3126,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onPrepareOptionsMenu(final NamedSuperCall<Boolean> superCall, final Menu menu) {
+    boolean onPrepareOptionsMenu(final CallFun1<Boolean, Menu> superCall, final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onPrepareOptionsMenu(menu);
         }
     }
 
-    boolean onPrepareOptionsPanel(final NamedSuperCall<Boolean> superCall, final View view,
+    boolean onPrepareOptionsPanel(final CallFun2<Boolean, View, Menu> superCall, final View view,
             final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3057,15 +3141,16 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onPreparePanel(final NamedSuperCall<Boolean> superCall, final int featureId,
-            final View view, final Menu menu) {
+    boolean onPreparePanel(final CallFun3<Boolean, Integer, View, Menu> superCall,
+            final int featureId, final View view, final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onPreparePanel(featureId, view, menu);
         }
     }
 
-    void onPrepareSupportNavigateUpTaskStack(final NamedSuperCall<Void> superCall,
+    void onPrepareSupportNavigateUpTaskStack(
+            final CallVoid1<android.support.v4.app.TaskStackBuilder> superCall,
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3073,7 +3158,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onProvideAssistContent(final NamedSuperCall<Void> superCall,
+    void onProvideAssistContent(final CallVoid1<AssistContent> superCall,
             final AssistContent outContent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3081,36 +3166,37 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onProvideAssistData(final NamedSuperCall<Void> superCall, final Bundle data) {
+    void onProvideAssistData(final CallVoid1<Bundle> superCall, final Bundle data) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onProvideAssistData(data);
         }
     }
 
-    Uri onProvideReferrer(final NamedSuperCall<Uri> superCall) {
+    Uri onProvideReferrer(final CallFun0<Uri> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onProvideReferrer();
         }
     }
 
-    void onRequestPermissionsResult(final NamedSuperCall<Void> superCall, final int requestCode,
-            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+    void onRequestPermissionsResult(final CallVoid3<Integer, String[], int[]> superCall,
+            final int requestCode, @NonNull final String[] permissions,
+            @NonNull final int[] grantResults) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
 
-    void onRestart(final NamedSuperCall<Void> superCall) {
+    void onRestart(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onRestart();
         }
     }
 
-    void onRestoreInstanceState(final NamedSuperCall<Void> superCall,
+    void onRestoreInstanceState(final CallVoid2<Bundle, PersistableBundle> superCall,
             final Bundle savedInstanceState, final PersistableBundle persistentState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3118,7 +3204,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onRestoreInstanceState(final NamedSuperCall<Void> superCall,
+    void onRestoreInstanceState(final CallVoid1<Bundle> superCall,
             final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3126,36 +3212,36 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onResume(final NamedSuperCall<Void> superCall) {
+    void onResume(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onResume();
         }
     }
 
-    void onResumeFragments(final NamedSuperCall<Void> superCall) {
+    void onResumeFragments(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onResumeFragments();
         }
     }
 
-    void onSaveInstanceState(final NamedSuperCall<Void> superCall, final Bundle outState,
-            final PersistableBundle outPersistentState) {
+    void onSaveInstanceState(final CallVoid2<Bundle, PersistableBundle> superCall,
+            final Bundle outState, final PersistableBundle outPersistentState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onSaveInstanceState(outState, outPersistentState);
         }
     }
 
-    void onSaveInstanceState(final NamedSuperCall<Void> superCall, final Bundle outState) {
+    void onSaveInstanceState(final CallVoid1<Bundle> superCall, final Bundle outState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onSaveInstanceState(outState);
         }
     }
 
-    boolean onSearchRequested(final NamedSuperCall<Boolean> superCall,
+    boolean onSearchRequested(final CallFun1<Boolean, SearchEvent> superCall,
             final SearchEvent searchEvent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3163,35 +3249,35 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onSearchRequested(final NamedSuperCall<Boolean> superCall) {
+    boolean onSearchRequested(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onSearchRequested();
         }
     }
 
-    void onStart(final NamedSuperCall<Void> superCall) {
+    void onStart(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onStart();
         }
     }
 
-    void onStateNotSaved(final NamedSuperCall<Void> superCall) {
+    void onStateNotSaved(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onStateNotSaved();
         }
     }
 
-    void onStop(final NamedSuperCall<Void> superCall) {
+    void onStop(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onStop();
         }
     }
 
-    void onSupportActionModeFinished(final NamedSuperCall<Void> superCall,
+    void onSupportActionModeFinished(final CallVoid1<ActionMode> superCall,
             @NonNull final ActionMode mode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3199,7 +3285,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onSupportActionModeStarted(final NamedSuperCall<Void> superCall,
+    void onSupportActionModeStarted(final CallVoid1<ActionMode> superCall,
             @NonNull final ActionMode mode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3207,21 +3293,21 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onSupportContentChanged(final NamedSuperCall<Void> superCall) {
+    void onSupportContentChanged(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onSupportContentChanged();
         }
     }
 
-    boolean onSupportNavigateUp(final NamedSuperCall<Boolean> superCall) {
+    boolean onSupportNavigateUp(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onSupportNavigateUp();
         }
     }
 
-    void onTitleChanged(final NamedSuperCall<Void> superCall, final CharSequence title,
+    void onTitleChanged(final CallVoid2<CharSequence, Integer> superCall, final CharSequence title,
             final int color) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3229,49 +3315,50 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean onTouchEvent(final NamedSuperCall<Boolean> superCall, final MotionEvent event) {
+    boolean onTouchEvent(final CallFun1<Boolean, MotionEvent> superCall, final MotionEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onTouchEvent(event);
         }
     }
 
-    boolean onTrackballEvent(final NamedSuperCall<Boolean> superCall, final MotionEvent event) {
+    boolean onTrackballEvent(final CallFun1<Boolean, MotionEvent> superCall,
+            final MotionEvent event) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onTrackballEvent(event);
         }
     }
 
-    void onTrimMemory(final NamedSuperCall<Void> superCall, final int level) {
+    void onTrimMemory(final CallVoid1<Integer> superCall, final int level) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onTrimMemory(level);
         }
     }
 
-    void onUserInteraction(final NamedSuperCall<Void> superCall) {
+    void onUserInteraction(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onUserInteraction();
         }
     }
 
-    void onUserLeaveHint(final NamedSuperCall<Void> superCall) {
+    void onUserLeaveHint(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onUserLeaveHint();
         }
     }
 
-    void onVisibleBehindCanceled(final NamedSuperCall<Void> superCall) {
+    void onVisibleBehindCanceled(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onVisibleBehindCanceled();
         }
     }
 
-    void onWindowAttributesChanged(final NamedSuperCall<Void> superCall,
+    void onWindowAttributesChanged(final CallVoid1<WindowManager.LayoutParams> superCall,
             final WindowManager.LayoutParams params) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3279,7 +3366,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void onWindowFocusChanged(final NamedSuperCall<Void> superCall, final boolean hasFocus) {
+    void onWindowFocusChanged(final CallVoid1<Boolean> superCall, final boolean hasFocus) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onWindowFocusChanged(hasFocus);
@@ -3287,7 +3374,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
     }
 
     android.view.ActionMode onWindowStartingActionMode(
-            final NamedSuperCall<android.view.ActionMode> superCall,
+            final CallFun1<android.view.ActionMode, android.view.ActionMode.Callback> superCall,
             final android.view.ActionMode.Callback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3296,7 +3383,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
     }
 
     android.view.ActionMode onWindowStartingActionMode(
-            final NamedSuperCall<android.view.ActionMode> superCall,
+            final CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer> superCall,
             final android.view.ActionMode.Callback callback, final int type) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3304,7 +3391,8 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    ActionMode onWindowStartingSupportActionMode(final NamedSuperCall<ActionMode> superCall,
+    ActionMode onWindowStartingSupportActionMode(
+            final CallFun1<ActionMode, ActionMode.Callback> superCall,
             @NonNull final ActionMode.Callback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3312,14 +3400,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void openContextMenu(final NamedSuperCall<Void> superCall, final View view) {
+    void openContextMenu(final CallVoid1<View> superCall, final View view) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             openContextMenu(view);
         }
     }
 
-    FileInputStream openFileInput(final NamedSuperCall<FileInputStream> superCall,
+    FileInputStream openFileInput(final CallFun1<FileInputStream, String> superCall,
             final String name) throws FileNotFoundException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3327,7 +3415,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    FileOutputStream openFileOutput(final NamedSuperCall<FileOutputStream> superCall,
+    FileOutputStream openFileOutput(final CallFun2<FileOutputStream, String, Integer> superCall,
             final String name, final int mode) throws FileNotFoundException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3335,14 +3423,15 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void openOptionsMenu(final NamedSuperCall<Void> superCall) {
+    void openOptionsMenu(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             openOptionsMenu();
         }
     }
 
-    SQLiteDatabase openOrCreateDatabase(final NamedSuperCall<SQLiteDatabase> superCall,
+    SQLiteDatabase openOrCreateDatabase(
+            final CallFun3<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory> superCall,
             final String name, final int mode, final SQLiteDatabase.CursorFactory factory) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3350,7 +3439,8 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    SQLiteDatabase openOrCreateDatabase(final NamedSuperCall<SQLiteDatabase> superCall,
+    SQLiteDatabase openOrCreateDatabase(
+            final CallFun4<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler> superCall,
             final String name, final int mode, final SQLiteDatabase.CursorFactory factory,
             final DatabaseErrorHandler errorHandler) {
         synchronized (mSuperListeners) {
@@ -3359,7 +3449,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void overridePendingTransition(final NamedSuperCall<Void> superCall, final int enterAnim,
+    void overridePendingTransition(final CallVoid2<Integer, Integer> superCall, final int enterAnim,
             final int exitAnim) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3367,28 +3457,28 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    Drawable peekWallpaper(final NamedSuperCall<Drawable> superCall) {
+    Drawable peekWallpaper(final CallFun0<Drawable> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return peekWallpaper();
         }
     }
 
-    void postponeEnterTransition(final NamedSuperCall<Void> superCall) {
+    void postponeEnterTransition(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             postponeEnterTransition();
         }
     }
 
-    void recreate(final NamedSuperCall<Void> superCall) {
+    void recreate(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             recreate();
         }
     }
 
-    void registerComponentCallbacks(final NamedSuperCall<Void> superCall,
+    void registerComponentCallbacks(final CallVoid1<ComponentCallbacks> superCall,
             final ComponentCallbacks callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3396,14 +3486,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void registerForContextMenu(final NamedSuperCall<Void> superCall, final View view) {
+    void registerForContextMenu(final CallVoid1<View> superCall, final View view) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             registerForContextMenu(view);
         }
     }
 
-    Intent registerReceiver(final NamedSuperCall<Intent> superCall,
+    Intent registerReceiver(final CallFun2<Intent, BroadcastReceiver, IntentFilter> superCall,
             final BroadcastReceiver receiver, final IntentFilter filter) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3411,7 +3501,8 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    Intent registerReceiver(final NamedSuperCall<Intent> superCall,
+    Intent registerReceiver(
+            final CallFun4<Intent, BroadcastReceiver, IntentFilter, String, Handler> superCall,
             final BroadcastReceiver receiver, final IntentFilter filter,
             final String broadcastPermission, final Handler scheduler) {
         synchronized (mSuperListeners) {
@@ -3420,43 +3511,44 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean releaseInstance(final NamedSuperCall<Boolean> superCall) {
+    boolean releaseInstance(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return releaseInstance();
         }
     }
 
-    void removeStickyBroadcast(final NamedSuperCall<Void> superCall, final Intent intent) {
+    void removeStickyBroadcast(final CallVoid1<Intent> superCall, final Intent intent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             removeStickyBroadcast(intent);
         }
     }
 
-    void removeStickyBroadcastAsUser(final NamedSuperCall<Void> superCall, final Intent intent,
-            final UserHandle user) {
+    void removeStickyBroadcastAsUser(final CallVoid2<Intent, UserHandle> superCall,
+            final Intent intent, final UserHandle user) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             removeStickyBroadcastAsUser(intent, user);
         }
     }
 
-    void reportFullyDrawn(final NamedSuperCall<Void> superCall) {
+    void reportFullyDrawn(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             reportFullyDrawn();
         }
     }
 
-    boolean requestVisibleBehind(final NamedSuperCall<Boolean> superCall, final boolean visible) {
+    boolean requestVisibleBehind(final CallFun1<Boolean, Boolean> superCall,
+            final boolean visible) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return requestVisibleBehind(visible);
         }
     }
 
-    void revokeUriPermission(final NamedSuperCall<Void> superCall, final Uri uri,
+    void revokeUriPermission(final CallVoid2<Uri, Integer> superCall, final Uri uri,
             final int modeFlags) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3464,14 +3556,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void sendBroadcast(final NamedSuperCall<Void> superCall, final Intent intent) {
+    void sendBroadcast(final CallVoid1<Intent> superCall, final Intent intent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             sendBroadcast(intent);
         }
     }
 
-    void sendBroadcast(final NamedSuperCall<Void> superCall, final Intent intent,
+    void sendBroadcast(final CallVoid2<Intent, String> superCall, final Intent intent,
             final String receiverPermission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3479,7 +3571,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void sendBroadcastAsUser(final NamedSuperCall<Void> superCall, final Intent intent,
+    void sendBroadcastAsUser(final CallVoid2<Intent, UserHandle> superCall, final Intent intent,
             final UserHandle user) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3487,15 +3579,15 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void sendBroadcastAsUser(final NamedSuperCall<Void> superCall, final Intent intent,
-            final UserHandle user, final String receiverPermission) {
+    void sendBroadcastAsUser(final CallVoid3<Intent, UserHandle, String> superCall,
+            final Intent intent, final UserHandle user, final String receiverPermission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             sendBroadcastAsUser(intent, user, receiverPermission);
         }
     }
 
-    void sendOrderedBroadcast(final NamedSuperCall<Void> superCall, final Intent intent,
+    void sendOrderedBroadcast(final CallVoid2<Intent, String> superCall, final Intent intent,
             final String receiverPermission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3503,10 +3595,11 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void sendOrderedBroadcast(final NamedSuperCall<Void> superCall, final Intent intent,
-            final String receiverPermission, final BroadcastReceiver resultReceiver,
-            final Handler scheduler, final int initialCode, final String initialData,
-            final Bundle initialExtras) {
+    void sendOrderedBroadcast(
+            final CallVoid7<Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle> superCall,
+            final Intent intent, final String receiverPermission,
+            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
+            final String initialData, final Bundle initialExtras) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             sendOrderedBroadcast(intent, receiverPermission, resultReceiver, scheduler, initialCode,
@@ -3514,8 +3607,9 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void sendOrderedBroadcastAsUser(final NamedSuperCall<Void> superCall, final Intent intent,
-            final UserHandle user, final String receiverPermission,
+    void sendOrderedBroadcastAsUser(
+            final CallVoid8<Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle> superCall,
+            final Intent intent, final UserHandle user, final String receiverPermission,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
         synchronized (mSuperListeners) {
@@ -3525,24 +3619,25 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void sendStickyBroadcast(final NamedSuperCall<Void> superCall, final Intent intent) {
+    void sendStickyBroadcast(final CallVoid1<Intent> superCall, final Intent intent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             sendStickyBroadcast(intent);
         }
     }
 
-    void sendStickyBroadcastAsUser(final NamedSuperCall<Void> superCall, final Intent intent,
-            final UserHandle user) {
+    void sendStickyBroadcastAsUser(final CallVoid2<Intent, UserHandle> superCall,
+            final Intent intent, final UserHandle user) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             sendStickyBroadcastAsUser(intent, user);
         }
     }
 
-    void sendStickyOrderedBroadcast(final NamedSuperCall<Void> superCall, final Intent intent,
-            final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
-            final String initialData, final Bundle initialExtras) {
+    void sendStickyOrderedBroadcast(
+            final CallVoid6<Intent, BroadcastReceiver, Handler, Integer, String, Bundle> superCall,
+            final Intent intent, final BroadcastReceiver resultReceiver, final Handler scheduler,
+            final int initialCode, final String initialData, final Bundle initialExtras) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             sendStickyOrderedBroadcast(intent, resultReceiver, scheduler, initialCode, initialData,
@@ -3550,9 +3645,11 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void sendStickyOrderedBroadcastAsUser(final NamedSuperCall<Void> superCall, final Intent intent,
-            final UserHandle user, final BroadcastReceiver resultReceiver, final Handler scheduler,
-            final int initialCode, final String initialData, final Bundle initialExtras) {
+    void sendStickyOrderedBroadcastAsUser(
+            final CallVoid7<Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle> superCall,
+            final Intent intent, final UserHandle user, final BroadcastReceiver resultReceiver,
+            final Handler scheduler, final int initialCode, final String initialData,
+            final Bundle initialExtras) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             sendStickyOrderedBroadcastAsUser(intent, user, resultReceiver, scheduler, initialCode,
@@ -3560,14 +3657,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setActionBar(final NamedSuperCall<Void> superCall, final Toolbar toolbar) {
+    void setActionBar(final CallVoid1<Toolbar> superCall, final Toolbar toolbar) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setActionBar(toolbar);
         }
     }
 
-    void setContentTransitionManager(final NamedSuperCall<Void> superCall,
+    void setContentTransitionManager(final CallVoid1<TransitionManager> superCall,
             final TransitionManager tm) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3575,21 +3672,21 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setContentView(final NamedSuperCall<Void> superCall, @LayoutRes final int layoutResID) {
+    void setContentView(final CallVoid1<Integer> superCall, @LayoutRes final int layoutResID) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setContentView(layoutResID);
         }
     }
 
-    void setContentView(final NamedSuperCall<Void> superCall, final View view) {
+    void setContentView(final CallVoid1<View> superCall, final View view) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setContentView(view);
         }
     }
 
-    void setContentView(final NamedSuperCall<Void> superCall, final View view,
+    void setContentView(final CallVoid2<View, ViewGroup.LayoutParams> superCall, final View view,
             final ViewGroup.LayoutParams params) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3597,7 +3694,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setEnterSharedElementCallback(final NamedSuperCall<Void> superCall,
+    void setEnterSharedElementCallback(final CallVoid1<SharedElementCallback> superCall,
             final SharedElementCallback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3605,7 +3702,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setEnterSharedElementCallback(final NamedSuperCall<Void> superCall,
+    void setEnterSharedElementCallback(final CallVoid1<android.app.SharedElementCallback> superCall,
             final android.app.SharedElementCallback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3613,7 +3710,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setExitSharedElementCallback(final NamedSuperCall<Void> superCall,
+    void setExitSharedElementCallback(final CallVoid1<SharedElementCallback> superCall,
             final SharedElementCallback listener) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3621,7 +3718,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setExitSharedElementCallback(final NamedSuperCall<Void> superCall,
+    void setExitSharedElementCallback(final CallVoid1<android.app.SharedElementCallback> superCall,
             final android.app.SharedElementCallback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3629,28 +3726,28 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setFinishOnTouchOutside(final NamedSuperCall<Void> superCall, final boolean finish) {
+    void setFinishOnTouchOutside(final CallVoid1<Boolean> superCall, final boolean finish) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setFinishOnTouchOutside(finish);
         }
     }
 
-    void setImmersive(final NamedSuperCall<Void> superCall, final boolean i) {
+    void setImmersive(final CallVoid1<Boolean> superCall, final boolean i) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setImmersive(i);
         }
     }
 
-    void setIntent(final NamedSuperCall<Void> superCall, final Intent newIntent) {
+    void setIntent(final CallVoid1<Intent> superCall, final Intent newIntent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setIntent(newIntent);
         }
     }
 
-    void setRequestedOrientation(final NamedSuperCall<Void> superCall,
+    void setRequestedOrientation(final CallVoid1<Integer> superCall,
             final int requestedOrientation) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3658,7 +3755,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setSupportActionBar(final NamedSuperCall<Void> superCall,
+    void setSupportActionBar(final CallVoid1<android.support.v7.widget.Toolbar> superCall,
             @Nullable final android.support.v7.widget.Toolbar toolbar) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3666,14 +3763,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setSupportProgress(final NamedSuperCall<Void> superCall, final int progress) {
+    void setSupportProgress(final CallVoid1<Integer> superCall, final int progress) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setSupportProgress(progress);
         }
     }
 
-    void setSupportProgressBarIndeterminate(final NamedSuperCall<Void> superCall,
+    void setSupportProgressBarIndeterminate(final CallVoid1<Boolean> superCall,
             final boolean indeterminate) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3681,7 +3778,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setSupportProgressBarIndeterminateVisibility(final NamedSuperCall<Void> superCall,
+    void setSupportProgressBarIndeterminateVisibility(final CallVoid1<Boolean> superCall,
             final boolean visible) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3689,7 +3786,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setSupportProgressBarVisibility(final NamedSuperCall<Void> superCall,
+    void setSupportProgressBarVisibility(final CallVoid1<Boolean> superCall,
             final boolean visible) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3697,7 +3794,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setTaskDescription(final NamedSuperCall<Void> superCall,
+    void setTaskDescription(final CallVoid1<ActivityManager.TaskDescription> superCall,
             final ActivityManager.TaskDescription taskDescription) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3705,50 +3802,49 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void setTheme(final NamedSuperCall<Void> superCall, @StyleRes final int resid) {
+    void setTheme(final CallVoid1<Integer> superCall, @StyleRes final int resid) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setTheme(resid);
         }
     }
 
-    void setTitle(final NamedSuperCall<Void> superCall, final CharSequence title) {
+    void setTitle(final CallVoid1<CharSequence> superCall, final CharSequence title) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setTitle(title);
         }
     }
 
-    void setTitle(final NamedSuperCall<Void> superCall, final int titleId) {
+    void setTitle(final CallVoid1<Integer> superCall, final int titleId) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setTitle(titleId);
         }
     }
 
-    void setTitleColor(final NamedSuperCall<Void> superCall, final int textColor) {
+    void setTitleColor(final CallVoid1<Integer> superCall, final int textColor) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setTitleColor(textColor);
         }
     }
 
-    void setVisible(final NamedSuperCall<Void> superCall, final boolean visible) {
+    void setVisible(final CallVoid1<Boolean> superCall, final boolean visible) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setVisible(visible);
         }
     }
 
-    void setWallpaper(final NamedSuperCall<Void> superCall, final Bitmap bitmap)
-            throws IOException {
+    void setWallpaper(final CallVoid1<Bitmap> superCall, final Bitmap bitmap) throws IOException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setWallpaper(bitmap);
         }
     }
 
-    void setWallpaper(final NamedSuperCall<Void> superCall, final InputStream data)
+    void setWallpaper(final CallVoid1<InputStream> superCall, final InputStream data)
             throws IOException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3756,7 +3852,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean shouldShowRequestPermissionRationale(final NamedSuperCall<Boolean> superCall,
+    boolean shouldShowRequestPermissionRationale(final CallFun1<Boolean, String> superCall,
             final String permission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3764,7 +3860,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean shouldUpRecreateTask(final NamedSuperCall<Boolean> superCall,
+    boolean shouldUpRecreateTask(final CallFun1<Boolean, Intent> superCall,
             final Intent targetIntent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3772,21 +3868,22 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean showAssist(final NamedSuperCall<Boolean> superCall, final Bundle args) {
+    boolean showAssist(final CallFun1<Boolean, Bundle> superCall, final Bundle args) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return showAssist(args);
         }
     }
 
-    void showLockTaskEscapeMessage(final NamedSuperCall<Void> superCall) {
+    void showLockTaskEscapeMessage(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             showLockTaskEscapeMessage();
         }
     }
 
-    android.view.ActionMode startActionMode(final NamedSuperCall<android.view.ActionMode> superCall,
+    android.view.ActionMode startActionMode(
+            final CallFun1<android.view.ActionMode, android.view.ActionMode.Callback> superCall,
             final android.view.ActionMode.Callback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3794,7 +3891,8 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    android.view.ActionMode startActionMode(final NamedSuperCall<android.view.ActionMode> superCall,
+    android.view.ActionMode startActionMode(
+            final CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer> superCall,
             final android.view.ActionMode.Callback callback, final int type) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3802,14 +3900,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startActivities(final NamedSuperCall<Void> superCall, final Intent[] intents) {
+    void startActivities(final CallVoid1<Intent[]> superCall, final Intent[] intents) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivities(intents);
         }
     }
 
-    void startActivities(final NamedSuperCall<Void> superCall, final Intent[] intents,
+    void startActivities(final CallVoid2<Intent[], Bundle> superCall, final Intent[] intents,
             final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3817,14 +3915,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startActivity(final NamedSuperCall<Void> superCall, final Intent intent) {
+    void startActivity(final CallVoid1<Intent> superCall, final Intent intent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivity(intent);
         }
     }
 
-    void startActivity(final NamedSuperCall<Void> superCall, final Intent intent,
+    void startActivity(final CallVoid2<Intent, Bundle> superCall, final Intent intent,
             final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3832,7 +3930,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startActivityForResult(final NamedSuperCall<Void> superCall, final Intent intent,
+    void startActivityForResult(final CallVoid2<Intent, Integer> superCall, final Intent intent,
             final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3840,47 +3938,49 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startActivityForResult(final NamedSuperCall<Void> superCall, final Intent intent,
-            final int requestCode, final Bundle options) {
+    void startActivityForResult(final CallVoid3<Intent, Integer, Bundle> superCall,
+            final Intent intent, final int requestCode, final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivityForResult(intent, requestCode, options);
         }
     }
 
-    void startActivityFromChild(final NamedSuperCall<Void> superCall, final Activity child,
-            final Intent intent, final int requestCode) {
+    void startActivityFromChild(final CallVoid3<Activity, Intent, Integer> superCall,
+            final Activity child, final Intent intent, final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivityFromChild(child, intent, requestCode);
         }
     }
 
-    void startActivityFromChild(final NamedSuperCall<Void> superCall, final Activity child,
-            final Intent intent, final int requestCode, final Bundle options) {
+    void startActivityFromChild(final CallVoid4<Activity, Intent, Integer, Bundle> superCall,
+            final Activity child, final Intent intent, final int requestCode,
+            final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivityFromChild(child, intent, requestCode, options);
         }
     }
 
-    void startActivityFromFragment(final NamedSuperCall<Void> superCall, final Fragment fragment,
-            final Intent intent, final int requestCode) {
+    void startActivityFromFragment(final CallVoid3<Fragment, Intent, Integer> superCall,
+            final Fragment fragment, final Intent intent, final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivityFromFragment(fragment, intent, requestCode);
         }
     }
 
-    void startActivityFromFragment(final NamedSuperCall<Void> superCall, final Fragment fragment,
-            final Intent intent, final int requestCode, @Nullable final Bundle options) {
+    void startActivityFromFragment(final CallVoid4<Fragment, Intent, Integer, Bundle> superCall,
+            final Fragment fragment, final Intent intent, final int requestCode,
+            @Nullable final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivityFromFragment(fragment, intent, requestCode, options);
         }
     }
 
-    void startActivityFromFragment(final NamedSuperCall<Void> superCall,
+    void startActivityFromFragment(final CallVoid3<android.app.Fragment, Intent, Integer> superCall,
             final android.app.Fragment fragment, final Intent intent, final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3888,7 +3988,8 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startActivityFromFragment(final NamedSuperCall<Void> superCall,
+    void startActivityFromFragment(
+            final CallVoid4<android.app.Fragment, Intent, Integer, Bundle> superCall,
             final android.app.Fragment fragment, final Intent intent, final int requestCode,
             final Bundle options) {
         synchronized (mSuperListeners) {
@@ -3897,23 +3998,23 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean startActivityIfNeeded(final NamedSuperCall<Boolean> superCall, final Intent intent,
-            final int requestCode) {
+    boolean startActivityIfNeeded(final CallFun2<Boolean, Intent, Integer> superCall,
+            final Intent intent, final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return startActivityIfNeeded(intent, requestCode);
         }
     }
 
-    boolean startActivityIfNeeded(final NamedSuperCall<Boolean> superCall, final Intent intent,
-            final int requestCode, final Bundle options) {
+    boolean startActivityIfNeeded(final CallFun3<Boolean, Intent, Integer, Bundle> superCall,
+            final Intent intent, final int requestCode, final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return startActivityIfNeeded(intent, requestCode, options);
         }
     }
 
-    boolean startInstrumentation(final NamedSuperCall<Boolean> superCall,
+    boolean startInstrumentation(final CallFun3<Boolean, ComponentName, String, Bundle> superCall,
             final ComponentName className, final String profileFile, final Bundle arguments) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3921,27 +4022,32 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startIntentSender(final NamedSuperCall<Void> superCall, final IntentSender intent,
-            final Intent fillInIntent, final int flagsMask, final int flagsValues,
-            final int extraFlags) throws IntentSender.SendIntentException {
+    void startIntentSender(
+            final CallVoid5<IntentSender, Intent, Integer, Integer, Integer> superCall,
+            final IntentSender intent, final Intent fillInIntent, final int flagsMask,
+            final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startIntentSender(intent, fillInIntent, flagsMask, flagsValues, extraFlags);
         }
     }
 
-    void startIntentSender(final NamedSuperCall<Void> superCall, final IntentSender intent,
-            final Intent fillInIntent, final int flagsMask, final int flagsValues,
-            final int extraFlags, final Bundle options) throws IntentSender.SendIntentException {
+    void startIntentSender(
+            final CallVoid6<IntentSender, Intent, Integer, Integer, Integer, Bundle> superCall,
+            final IntentSender intent, final Intent fillInIntent, final int flagsMask,
+            final int flagsValues, final int extraFlags, final Bundle options)
+            throws IntentSender.SendIntentException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startIntentSender(intent, fillInIntent, flagsMask, flagsValues, extraFlags, options);
         }
     }
 
-    void startIntentSenderForResult(final NamedSuperCall<Void> superCall, final IntentSender intent,
-            final int requestCode, final Intent fillInIntent, final int flagsMask,
-            final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException {
+    void startIntentSenderForResult(
+            final CallVoid6<IntentSender, Integer, Intent, Integer, Integer, Integer> superCall,
+            final IntentSender intent, final int requestCode, final Intent fillInIntent,
+            final int flagsMask, final int flagsValues, final int extraFlags)
+            throws IntentSender.SendIntentException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask, flagsValues,
@@ -3949,9 +4055,10 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startIntentSenderForResult(final NamedSuperCall<Void> superCall, final IntentSender intent,
-            final int requestCode, final Intent fillInIntent, final int flagsMask,
-            final int flagsValues, final int extraFlags, final Bundle options)
+    void startIntentSenderForResult(
+            final CallVoid7<IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle> superCall,
+            final IntentSender intent, final int requestCode, final Intent fillInIntent,
+            final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -3960,10 +4067,11 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startIntentSenderFromChild(final NamedSuperCall<Void> superCall, final Activity child,
-            final IntentSender intent, final int requestCode, final Intent fillInIntent,
-            final int flagsMask, final int flagsValues, final int extraFlags)
-            throws IntentSender.SendIntentException {
+    void startIntentSenderFromChild(
+            final CallVoid7<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer> superCall,
+            final Activity child, final IntentSender intent, final int requestCode,
+            final Intent fillInIntent, final int flagsMask, final int flagsValues,
+            final int extraFlags) throws IntentSender.SendIntentException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startIntentSenderFromChild(child, intent, requestCode, fillInIntent, flagsMask,
@@ -3971,10 +4079,11 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startIntentSenderFromChild(final NamedSuperCall<Void> superCall, final Activity child,
-            final IntentSender intent, final int requestCode, final Intent fillInIntent,
-            final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
-            throws IntentSender.SendIntentException {
+    void startIntentSenderFromChild(
+            final CallVoid8<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle> superCall,
+            final Activity child, final IntentSender intent, final int requestCode,
+            final Intent fillInIntent, final int flagsMask, final int flagsValues,
+            final int extraFlags, final Bundle options) throws IntentSender.SendIntentException {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startIntentSenderFromChild(child, intent, requestCode, fillInIntent, flagsMask,
@@ -3982,21 +4091,21 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void startLockTask(final NamedSuperCall<Void> superCall) {
+    void startLockTask(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startLockTask();
         }
     }
 
-    void startManagingCursor(final NamedSuperCall<Void> superCall, final Cursor c) {
+    void startManagingCursor(final CallVoid1<Cursor> superCall, final Cursor c) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startManagingCursor(c);
         }
     }
 
-    boolean startNextMatchingActivity(final NamedSuperCall<Boolean> superCall,
+    boolean startNextMatchingActivity(final CallFun1<Boolean, Intent> superCall,
             final Intent intent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4004,23 +4113,23 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean startNextMatchingActivity(final NamedSuperCall<Boolean> superCall, final Intent intent,
-            final Bundle options) {
+    boolean startNextMatchingActivity(final CallFun2<Boolean, Intent, Bundle> superCall,
+            final Intent intent, final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return startNextMatchingActivity(intent, options);
         }
     }
 
-    void startPostponedEnterTransition(final NamedSuperCall<Void> superCall) {
+    void startPostponedEnterTransition(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startPostponedEnterTransition();
         }
     }
 
-    void startSearch(final NamedSuperCall<Void> superCall, final String initialQuery,
-            final boolean selectInitialQuery, final Bundle appSearchData,
+    void startSearch(final CallVoid4<String, Boolean, Bundle, Boolean> superCall,
+            final String initialQuery, final boolean selectInitialQuery, final Bundle appSearchData,
             final boolean globalSearch) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4028,7 +4137,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    ComponentName startService(final NamedSuperCall<ComponentName> superCall,
+    ComponentName startService(final CallFun1<ComponentName, Intent> superCall,
             final Intent service) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4036,7 +4145,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    ActionMode startSupportActionMode(final NamedSuperCall<ActionMode> superCall,
+    ActionMode startSupportActionMode(final CallFun1<ActionMode, ActionMode.Callback> superCall,
             @NonNull final ActionMode.Callback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4044,56 +4153,56 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void stopLockTask(final NamedSuperCall<Void> superCall) {
+    void stopLockTask(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             stopLockTask();
         }
     }
 
-    void stopManagingCursor(final NamedSuperCall<Void> superCall, final Cursor c) {
+    void stopManagingCursor(final CallVoid1<Cursor> superCall, final Cursor c) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             stopManagingCursor(c);
         }
     }
 
-    boolean stopService(final NamedSuperCall<Boolean> superCall, final Intent name) {
+    boolean stopService(final CallFun1<Boolean, Intent> superCall, final Intent name) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return stopService(name);
         }
     }
 
-    void supportFinishAfterTransition(final NamedSuperCall<Void> superCall) {
+    void supportFinishAfterTransition(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             supportFinishAfterTransition();
         }
     }
 
-    void supportInvalidateOptionsMenu(final NamedSuperCall<Void> superCall) {
+    void supportInvalidateOptionsMenu(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             supportInvalidateOptionsMenu();
         }
     }
 
-    void supportNavigateUpTo(final NamedSuperCall<Void> superCall, @NonNull final Intent upIntent) {
+    void supportNavigateUpTo(final CallVoid1<Intent> superCall, @NonNull final Intent upIntent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             supportNavigateUpTo(upIntent);
         }
     }
 
-    void supportPostponeEnterTransition(final NamedSuperCall<Void> superCall) {
+    void supportPostponeEnterTransition(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             supportPostponeEnterTransition();
         }
     }
 
-    boolean supportRequestWindowFeature(final NamedSuperCall<Boolean> superCall,
+    boolean supportRequestWindowFeature(final CallFun1<Boolean, Integer> superCall,
             final int featureId) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4101,7 +4210,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    boolean supportShouldUpRecreateTask(final NamedSuperCall<Boolean> superCall,
+    boolean supportShouldUpRecreateTask(final CallFun1<Boolean, Intent> superCall,
             @NonNull final Intent targetIntent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4109,21 +4218,21 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void supportStartPostponedEnterTransition(final NamedSuperCall<Void> superCall) {
+    void supportStartPostponedEnterTransition(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             supportStartPostponedEnterTransition();
         }
     }
 
-    void takeKeyEvents(final NamedSuperCall<Void> superCall, final boolean get) {
+    void takeKeyEvents(final CallVoid1<Boolean> superCall, final boolean get) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             takeKeyEvents(get);
         }
     }
 
-    void triggerSearch(final NamedSuperCall<Void> superCall, final String query,
+    void triggerSearch(final CallVoid2<String, Bundle> superCall, final String query,
             final Bundle appSearchData) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4131,14 +4240,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void unbindService(final NamedSuperCall<Void> superCall, final ServiceConnection conn) {
+    void unbindService(final CallVoid1<ServiceConnection> superCall, final ServiceConnection conn) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             unbindService(conn);
         }
     }
 
-    void unregisterComponentCallbacks(final NamedSuperCall<Void> superCall,
+    void unregisterComponentCallbacks(final CallVoid1<ComponentCallbacks> superCall,
             final ComponentCallbacks callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -4146,14 +4255,14 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         }
     }
 
-    void unregisterForContextMenu(final NamedSuperCall<Void> superCall, final View view) {
+    void unregisterForContextMenu(final CallVoid1<View> superCall, final View view) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             unregisterForContextMenu(view);
         }
     }
 
-    void unregisterReceiver(final NamedSuperCall<Void> superCall,
+    void unregisterReceiver(final CallVoid1<BroadcastReceiver> superCall,
             final BroadcastReceiver receiver) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractDelegate.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractDelegate.java
@@ -1,10 +1,6 @@
 package com.pascalwelsch.compositeandroid.core;
 
-import android.support.annotation.NonNull;
-
 import java.util.List;
-import java.util.ListIterator;
-import java.util.Stack;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -13,91 +9,9 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class AbstractDelegate<T, P extends AbstractPlugin> {
 
-    public static abstract class ObjectPool<O> {
-
-        private int mMaxSize;
-
-        private Stack<O> pool = new Stack<>();
-
-        public ObjectPool(final int maxSize) {
-            mMaxSize = maxSize;
-        }
-
-        public void clear() {
-            pool.clear();
-        }
-
-        public O get() {
-            if (pool.isEmpty()) {
-                return newItem();
-            } else {
-                return pool.pop();
-            }
-        }
-
-        public void returnItem(final O iterator) {
-            if (pool.size() < mMaxSize) {
-                pool.push(iterator);
-            }
-        }
-
-        protected abstract O newItem();
-    }
-
-
     protected final T mOriginal;
 
     protected List<P> mPlugins = new CopyOnWriteArrayList<>();
-
-/*    protected IteratorPool<ListIterator<P>> mIteratorPool = new IteratorPool<ListIterator<P>>(10) {
-
-        @Override
-        protected ListIterator<P> newItem() {
-            return mPlugins.listIterator(mPlugins.size());
-        }
-    };*/
-/*    private IteratorPool<CachedNamedSuperCall> mSuperPool = new IteratorPool<CachedNamedSuperCall>(10){
-
-        @Override
-        protected CachedNamedSuperCall newItem() {
-            return new CachedNamedSuperCall();
-        }
-
-        @Override
-        public void returnItem(final CachedNamedSuperCall iterator) {
-            super.returnItem(iterator);
-            iterator.unbind();
-        }
-    };*/
-
-/*    private class CachedNamedSuperCall<R> extends NamedSuperCall<R> {
-
-        private SuperCall<R> mActivitySuper;
-
-        private PluginCall<P, R> mMethodCall;
-
-        public CachedNamedSuperCall() {
-            super(null);
-        }
-
-        public void bind(final String methodName,
-                final PluginCall<P, R> methodCall, final SuperCall<R> activitySuper){
-            setMethodName(methodName);
-            mMethodCall = methodCall;
-            mActivitySuper = activitySuper;
-        }
-
-        public void unbind(){
-            setMethodName(null);
-            mMethodCall = null;
-            mActivitySuper = null;
-        }
-
-        @Override
-        public R call(final Object... args) {
-            return callFunction(getMethodName(), mMethodCall, mActivitySuper, args);
-        }
-    }*/
 
     public AbstractDelegate(final T original) {
         mOriginal = original;
@@ -121,69 +35,4 @@ public class AbstractDelegate<T, P extends AbstractPlugin> {
         return mOriginal;
     }
 
-    @NonNull
-    protected <R> R callFunction(final String methodName,
-            final PluginCall<P, R> methodCall, final SuperCall<R> activitySuper,
-            final Object... args) {
-        if (mPlugins.isEmpty()) {
-            return activitySuper.call(args);
-        }
-
-        final ListIterator<P> iterator = mPlugins.listIterator(mPlugins.size());
-        final R r = callFunction(iterator, methodName, methodCall, activitySuper, args);
-        return r;
-    }
-
-    @NonNull
-    protected <R> R callFunction(final ListIterator<P> iterator,
-            final String methodName,
-            final PluginCall<P, R> methodCall, final SuperCall<R> activitySuper,
-            final Object... args) {
-
-        if (iterator.hasPrevious()) {
-            P plugin = iterator.previous();
-            final NamedSuperCall<R> listener = new NamedSuperCall<R>(methodName) {
-                @Override
-                public R call(final Object... args) {
-                    return callFunction(iterator, methodName, methodCall, activitySuper, args);
-                }
-            };
-            final R result = methodCall.call(listener, plugin, args);
-            return result;
-
-        } else {
-            return activitySuper.call(args);
-        }
-    }
-
-    protected void callHook(final String methodName,
-            final PluginCallVoid methodCall, final SuperCallVoid activitySuper,
-            final Object... args) {
-        if (mPlugins.isEmpty()) {
-            activitySuper.call(args);
-            return;
-        }
-
-        final ListIterator<P> iterator = mPlugins.listIterator(mPlugins.size());
-        callHook(iterator, methodName, methodCall, activitySuper, args);
-    }
-
-    void callHook(final ListIterator<P> iterator, final String methodName,
-            final PluginCallVoid methodCall, final SuperCallVoid activitySuper,
-            final Object... args) {
-
-        if (iterator.hasPrevious()) {
-            final P plugin = iterator.previous();
-            final NamedSuperCall<Void> listener = new NamedSuperCall<Void>(methodName) {
-                @Override
-                public Void call(final Object... args) {
-                    callHook(iterator, methodName, methodCall, activitySuper, args);
-                    return null;
-                }
-            };
-            methodCall.call(listener, plugin, args);
-        } else {
-            activitySuper.call(args);
-        }
-    }
 }

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractDelegate.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractDelegate.java
@@ -2,9 +2,9 @@ package com.pascalwelsch.compositeandroid.core;
 
 import android.support.annotation.NonNull;
 
-import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Stack;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -13,9 +13,91 @@ import java.util.concurrent.CopyOnWriteArrayList;
  */
 public class AbstractDelegate<T, P extends AbstractPlugin> {
 
+    public static abstract class ObjectPool<O> {
+
+        private int mMaxSize;
+
+        private Stack<O> pool = new Stack<>();
+
+        public ObjectPool(final int maxSize) {
+            mMaxSize = maxSize;
+        }
+
+        public void clear() {
+            pool.clear();
+        }
+
+        public O get() {
+            if (pool.isEmpty()) {
+                return newItem();
+            } else {
+                return pool.pop();
+            }
+        }
+
+        public void returnItem(final O iterator) {
+            if (pool.size() < mMaxSize) {
+                pool.push(iterator);
+            }
+        }
+
+        protected abstract O newItem();
+    }
+
+
     protected final T mOriginal;
 
     protected List<P> mPlugins = new CopyOnWriteArrayList<>();
+
+/*    protected IteratorPool<ListIterator<P>> mIteratorPool = new IteratorPool<ListIterator<P>>(10) {
+
+        @Override
+        protected ListIterator<P> newItem() {
+            return mPlugins.listIterator(mPlugins.size());
+        }
+    };*/
+/*    private IteratorPool<CachedNamedSuperCall> mSuperPool = new IteratorPool<CachedNamedSuperCall>(10){
+
+        @Override
+        protected CachedNamedSuperCall newItem() {
+            return new CachedNamedSuperCall();
+        }
+
+        @Override
+        public void returnItem(final CachedNamedSuperCall iterator) {
+            super.returnItem(iterator);
+            iterator.unbind();
+        }
+    };*/
+
+/*    private class CachedNamedSuperCall<R> extends NamedSuperCall<R> {
+
+        private SuperCall<R> mActivitySuper;
+
+        private PluginCall<P, R> mMethodCall;
+
+        public CachedNamedSuperCall() {
+            super(null);
+        }
+
+        public void bind(final String methodName,
+                final PluginCall<P, R> methodCall, final SuperCall<R> activitySuper){
+            setMethodName(methodName);
+            mMethodCall = methodCall;
+            mActivitySuper = activitySuper;
+        }
+
+        public void unbind(){
+            setMethodName(null);
+            mMethodCall = null;
+            mActivitySuper = null;
+        }
+
+        @Override
+        public R call(final Object... args) {
+            return callFunction(getMethodName(), mMethodCall, mActivitySuper, args);
+        }
+    }*/
 
     public AbstractDelegate(final T original) {
         mOriginal = original;
@@ -25,6 +107,7 @@ public class AbstractDelegate<T, P extends AbstractPlugin> {
     public Removable addPlugin(final P plugin) {
         plugin.addToDelegate(this, mOriginal);
         mPlugins.add(plugin);
+
         return new Removable() {
             @Override
             public void remove() {
@@ -42,11 +125,13 @@ public class AbstractDelegate<T, P extends AbstractPlugin> {
     protected <R> R callFunction(final String methodName,
             final PluginCall<P, R> methodCall, final SuperCall<R> activitySuper,
             final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return activitySuper.call(args);
+        }
 
-        final LinkedList<P> plugins = new LinkedList<>(mPlugins);
-
-        final ListIterator<P> iterator = plugins.listIterator(plugins.size());
-        return callFunction(iterator, methodName, methodCall, activitySuper, args);
+        final ListIterator<P> iterator = mPlugins.listIterator(mPlugins.size());
+        final R r = callFunction(iterator, methodName, methodCall, activitySuper, args);
+        return r;
     }
 
     @NonNull
@@ -74,10 +159,12 @@ public class AbstractDelegate<T, P extends AbstractPlugin> {
     protected void callHook(final String methodName,
             final PluginCallVoid methodCall, final SuperCallVoid activitySuper,
             final Object... args) {
+        if (mPlugins.isEmpty()) {
+            activitySuper.call(args);
+            return;
+        }
 
-        final LinkedList<P> plugins = new LinkedList<>(mPlugins);
-
-        final ListIterator<P> iterator = plugins.listIterator(plugins.size());
+        final ListIterator<P> iterator = mPlugins.listIterator(mPlugins.size());
         callHook(iterator, methodName, methodCall, activitySuper, args);
     }
 

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractPlugin.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractPlugin.java
@@ -39,7 +39,7 @@ public class AbstractPlugin<T, D> {
         final String superListener = mSuperListeners.peek().getMethodName();
         if (!superListener.equals(method)) {
             throw new IllegalStateException("You may have called "
-                    + method + " from " + superListener + " instead of calling getActivity()."
+                    + method + " from " + superListener + " instead of calling getOriginal()."
                     + method + ". Do not call " + method
                     + " on a ActivityPlugin directly. You have to call mDelegate." + method
                     + " or the call order of the plugins would be mixed up.");

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractPlugin.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractPlugin.java
@@ -4,7 +4,7 @@ import java.util.Stack;
 
 public class AbstractPlugin<T, D> {
 
-    final public Stack<NamedSuperCall<?>> mSuperListeners = new Stack<>();
+    final public Stack<NamedSuperCall> mSuperListeners = new Stack<>();
 
     private D mDelegate;
 

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun0.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun0.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun0<R> extends NamedSuperCall {
+
+    public CallFun0(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call();
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun1.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun1.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun1<R, T1> extends NamedSuperCall {
+
+    public CallFun1(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun2.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun2.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun2<R, T1, T2> extends NamedSuperCall {
+
+    public CallFun2(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun3.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun3.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun3<R, T1, T2, T3> extends NamedSuperCall {
+
+    public CallFun3(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2, final T3 p3);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun4.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun4.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun4<R, T1, T2, T3, T4> extends NamedSuperCall {
+
+    public CallFun4(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2, final T3 p3, final T4 p4);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun5.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun5.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun5<R, T1, T2, T3, T4, T5> extends NamedSuperCall {
+
+    public CallFun5(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2, final T3 p3,  final T4 p4, T5 p5);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun6.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun6.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun6<R, T1, T2, T3, T4, T5, T6> extends NamedSuperCall {
+
+    public CallFun6(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2, final T3 p3,  final T4 p4, T5 p5, T6 p6);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun7.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun7.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun7<R, T1, T2, T3, T4, T5, T6, T7> extends NamedSuperCall {
+
+    public CallFun7(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2, final T3 p3, final T4 p4, T5 p5, T6 p6, T7 p7);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun8.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun8.java
@@ -1,0 +1,11 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun8<R, T1, T2, T3, T4, T5, T6, T7, T8> extends NamedSuperCall {
+
+    public CallFun8(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2, final T3 p3, final T4 p4, T5 p5, T6 p6, T7 p7,
+            T8 p8);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun9.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallFun9.java
@@ -1,0 +1,11 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallFun9<R, T1, T2, T3, T4, T5, T6, T7, T8, T9> extends NamedSuperCall {
+
+    public CallFun9(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract R call(final T1 p1, final T2 p2, final T3 p3, final T4 p4, T5 p5, T6 p6, T7 p7,
+            T8 p8, T9 p9);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid0.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid0.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid0 extends NamedSuperCall {
+
+    public CallVoid0(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call();
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid1.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid1.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid1<T1> extends NamedSuperCall {
+
+    public CallVoid1(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid2.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid2.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid2<T1, T2> extends NamedSuperCall {
+
+    public CallVoid2(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid3.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid3.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid3<T1, T2, T3> extends NamedSuperCall {
+
+    public CallVoid3(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2, final T3 p3);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid4.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid4.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid4<T1, T2, T3, T4> extends NamedSuperCall {
+
+    public CallVoid4(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2, final T3 p3,  final T4 p4);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid5.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid5.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid5<T1, T2, T3, T4, T5> extends NamedSuperCall {
+
+    public CallVoid5(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2, final T3 p3,  final T4 p4, T5 p5);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid6.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid6.java
@@ -1,0 +1,10 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid6<T1, T2, T3, T4, T5, T6> extends NamedSuperCall {
+
+    public CallVoid6(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2, final T3 p3, final T4 p4, T5 p5, T6 p6);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid7.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid7.java
@@ -1,0 +1,11 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid7<T1, T2, T3, T4, T5, T6, T7> extends NamedSuperCall {
+
+    public CallVoid7(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2, final T3 p3, final T4 p4, T5 p5, T6 p6,
+            T7 p7);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid8.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid8.java
@@ -1,0 +1,11 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid8<T1, T2, T3, T4, T5, T6, T7, T8> extends NamedSuperCall {
+
+    public CallVoid8(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2, final T3 p3, final T4 p4, T5 p5, T6 p6,
+            T7 p7, T8 p8);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid9.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/CallVoid9.java
@@ -1,0 +1,11 @@
+package com.pascalwelsch.compositeandroid.core;
+
+public abstract class CallVoid9<T1, T2, T3, T4, T5, T6, T7, T8, T9> extends NamedSuperCall {
+
+    public CallVoid9(final String methodName) {
+        super(methodName);
+    }
+
+    public abstract void call(final T1 p1, final T2 p2, final T3 p3, final T4 p4, T5 p5, T6 p6,
+            T7 p7, T8 p8, T9 p9);
+}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/NamedSuperCallVoid.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/NamedSuperCallVoid.java
@@ -1,10 +1,10 @@
 package com.pascalwelsch.compositeandroid.core;
 
-public abstract class NamedSuperCall {
+public abstract class NamedSuperCallVoid implements SuperCall {
 
     private final String mMethodName;
 
-    public NamedSuperCall(final String methodName) {
+    public NamedSuperCallVoid(final String methodName) {
         mMethodName = methodName;
     }
 

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/PluginCall.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/PluginCall.java
@@ -1,6 +1,0 @@
-package com.pascalwelsch.compositeandroid.core;
-
-public interface PluginCall<P, R> {
-
-    R call(NamedSuperCall<R> superCall, P plugin, Object... args);
-}

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/PluginCallVoid.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/PluginCallVoid.java
@@ -1,6 +1,0 @@
-package com.pascalwelsch.compositeandroid.core;
-
-public interface PluginCallVoid<P> {
-
-    void call(NamedSuperCall<Void> superCall, P plugin, Object... args);
-}

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
@@ -2,11 +2,7 @@ package com.pascalwelsch.compositeandroid.fragment;
 
 import com.pascalwelsch.compositeandroid.core.AbstractDelegate;
 import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
-import com.pascalwelsch.compositeandroid.core.PluginCall;
-import com.pascalwelsch.compositeandroid.core.PluginCallVoid;
 import com.pascalwelsch.compositeandroid.core.Removable;
-import com.pascalwelsch.compositeandroid.core.SuperCall;
-import com.pascalwelsch.compositeandroid.core.SuperCallVoid;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -35,6 +31,7 @@ import android.view.animation.Animation;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
+import java.util.ListIterator;
 
 public class DialogFragmentDelegate
         extends AbstractDelegate<ICompositeDialogFragment, DialogFragmentPlugin> {
@@ -64,33 +61,52 @@ public class DialogFragmentDelegate
     }
 
     public void dismiss() {
-        callHook("dismiss()", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_dismiss();
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("dismiss()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.dismiss(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().dismiss(this);
+                    return null;
+                } else {
+                    getOriginal().super_dismiss();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_dismiss();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void dismissAllowingStateLoss() {
-        callHook("dismissAllowingStateLoss()", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_dismissAllowingStateLoss();
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "dismissAllowingStateLoss()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.dismissAllowingStateLoss(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().dismissAllowingStateLoss(this);
+                    return null;
+                } else {
+                    getOriginal().super_dismissAllowingStateLoss();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_dismissAllowingStateLoss();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
@@ -111,20 +127,24 @@ public class DialogFragmentDelegate
     }
 
     public Dialog getDialog() {
-        return callFunction("getDialog()", new PluginCall<DialogFragmentPlugin, Dialog>() {
-            @Override
-            public Dialog call(final NamedSuperCall<Dialog> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getDialog();
+        }
 
-                return plugin.getDialog(superCall);
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Dialog>() {
+        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>("getDialog()") {
+
             @Override
             public Dialog call(final Object... args) {
-                return getOriginal().super_getDialog();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getDialog(this);
+                } else {
+                    return getOriginal().super_getDialog();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public Object getEnterTransition() {
@@ -160,37 +180,45 @@ public class DialogFragmentDelegate
     }
 
     public boolean getShowsDialog() {
-        return callFunction("getShowsDialog()", new PluginCall<DialogFragmentPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getShowsDialog();
+        }
 
-                return plugin.getShowsDialog(superCall);
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("getShowsDialog()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_getShowsDialog();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getShowsDialog(this);
+                } else {
+                    return getOriginal().super_getShowsDialog();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public int getTheme() {
-        return callFunction("getTheme()", new PluginCall<DialogFragmentPlugin, Integer>() {
-            @Override
-            public Integer call(final NamedSuperCall<Integer> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getTheme();
+        }
 
-                return plugin.getTheme(superCall);
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Integer>() {
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>("getTheme()") {
+
             @Override
             public Integer call(final Object... args) {
-                return getOriginal().super_getTheme();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getTheme(this);
+                } else {
+                    return getOriginal().super_getTheme();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public boolean getUserVisibleHint() {
@@ -202,20 +230,24 @@ public class DialogFragmentDelegate
     }
 
     public boolean isCancelable() {
-        return callFunction("isCancelable()", new PluginCall<DialogFragmentPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_isCancelable();
+        }
 
-                return plugin.isCancelable(superCall);
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<Boolean>() {
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isCancelable()") {
+
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_isCancelable();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().isCancelable(this);
+                } else {
+                    return getOriginal().super_isCancelable();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
@@ -235,18 +267,28 @@ public class DialogFragmentDelegate
     }
 
     public void onCancel(final DialogInterface dialog) {
-        callHook("onCancel(DialogInterface)", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCancel(dialog);
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onCancel(DialogInterface)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.onCancel(superCall, (DialogInterface) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onCancel(this, (DialogInterface) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onCancel((DialogInterface) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onCancel((DialogInterface) args[0]);
-            }
-        }, dialog);
+        };
+        superCall.call(dialog);
     }
 
     public void onConfigurationChanged(final Configuration newConfig) {
@@ -271,21 +313,25 @@ public class DialogFragmentDelegate
     }
 
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        return callFunction("onCreateDialog(Bundle)",
-                new PluginCall<DialogFragmentPlugin, Dialog>() {
-                    @Override
-                    public Dialog call(final NamedSuperCall<Dialog> superCall,
-                            final DialogFragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateDialog(savedInstanceState);
+        }
 
-                        return plugin.onCreateDialog(superCall, (Bundle) args[0]);
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Dialog>() {
-                    @Override
-                    public Dialog call(final Object... args) {
-                        return getOriginal().super_onCreateDialog((Bundle) args[0]);
-                    }
-                }, savedInstanceState);
+        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>(
+                "onCreateDialog(Bundle)") {
+
+            @Override
+            public Dialog call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onCreateDialog(this, (Bundle) args[0]);
+                } else {
+                    return getOriginal().super_onCreateDialog((Bundle) args[0]);
+                }
+            }
+        };
+        return superCall.call(savedInstanceState);
     }
 
     public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
@@ -314,18 +360,28 @@ public class DialogFragmentDelegate
     }
 
     public void onDismiss(final DialogInterface dialog) {
-        callHook("onDismiss(DialogInterface)", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onDismiss(dialog);
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onDismiss(DialogInterface)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.onDismiss(superCall, (DialogInterface) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onDismiss(this, (DialogInterface) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onDismiss((DialogInterface) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onDismiss((DialogInterface) args[0]);
-            }
-        }, dialog);
+        };
+        superCall.call(dialog);
     }
 
     public void onHiddenChanged(final boolean hidden) {
@@ -408,18 +464,27 @@ public class DialogFragmentDelegate
     }
 
     public void setCancelable(final boolean cancelable) {
-        callHook("setCancelable(boolean)", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setCancelable(cancelable);
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setCancelable(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.setCancelable(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setCancelable(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setCancelable((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setCancelable((boolean) args[0]);
-            }
-        }, cancelable);
+        };
+        superCall.call(cancelable);
     }
 
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
@@ -471,33 +536,51 @@ public class DialogFragmentDelegate
     }
 
     public void setShowsDialog(final boolean showsDialog) {
-        callHook("setShowsDialog(boolean)", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setShowsDialog(showsDialog);
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setShowsDialog(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.setShowsDialog(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setShowsDialog(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setShowsDialog((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setShowsDialog((boolean) args[0]);
-            }
-        }, showsDialog);
+        };
+        superCall.call(showsDialog);
     }
 
     public void setStyle(final int style, @StyleRes final int theme) {
-        callHook("setStyle(int, int)", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setStyle(style, theme);
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setStyle(int, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.setStyle(superCall, (int) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setStyle(this, (int) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_setStyle((int) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setStyle((int) args[0], (int) args[1]);
-            }
-        }, style, theme);
+        };
+        superCall.call(style, theme);
     }
 
     public void setTargetFragment(final Fragment fragment, final int requestCode) {
@@ -509,18 +592,28 @@ public class DialogFragmentDelegate
     }
 
     public void setupDialog(final Dialog dialog, final int style) {
-        callHook("setupDialog(Dialog, int)", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setupDialog(dialog, style);
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setupDialog(Dialog, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.setupDialog(superCall, (Dialog) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setupDialog(this, (Dialog) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_setupDialog((Dialog) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setupDialog((Dialog) args[0], (int) args[1]);
-            }
-        }, dialog, style);
+        };
+        superCall.call(dialog, style);
     }
 
     public boolean shouldShowRequestPermissionRationale(@NonNull final String permission) {
@@ -528,38 +621,52 @@ public class DialogFragmentDelegate
     }
 
     public void show(final FragmentManager manager, final String tag) {
-        callHook("show(FragmentManager, String)", new PluginCallVoid<DialogFragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_show(manager, tag);
+            return;
+        }
+
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "show(FragmentManager, String)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall,
-                    final DialogFragmentPlugin plugin, final Object... args) {
-                plugin.show(superCall, (FragmentManager) args[0], (String) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().show(this, (FragmentManager) args[0], (String) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_show((FragmentManager) args[0], (String) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_show((FragmentManager) args[0], (String) args[1]);
-            }
-        }, manager, tag);
+        };
+        superCall.call(manager, tag);
     }
 
     public int show(final FragmentTransaction transaction, final String tag) {
-        return callFunction("show(FragmentTransaction, String)",
-                new PluginCall<DialogFragmentPlugin, Integer>() {
-                    @Override
-                    public Integer call(final NamedSuperCall<Integer> superCall,
-                            final DialogFragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_show(transaction, tag);
+        }
 
-                        return plugin
-                                .show(superCall, (FragmentTransaction) args[0], (String) args[1]);
+        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Integer>() {
-                    @Override
-                    public Integer call(final Object... args) {
-                        return getOriginal()
-                                .super_show((FragmentTransaction) args[0], (String) args[1]);
-                    }
-                }, transaction, tag);
+        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+                "show(FragmentTransaction, String)") {
+
+            @Override
+            public Integer call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .show(this, (FragmentTransaction) args[0], (String) args[1]);
+                } else {
+                    return getOriginal()
+                            .super_show((FragmentTransaction) args[0], (String) args[1]);
+                }
+            }
+        };
+        return superCall.call(transaction, tag);
     }
 
     public void startActivity(final Intent intent) {

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
@@ -1,7 +1,12 @@
 package com.pascalwelsch.compositeandroid.fragment;
 
 import com.pascalwelsch.compositeandroid.core.AbstractDelegate;
-import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
+import com.pascalwelsch.compositeandroid.core.CallFun0;
+import com.pascalwelsch.compositeandroid.core.CallFun1;
+import com.pascalwelsch.compositeandroid.core.CallFun2;
+import com.pascalwelsch.compositeandroid.core.CallVoid0;
+import com.pascalwelsch.compositeandroid.core.CallVoid1;
+import com.pascalwelsch.compositeandroid.core.CallVoid2;
 import com.pascalwelsch.compositeandroid.core.Removable;
 
 import android.app.Activity;
@@ -68,16 +73,14 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("dismiss()") {
+        final CallVoid0 superCall = new CallVoid0("dismiss()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().dismiss(this);
-                    return null;
                 } else {
                     getOriginal().super_dismiss();
-                    return null;
                 }
             }
         };
@@ -92,17 +95,14 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "dismissAllowingStateLoss()") {
+        final CallVoid0 superCall = new CallVoid0("dismissAllowingStateLoss()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().dismissAllowingStateLoss(this);
-                    return null;
                 } else {
                     getOriginal().super_dismissAllowingStateLoss();
-                    return null;
                 }
             }
         };
@@ -133,10 +133,10 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>("getDialog()") {
+        final CallFun0<Dialog> superCall = new CallFun0<Dialog>("getDialog()") {
 
             @Override
-            public Dialog call(final Object... args) {
+            public Dialog call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getDialog(this);
                 } else {
@@ -186,10 +186,10 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("getShowsDialog()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("getShowsDialog()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getShowsDialog(this);
                 } else {
@@ -207,10 +207,10 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>("getTheme()") {
+        final CallFun0<Integer> superCall = new CallFun0<Integer>("getTheme()") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getTheme(this);
                 } else {
@@ -236,10 +236,10 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>("isCancelable()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isCancelable()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().isCancelable(this);
                 } else {
@@ -274,17 +274,15 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<DialogInterface> superCall = new CallVoid1<DialogInterface>(
                 "onCancel(DialogInterface)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final DialogInterface dialog) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onCancel(this, (DialogInterface) args[0]);
-                    return null;
+                    iterator.previous().onCancel(this, dialog);
                 } else {
-                    getOriginal().super_onCancel((DialogInterface) args[0]);
-                    return null;
+                    getOriginal().super_onCancel(dialog);
                 }
             }
         };
@@ -319,15 +317,15 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Dialog> superCall = new NamedSuperCall<Dialog>(
+        final CallFun1<Dialog, Bundle> superCall = new CallFun1<Dialog, Bundle>(
                 "onCreateDialog(Bundle)") {
 
             @Override
-            public Dialog call(final Object... args) {
+            public Dialog call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onCreateDialog(this, (Bundle) args[0]);
+                    return iterator.previous().onCreateDialog(this, savedInstanceState);
                 } else {
-                    return getOriginal().super_onCreateDialog((Bundle) args[0]);
+                    return getOriginal().super_onCreateDialog(savedInstanceState);
                 }
             }
         };
@@ -367,17 +365,15 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<DialogInterface> superCall = new CallVoid1<DialogInterface>(
                 "onDismiss(DialogInterface)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final DialogInterface dialog) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onDismiss(this, (DialogInterface) args[0]);
-                    return null;
+                    iterator.previous().onDismiss(this, dialog);
                 } else {
-                    getOriginal().super_onDismiss((DialogInterface) args[0]);
-                    return null;
+                    getOriginal().super_onDismiss(dialog);
                 }
             }
         };
@@ -471,16 +467,14 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setCancelable(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setCancelable(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean cancelable) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setCancelable(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setCancelable(this, cancelable);
                 } else {
-                    getOriginal().super_setCancelable((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setCancelable(cancelable);
                 }
             }
         };
@@ -543,16 +537,14 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setShowsDialog(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setShowsDialog(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean showsDialog) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setShowsDialog(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setShowsDialog(this, showsDialog);
                 } else {
-                    getOriginal().super_setShowsDialog((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setShowsDialog(showsDialog);
                 }
             }
         };
@@ -567,16 +559,15 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setStyle(int, int)") {
+        final CallVoid2<Integer, Integer> superCall = new CallVoid2<Integer, Integer>(
+                "setStyle(Integer, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer style, final Integer theme) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setStyle(this, (int) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().setStyle(this, style, theme);
                 } else {
-                    getOriginal().super_setStyle((int) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_setStyle(style, theme);
                 }
             }
         };
@@ -599,17 +590,15 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setupDialog(Dialog, int)") {
+        final CallVoid2<Dialog, Integer> superCall = new CallVoid2<Dialog, Integer>(
+                "setupDialog(Dialog, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Dialog dialog, final Integer style) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setupDialog(this, (Dialog) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().setupDialog(this, dialog, style);
                 } else {
-                    getOriginal().super_setupDialog((Dialog) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_setupDialog(dialog, style);
                 }
             }
         };
@@ -628,17 +617,15 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<FragmentManager, String> superCall = new CallVoid2<FragmentManager, String>(
                 "show(FragmentManager, String)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final FragmentManager manager, final String tag) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().show(this, (FragmentManager) args[0], (String) args[1]);
-                    return null;
+                    iterator.previous().show(this, manager, tag);
                 } else {
-                    getOriginal().super_show((FragmentManager) args[0], (String) args[1]);
-                    return null;
+                    getOriginal().super_show(manager, tag);
                 }
             }
         };
@@ -652,17 +639,16 @@ public class DialogFragmentDelegate
 
         final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Integer> superCall = new NamedSuperCall<Integer>(
+        final CallFun2<Integer, FragmentTransaction, String> superCall
+                = new CallFun2<Integer, FragmentTransaction, String>(
                 "show(FragmentTransaction, String)") {
 
             @Override
-            public Integer call(final Object... args) {
+            public Integer call(final FragmentTransaction transaction, final String tag) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .show(this, (FragmentTransaction) args[0], (String) args[1]);
+                    return iterator.previous().show(this, transaction, tag);
                 } else {
-                    return getOriginal()
-                            .super_show((FragmentTransaction) args[0], (String) args[1]);
+                    return getOriginal().super_show(transaction, tag);
                 }
             }
         };

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentPlugin.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentPlugin.java
@@ -1,6 +1,11 @@
 package com.pascalwelsch.compositeandroid.fragment;
 
-import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
+import com.pascalwelsch.compositeandroid.core.CallFun0;
+import com.pascalwelsch.compositeandroid.core.CallFun1;
+import com.pascalwelsch.compositeandroid.core.CallFun2;
+import com.pascalwelsch.compositeandroid.core.CallVoid0;
+import com.pascalwelsch.compositeandroid.core.CallVoid1;
+import com.pascalwelsch.compositeandroid.core.CallVoid2;
 
 import android.app.Activity;
 import android.app.Dialog;
@@ -19,17 +24,17 @@ public class DialogFragmentPlugin extends FragmentPlugin {
 
     public void dismiss() {
         verifyMethodCalledFromDelegate("dismiss()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void dismissAllowingStateLoss() {
         verifyMethodCalledFromDelegate("dismissAllowingStateLoss()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public Dialog getDialog() {
         verifyMethodCalledFromDelegate("getDialog()");
-        return (Dialog) mSuperListeners.pop().call();
+        return ((CallFun0<Dialog>) mSuperListeners.pop()).call();
     }
 
     public DialogFragment getDialogFragment() {
@@ -38,131 +43,132 @@ public class DialogFragmentPlugin extends FragmentPlugin {
 
     public LayoutInflater getLayoutInflater(final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("getLayoutInflater(Bundle)");
-        return (LayoutInflater) mSuperListeners.pop().call(savedInstanceState);
+        return ((CallFun1<LayoutInflater, Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public boolean getShowsDialog() {
         verifyMethodCalledFromDelegate("getShowsDialog()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public int getTheme() {
         verifyMethodCalledFromDelegate("getTheme()");
-        return (Integer) mSuperListeners.pop().call();
+        return ((CallFun0<Integer>) mSuperListeners.pop()).call();
     }
 
     public boolean isCancelable() {
         verifyMethodCalledFromDelegate("isCancelable()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public void onActivityCreated(final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onActivityCreated(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public void onAttach(final Activity activity) {
         verifyMethodCalledFromDelegate("onAttach(Activity)");
-        mSuperListeners.pop().call(activity);
+        ((CallVoid1<Activity>) mSuperListeners.pop()).call(activity);
     }
 
     public void onCancel(final DialogInterface dialog) {
         verifyMethodCalledFromDelegate("onCancel(DialogInterface)");
-        mSuperListeners.pop().call(dialog);
+        ((CallVoid1<DialogInterface>) mSuperListeners.pop()).call(dialog);
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onCreate(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onCreateDialog(Bundle)");
-        return (Dialog) mSuperListeners.pop().call(savedInstanceState);
+        return ((CallFun1<Dialog, Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public void onDestroyView() {
         verifyMethodCalledFromDelegate("onDestroyView()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onDetach() {
         verifyMethodCalledFromDelegate("onDetach()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onDismiss(final DialogInterface dialog) {
         verifyMethodCalledFromDelegate("onDismiss(DialogInterface)");
-        mSuperListeners.pop().call(dialog);
+        ((CallVoid1<DialogInterface>) mSuperListeners.pop()).call(dialog);
     }
 
     public void onSaveInstanceState(final Bundle outState) {
         verifyMethodCalledFromDelegate("onSaveInstanceState(Bundle)");
-        mSuperListeners.pop().call(outState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(outState);
     }
 
     public void onStart() {
         verifyMethodCalledFromDelegate("onStart()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onStop() {
         verifyMethodCalledFromDelegate("onStop()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void setCancelable(final boolean cancelable) {
-        verifyMethodCalledFromDelegate("setCancelable(boolean)");
-        mSuperListeners.pop().call(cancelable);
+        verifyMethodCalledFromDelegate("setCancelable(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(cancelable);
     }
 
     public void setShowsDialog(final boolean showsDialog) {
-        verifyMethodCalledFromDelegate("setShowsDialog(boolean)");
-        mSuperListeners.pop().call(showsDialog);
+        verifyMethodCalledFromDelegate("setShowsDialog(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(showsDialog);
     }
 
     public void setStyle(final int style, @StyleRes final int theme) {
-        verifyMethodCalledFromDelegate("setStyle(int, int)");
-        mSuperListeners.pop().call(style, theme);
+        verifyMethodCalledFromDelegate("setStyle(Integer, Integer)");
+        ((CallVoid2<Integer, Integer>) mSuperListeners.pop()).call(style, theme);
     }
 
     public void setupDialog(final Dialog dialog, final int style) {
-        verifyMethodCalledFromDelegate("setupDialog(Dialog, int)");
-        mSuperListeners.pop().call(dialog, style);
+        verifyMethodCalledFromDelegate("setupDialog(Dialog, Integer)");
+        ((CallVoid2<Dialog, Integer>) mSuperListeners.pop()).call(dialog, style);
     }
 
     public void show(final FragmentManager manager, final String tag) {
         verifyMethodCalledFromDelegate("show(FragmentManager, String)");
-        mSuperListeners.pop().call(manager, tag);
+        ((CallVoid2<FragmentManager, String>) mSuperListeners.pop()).call(manager, tag);
     }
 
     public int show(final FragmentTransaction transaction, final String tag) {
         verifyMethodCalledFromDelegate("show(FragmentTransaction, String)");
-        return (Integer) mSuperListeners.pop().call(transaction, tag);
+        return ((CallFun2<Integer, FragmentTransaction, String>) mSuperListeners.pop())
+                .call(transaction, tag);
     }
 
-    void dismiss(final NamedSuperCall<Void> superCall) {
+    void dismiss(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             dismiss();
         }
     }
 
-    void dismissAllowingStateLoss(final NamedSuperCall<Void> superCall) {
+    void dismissAllowingStateLoss(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             dismissAllowingStateLoss();
         }
     }
 
-    Dialog getDialog(final NamedSuperCall<Dialog> superCall) {
+    Dialog getDialog(final CallFun0<Dialog> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getDialog();
         }
     }
 
-    LayoutInflater getLayoutInflater(final NamedSuperCall<LayoutInflater> superCall,
+    LayoutInflater getLayoutInflater(final CallFun1<LayoutInflater, Bundle> superCall,
             final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -170,119 +176,120 @@ public class DialogFragmentPlugin extends FragmentPlugin {
         }
     }
 
-    boolean getShowsDialog(final NamedSuperCall<Boolean> superCall) {
+    boolean getShowsDialog(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getShowsDialog();
         }
     }
 
-    int getTheme(final NamedSuperCall<Integer> superCall) {
+    int getTheme(final CallFun0<Integer> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getTheme();
         }
     }
 
-    boolean isCancelable(final NamedSuperCall<Boolean> superCall) {
+    boolean isCancelable(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return isCancelable();
         }
     }
 
-    void onActivityCreated(final NamedSuperCall<Void> superCall, final Bundle savedInstanceState) {
+    void onActivityCreated(final CallVoid1<Bundle> superCall, final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onActivityCreated(savedInstanceState);
         }
     }
 
-    void onAttach(final NamedSuperCall<Void> superCall, final Activity activity) {
+    void onAttach(final CallVoid1<Activity> superCall, final Activity activity) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onAttach(activity);
         }
     }
 
-    void onCancel(final NamedSuperCall<Void> superCall, final DialogInterface dialog) {
+    void onCancel(final CallVoid1<DialogInterface> superCall, final DialogInterface dialog) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onCancel(dialog);
         }
     }
 
-    void onCreate(final NamedSuperCall<Void> superCall, @Nullable final Bundle savedInstanceState) {
+    void onCreate(final CallVoid1<Bundle> superCall, @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onCreate(savedInstanceState);
         }
     }
 
-    Dialog onCreateDialog(final NamedSuperCall<Dialog> superCall, final Bundle savedInstanceState) {
+    Dialog onCreateDialog(final CallFun1<Dialog, Bundle> superCall,
+            final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateDialog(savedInstanceState);
         }
     }
 
-    void onDestroyView(final NamedSuperCall<Void> superCall) {
+    void onDestroyView(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDestroyView();
         }
     }
 
-    void onDetach(final NamedSuperCall<Void> superCall) {
+    void onDetach(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDetach();
         }
     }
 
-    void onDismiss(final NamedSuperCall<Void> superCall, final DialogInterface dialog) {
+    void onDismiss(final CallVoid1<DialogInterface> superCall, final DialogInterface dialog) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDismiss(dialog);
         }
     }
 
-    void onSaveInstanceState(final NamedSuperCall<Void> superCall, final Bundle outState) {
+    void onSaveInstanceState(final CallVoid1<Bundle> superCall, final Bundle outState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onSaveInstanceState(outState);
         }
     }
 
-    void onStart(final NamedSuperCall<Void> superCall) {
+    void onStart(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onStart();
         }
     }
 
-    void onStop(final NamedSuperCall<Void> superCall) {
+    void onStop(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onStop();
         }
     }
 
-    void setCancelable(final NamedSuperCall<Void> superCall, final boolean cancelable) {
+    void setCancelable(final CallVoid1<Boolean> superCall, final boolean cancelable) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setCancelable(cancelable);
         }
     }
 
-    void setShowsDialog(final NamedSuperCall<Void> superCall, final boolean showsDialog) {
+    void setShowsDialog(final CallVoid1<Boolean> superCall, final boolean showsDialog) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setShowsDialog(showsDialog);
         }
     }
 
-    void setStyle(final NamedSuperCall<Void> superCall, final int style,
+    void setStyle(final CallVoid2<Integer, Integer> superCall, final int style,
             @StyleRes final int theme) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -290,14 +297,15 @@ public class DialogFragmentPlugin extends FragmentPlugin {
         }
     }
 
-    void setupDialog(final NamedSuperCall<Void> superCall, final Dialog dialog, final int style) {
+    void setupDialog(final CallVoid2<Dialog, Integer> superCall, final Dialog dialog,
+            final int style) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setupDialog(dialog, style);
         }
     }
 
-    void show(final NamedSuperCall<Void> superCall, final FragmentManager manager,
+    void show(final CallVoid2<FragmentManager, String> superCall, final FragmentManager manager,
             final String tag) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -305,8 +313,8 @@ public class DialogFragmentPlugin extends FragmentPlugin {
         }
     }
 
-    int show(final NamedSuperCall<Integer> superCall, final FragmentTransaction transaction,
-            final String tag) {
+    int show(final CallFun2<Integer, FragmentTransaction, String> superCall,
+            final FragmentTransaction transaction, final String tag) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return show(transaction, tag);

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
@@ -1,7 +1,14 @@
 package com.pascalwelsch.compositeandroid.fragment;
 
 import com.pascalwelsch.compositeandroid.core.AbstractDelegate;
-import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
+import com.pascalwelsch.compositeandroid.core.CallFun0;
+import com.pascalwelsch.compositeandroid.core.CallFun1;
+import com.pascalwelsch.compositeandroid.core.CallFun3;
+import com.pascalwelsch.compositeandroid.core.CallVoid0;
+import com.pascalwelsch.compositeandroid.core.CallVoid1;
+import com.pascalwelsch.compositeandroid.core.CallVoid2;
+import com.pascalwelsch.compositeandroid.core.CallVoid3;
+import com.pascalwelsch.compositeandroid.core.CallVoid4;
 
 import android.app.Activity;
 import android.content.Context;
@@ -45,19 +52,17 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid4<String, FileDescriptor, PrintWriter, String[]> superCall
+                = new CallVoid4<String, FileDescriptor, PrintWriter, String[]>(
                 "dump(String, FileDescriptor, PrintWriter, String[])") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final String prefix, final FileDescriptor fd, final PrintWriter writer,
+                    final String[] args) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().dump(this, (String) args[0], (FileDescriptor) args[1],
-                            (PrintWriter) args[2], (String[]) args[3]);
-                    return null;
+                    iterator.previous().dump(this, prefix, fd, writer, args);
                 } else {
-                    getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
-                            (PrintWriter) args[2], (String[]) args[3]);
-                    return null;
+                    getOriginal().super_dump(prefix, fd, writer, args);
                 }
             }
         };
@@ -71,11 +76,11 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>(
                 "getAllowEnterTransitionOverlap()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getAllowEnterTransitionOverlap(this);
                 } else {
@@ -93,11 +98,11 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>(
                 "getAllowReturnTransitionOverlap()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getAllowReturnTransitionOverlap(this);
                 } else {
@@ -115,10 +120,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>("getContext()") {
+        final CallFun0<Context> superCall = new CallFun0<Context>("getContext()") {
 
             @Override
-            public Context call(final Object... args) {
+            public Context call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getContext(this);
                 } else {
@@ -136,11 +141,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
-                "getEnterTransition()") {
+        final CallFun0<Object> superCall = new CallFun0<Object>("getEnterTransition()") {
 
             @Override
-            public Object call(final Object... args) {
+            public Object call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getEnterTransition(this);
                 } else {
@@ -158,10 +162,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>("getExitTransition()") {
+        final CallFun0<Object> superCall = new CallFun0<Object>("getExitTransition()") {
 
             @Override
-            public Object call(final Object... args) {
+            public Object call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getExitTransition(this);
                 } else {
@@ -179,15 +183,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<LayoutInflater> superCall = new NamedSuperCall<LayoutInflater>(
+        final CallFun1<LayoutInflater, Bundle> superCall = new CallFun1<LayoutInflater, Bundle>(
                 "getLayoutInflater(Bundle)") {
 
             @Override
-            public LayoutInflater call(final Object... args) {
+            public LayoutInflater call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().getLayoutInflater(this, (Bundle) args[0]);
+                    return iterator.previous().getLayoutInflater(this, savedInstanceState);
                 } else {
-                    return getOriginal().super_getLayoutInflater((Bundle) args[0]);
+                    return getOriginal().super_getLayoutInflater(savedInstanceState);
                 }
             }
         };
@@ -201,11 +205,11 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<LoaderManager> superCall = new NamedSuperCall<LoaderManager>(
+        final CallFun0<LoaderManager> superCall = new CallFun0<LoaderManager>(
                 "getLoaderManager()") {
 
             @Override
-            public LoaderManager call(final Object... args) {
+            public LoaderManager call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getLoaderManager(this);
                 } else {
@@ -223,11 +227,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
-                "getReenterTransition()") {
+        final CallFun0<Object> superCall = new CallFun0<Object>("getReenterTransition()") {
 
             @Override
-            public Object call(final Object... args) {
+            public Object call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getReenterTransition(this);
                 } else {
@@ -245,11 +248,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
-                "getReturnTransition()") {
+        final CallFun0<Object> superCall = new CallFun0<Object>("getReturnTransition()") {
 
             @Override
-            public Object call(final Object... args) {
+            public Object call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getReturnTransition(this);
                 } else {
@@ -267,11 +269,11 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+        final CallFun0<Object> superCall = new CallFun0<Object>(
                 "getSharedElementEnterTransition()") {
 
             @Override
-            public Object call(final Object... args) {
+            public Object call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getSharedElementEnterTransition(this);
                 } else {
@@ -289,11 +291,11 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+        final CallFun0<Object> superCall = new CallFun0<Object>(
                 "getSharedElementReturnTransition()") {
 
             @Override
-            public Object call(final Object... args) {
+            public Object call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getSharedElementReturnTransition(this);
                 } else {
@@ -311,11 +313,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
-                "getUserVisibleHint()") {
+        final CallFun0<Boolean> superCall = new CallFun0<Boolean>("getUserVisibleHint()") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getUserVisibleHint(this);
                 } else {
@@ -333,10 +334,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("getView()") {
+        final CallFun0<View> superCall = new CallFun0<View>("getView()") {
 
             @Override
-            public View call(final Object... args) {
+            public View call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().getView(this);
                 } else {
@@ -355,17 +356,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onActivityCreated(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onActivityCreated(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onActivityCreated(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onActivityCreated(this, savedInstanceState);
                 } else {
-                    getOriginal().super_onActivityCreated((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onActivityCreated(savedInstanceState);
                 }
             }
         };
@@ -380,19 +378,17 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onActivityResult(int, int, Intent)") {
+        final CallVoid3<Integer, Integer, Intent> superCall
+                = new CallVoid3<Integer, Integer, Intent>(
+                "onActivityResult(Integer, Integer, Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer requestCode, final Integer resultCode,
+                    final Intent data) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onActivityResult(this, (int) args[0], (int) args[1], (Intent) args[2]);
-                    return null;
+                    iterator.previous().onActivityResult(this, requestCode, resultCode, data);
                 } else {
-                    getOriginal()
-                            .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
-                    return null;
+                    getOriginal().super_onActivityResult(requestCode, resultCode, data);
                 }
             }
         };
@@ -407,16 +403,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onAttach(Context)") {
+        final CallVoid1<Context> superCall = new CallVoid1<Context>("onAttach(Context)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Context context) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onAttach(this, (Context) args[0]);
-                    return null;
+                    iterator.previous().onAttach(this, context);
                 } else {
-                    getOriginal().super_onAttach((Context) args[0]);
-                    return null;
+                    getOriginal().super_onAttach(context);
                 }
             }
         };
@@ -431,16 +425,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onAttach(Activity)") {
+        final CallVoid1<Activity> superCall = new CallVoid1<Activity>("onAttach(Activity)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity activity) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onAttach(this, (Activity) args[0]);
-                    return null;
+                    iterator.previous().onAttach(this, activity);
                 } else {
-                    getOriginal().super_onAttach((Activity) args[0]);
-                    return null;
+                    getOriginal().super_onAttach(activity);
                 }
             }
         };
@@ -455,17 +447,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Configuration> superCall = new CallVoid1<Configuration>(
                 "onConfigurationChanged(Configuration)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Configuration newConfig) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onConfigurationChanged(this, (Configuration) args[0]);
-                    return null;
+                    iterator.previous().onConfigurationChanged(this, newConfig);
                 } else {
-                    getOriginal().super_onConfigurationChanged((Configuration) args[0]);
-                    return null;
+                    getOriginal().super_onConfigurationChanged(newConfig);
                 }
             }
         };
@@ -479,15 +469,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onContextItemSelected(MenuItem)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MenuItem item) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onContextItemSelected(this, (MenuItem) args[0]);
+                    return iterator.previous().onContextItemSelected(this, item);
                 } else {
-                    return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
+                    return getOriginal().super_onContextItemSelected(item);
                 }
             }
         };
@@ -502,16 +492,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onCreate(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onCreate(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onCreate(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onCreate(this, savedInstanceState);
                 } else {
-                    getOriginal().super_onCreate((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onCreate(savedInstanceState);
                 }
             }
         };
@@ -525,18 +513,17 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Animation> superCall = new NamedSuperCall<Animation>(
-                "onCreateAnimation(int, boolean, int)") {
+        final CallFun3<Animation, Integer, Boolean, Integer> superCall
+                = new CallFun3<Animation, Integer, Boolean, Integer>(
+                "onCreateAnimation(Integer, Boolean, Integer)") {
 
             @Override
-            public Animation call(final Object... args) {
+            public Animation call(final Integer transit, final Boolean enter,
+                    final Integer nextAnim) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous()
-                            .onCreateAnimation(this, (int) args[0], (boolean) args[1],
-                                    (int) args[2]);
+                    return iterator.previous().onCreateAnimation(this, transit, enter, nextAnim);
                 } else {
-                    return getOriginal().super_onCreateAnimation((int) args[0], (boolean) args[1],
-                            (int) args[2]);
+                    return getOriginal().super_onCreateAnimation(transit, enter, nextAnim);
                 }
             }
         };
@@ -552,20 +539,17 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo> superCall
+                = new CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo>(
                 "onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final ContextMenu menu, final View v,
+                    final ContextMenu.ContextMenuInfo menuInfo) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onCreateContextMenu(this, (ContextMenu) args[0], (View) args[1],
-                                    (ContextMenu.ContextMenuInfo) args[2]);
-                    return null;
+                    iterator.previous().onCreateContextMenu(this, menu, v, menuInfo);
                 } else {
-                    getOriginal().super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
-                            (ContextMenu.ContextMenuInfo) args[2]);
-                    return null;
+                    getOriginal().super_onCreateContextMenu(menu, v, menuInfo);
                 }
             }
         };
@@ -580,18 +564,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Menu, MenuInflater> superCall = new CallVoid2<Menu, MenuInflater>(
                 "onCreateOptionsMenu(Menu, MenuInflater)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Menu menu, final MenuInflater inflater) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onCreateOptionsMenu(this, (Menu) args[0], (MenuInflater) args[1]);
-                    return null;
+                    iterator.previous().onCreateOptionsMenu(this, menu, inflater);
                 } else {
-                    getOriginal().super_onCreateOptionsMenu((Menu) args[0], (MenuInflater) args[1]);
-                    return null;
+                    getOriginal().super_onCreateOptionsMenu(menu, inflater);
                 }
             }
         };
@@ -606,19 +587,19 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<View> superCall = new NamedSuperCall<View>(
+        final CallFun3<View, LayoutInflater, ViewGroup, Bundle> superCall
+                = new CallFun3<View, LayoutInflater, ViewGroup, Bundle>(
                 "onCreateView(LayoutInflater, ViewGroup, Bundle)") {
 
             @Override
-            public View call(final Object... args) {
+            public View call(final LayoutInflater inflater, final ViewGroup container,
+                    final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .onCreateView(this, (LayoutInflater) args[0], (ViewGroup) args[1],
-                                    (Bundle) args[2]);
+                            .onCreateView(this, inflater, container, savedInstanceState);
                 } else {
                     return getOriginal()
-                            .super_onCreateView((LayoutInflater) args[0], (ViewGroup) args[1],
-                                    (Bundle) args[2]);
+                            .super_onCreateView(inflater, container, savedInstanceState);
                 }
             }
         };
@@ -633,16 +614,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroy()") {
+        final CallVoid0 superCall = new CallVoid0("onDestroy()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onDestroy(this);
-                    return null;
                 } else {
                     getOriginal().super_onDestroy();
-                    return null;
                 }
             }
         };
@@ -657,16 +636,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroyOptionsMenu()") {
+        final CallVoid0 superCall = new CallVoid0("onDestroyOptionsMenu()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onDestroyOptionsMenu(this);
-                    return null;
                 } else {
                     getOriginal().super_onDestroyOptionsMenu();
-                    return null;
                 }
             }
         };
@@ -681,16 +658,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroyView()") {
+        final CallVoid0 superCall = new CallVoid0("onDestroyView()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onDestroyView(this);
-                    return null;
                 } else {
                     getOriginal().super_onDestroyView();
-                    return null;
                 }
             }
         };
@@ -705,16 +680,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDetach()") {
+        final CallVoid0 superCall = new CallVoid0("onDetach()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onDetach(this);
-                    return null;
                 } else {
                     getOriginal().super_onDetach();
-                    return null;
                 }
             }
         };
@@ -729,17 +702,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onHiddenChanged(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("onHiddenChanged(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean hidden) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onHiddenChanged(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().onHiddenChanged(this, hidden);
                 } else {
-                    getOriginal().super_onHiddenChanged((boolean) args[0]);
-                    return null;
+                    getOriginal().super_onHiddenChanged(hidden);
                 }
             }
         };
@@ -755,19 +725,17 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid3<Context, AttributeSet, Bundle> superCall
+                = new CallVoid3<Context, AttributeSet, Bundle>(
                 "onInflate(Context, AttributeSet, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Context context, final AttributeSet attrs,
+                    final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onInflate(this, (Context) args[0], (AttributeSet) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    iterator.previous().onInflate(this, context, attrs, savedInstanceState);
                 } else {
-                    getOriginal().super_onInflate((Context) args[0], (AttributeSet) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    getOriginal().super_onInflate(context, attrs, savedInstanceState);
                 }
             }
         };
@@ -783,19 +751,17 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid3<Activity, AttributeSet, Bundle> superCall
+                = new CallVoid3<Activity, AttributeSet, Bundle>(
                 "onInflate(Activity, AttributeSet, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Activity activity, final AttributeSet attrs,
+                    final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onInflate(this, (Activity) args[0], (AttributeSet) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    iterator.previous().onInflate(this, activity, attrs, savedInstanceState);
                 } else {
-                    getOriginal().super_onInflate((Activity) args[0], (AttributeSet) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    getOriginal().super_onInflate(activity, attrs, savedInstanceState);
                 }
             }
         };
@@ -810,16 +776,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onLowMemory()") {
+        final CallVoid0 superCall = new CallVoid0("onLowMemory()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onLowMemory(this);
-                    return null;
                 } else {
                     getOriginal().super_onLowMemory();
-                    return null;
                 }
             }
         };
@@ -833,15 +797,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onOptionsItemSelected(MenuItem)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final MenuItem item) {
                 if (iterator.hasPrevious()) {
-                    return iterator.previous().onOptionsItemSelected(this, (MenuItem) args[0]);
+                    return iterator.previous().onOptionsItemSelected(this, item);
                 } else {
-                    return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
+                    return getOriginal().super_onOptionsItemSelected(item);
                 }
             }
         };
@@ -856,17 +820,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onOptionsMenuClosed(Menu)") {
+        final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onOptionsMenuClosed(Menu)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onOptionsMenuClosed(this, (Menu) args[0]);
-                    return null;
+                    iterator.previous().onOptionsMenuClosed(this, menu);
                 } else {
-                    getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
-                    return null;
+                    getOriginal().super_onOptionsMenuClosed(menu);
                 }
             }
         };
@@ -881,16 +842,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPause()") {
+        final CallVoid0 superCall = new CallVoid0("onPause()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onPause(this);
-                    return null;
                 } else {
                     getOriginal().super_onPause();
-                    return null;
                 }
             }
         };
@@ -905,17 +864,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onPrepareOptionsMenu(Menu)") {
+        final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onPrepareOptionsMenu(Menu)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Menu menu) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onPrepareOptionsMenu(this, (Menu) args[0]);
-                    return null;
+                    iterator.previous().onPrepareOptionsMenu(this, menu);
                 } else {
-                    getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
-                    return null;
+                    getOriginal().super_onPrepareOptionsMenu(menu);
                 }
             }
         };
@@ -931,21 +887,19 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onRequestPermissionsResult(int, String[], int[])") {
+        final CallVoid3<Integer, String[], int[]> superCall
+                = new CallVoid3<Integer, String[], int[]>(
+                "onRequestPermissionsResult(Integer, String[], int[])") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Integer requestCode, final String[] permissions,
+                    final int[] grantResults) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .onRequestPermissionsResult(this, (int) args[0], (String[]) args[1],
-                                    (int[]) args[2]);
-                    return null;
+                    iterator.previous().onRequestPermissionsResult(this, requestCode, permissions,
+                            grantResults);
                 } else {
-                    getOriginal()
-                            .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
-                                    (int[]) args[2]);
-                    return null;
+                    getOriginal().super_onRequestPermissionsResult(requestCode, permissions,
+                            grantResults);
                 }
             }
         };
@@ -960,16 +914,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onResume()") {
+        final CallVoid0 superCall = new CallVoid0("onResume()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onResume(this);
-                    return null;
                 } else {
                     getOriginal().super_onResume();
-                    return null;
                 }
             }
         };
@@ -984,17 +936,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onSaveInstanceState(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onSaveInstanceState(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle outState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onSaveInstanceState(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onSaveInstanceState(this, outState);
                 } else {
-                    getOriginal().super_onSaveInstanceState((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onSaveInstanceState(outState);
                 }
             }
         };
@@ -1009,16 +958,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStart()") {
+        final CallVoid0 superCall = new CallVoid0("onStart()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onStart(this);
-                    return null;
                 } else {
                     getOriginal().super_onStart();
-                    return null;
                 }
             }
         };
@@ -1033,16 +980,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStop()") {
+        final CallVoid0 superCall = new CallVoid0("onStop()") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call() {
                 if (iterator.hasPrevious()) {
                     iterator.previous().onStop(this);
-                    return null;
                 } else {
                     getOriginal().super_onStop();
-                    return null;
                 }
             }
         };
@@ -1057,17 +1002,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<View, Bundle> superCall = new CallVoid2<View, Bundle>(
                 "onViewCreated(View, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view, final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onViewCreated(this, (View) args[0], (Bundle) args[1]);
-                    return null;
+                    iterator.previous().onViewCreated(this, view, savedInstanceState);
                 } else {
-                    getOriginal().super_onViewCreated((View) args[0], (Bundle) args[1]);
-                    return null;
+                    getOriginal().super_onViewCreated(view, savedInstanceState);
                 }
             }
         };
@@ -1082,17 +1025,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "onViewStateRestored(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onViewStateRestored(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle savedInstanceState) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().onViewStateRestored(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().onViewStateRestored(this, savedInstanceState);
                 } else {
-                    getOriginal().super_onViewStateRestored((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_onViewStateRestored(savedInstanceState);
                 }
             }
         };
@@ -1107,17 +1047,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "registerForContextMenu(View)") {
+        final CallVoid1<View> superCall = new CallVoid1<View>("registerForContextMenu(View)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().registerForContextMenu(this, (View) args[0]);
-                    return null;
+                    iterator.previous().registerForContextMenu(this, view);
                 } else {
-                    getOriginal().super_registerForContextMenu((View) args[0]);
-                    return null;
+                    getOriginal().super_registerForContextMenu(view);
                 }
             }
         };
@@ -1132,17 +1069,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setAllowEnterTransitionOverlap(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
+                "setAllowEnterTransitionOverlap(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean allow) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setAllowEnterTransitionOverlap(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setAllowEnterTransitionOverlap(this, allow);
                 } else {
-                    getOriginal().super_setAllowEnterTransitionOverlap((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setAllowEnterTransitionOverlap(allow);
                 }
             }
         };
@@ -1157,17 +1092,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setAllowReturnTransitionOverlap(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
+                "setAllowReturnTransitionOverlap(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean allow) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setAllowReturnTransitionOverlap(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setAllowReturnTransitionOverlap(this, allow);
                 } else {
-                    getOriginal().super_setAllowReturnTransitionOverlap((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setAllowReturnTransitionOverlap(allow);
                 }
             }
         };
@@ -1182,16 +1115,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setArguments(Bundle)") {
+        final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("setArguments(Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Bundle args) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setArguments(this, (Bundle) args[0]);
-                    return null;
+                    iterator.previous().setArguments(this, args);
                 } else {
-                    getOriginal().super_setArguments((Bundle) args[0]);
-                    return null;
+                    getOriginal().super_setArguments(args);
                 }
             }
         };
@@ -1206,19 +1137,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setEnterSharedElementCallback(SharedElementCallback)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final SharedElementCallback callback) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setEnterSharedElementCallback(this, (SharedElementCallback) args[0]);
-                    return null;
+                    iterator.previous().setEnterSharedElementCallback(this, callback);
                 } else {
-                    getOriginal()
-                            .super_setEnterSharedElementCallback((SharedElementCallback) args[0]);
-                    return null;
+                    getOriginal().super_setEnterSharedElementCallback(callback);
                 }
             }
         };
@@ -1233,17 +1160,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setEnterTransition(Object)") {
+        final CallVoid1<Object> superCall = new CallVoid1<Object>("setEnterTransition(Object)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Object transition) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setEnterTransition(this, (Object) args[0]);
-                    return null;
+                    iterator.previous().setEnterTransition(this, transition);
                 } else {
-                    getOriginal().super_setEnterTransition((Object) args[0]);
-                    return null;
+                    getOriginal().super_setEnterTransition(transition);
                 }
             }
         };
@@ -1258,19 +1182,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setExitSharedElementCallback(SharedElementCallback)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final SharedElementCallback callback) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .setExitSharedElementCallback(this, (SharedElementCallback) args[0]);
-                    return null;
+                    iterator.previous().setExitSharedElementCallback(this, callback);
                 } else {
-                    getOriginal()
-                            .super_setExitSharedElementCallback((SharedElementCallback) args[0]);
-                    return null;
+                    getOriginal().super_setExitSharedElementCallback(callback);
                 }
             }
         };
@@ -1285,17 +1205,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setExitTransition(Object)") {
+        final CallVoid1<Object> superCall = new CallVoid1<Object>("setExitTransition(Object)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Object transition) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setExitTransition(this, (Object) args[0]);
-                    return null;
+                    iterator.previous().setExitTransition(this, transition);
                 } else {
-                    getOriginal().super_setExitTransition((Object) args[0]);
-                    return null;
+                    getOriginal().super_setExitTransition(transition);
                 }
             }
         };
@@ -1310,17 +1227,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setHasOptionsMenu(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setHasOptionsMenu(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean hasMenu) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setHasOptionsMenu(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setHasOptionsMenu(this, hasMenu);
                 } else {
-                    getOriginal().super_setHasOptionsMenu((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setHasOptionsMenu(hasMenu);
                 }
             }
         };
@@ -1335,17 +1249,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Fragment.SavedState> superCall = new CallVoid1<Fragment.SavedState>(
                 "setInitialSavedState(Fragment.SavedState)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Fragment.SavedState state) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setInitialSavedState(this, (Fragment.SavedState) args[0]);
-                    return null;
+                    iterator.previous().setInitialSavedState(this, state);
                 } else {
-                    getOriginal().super_setInitialSavedState((Fragment.SavedState) args[0]);
-                    return null;
+                    getOriginal().super_setInitialSavedState(state);
                 }
             }
         };
@@ -1360,17 +1272,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setMenuVisibility(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setMenuVisibility(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean menuVisible) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setMenuVisibility(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setMenuVisibility(this, menuVisible);
                 } else {
-                    getOriginal().super_setMenuVisibility((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setMenuVisibility(menuVisible);
                 }
             }
         };
@@ -1385,17 +1294,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setReenterTransition(Object)") {
+        final CallVoid1<Object> superCall = new CallVoid1<Object>("setReenterTransition(Object)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Object transition) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setReenterTransition(this, (Object) args[0]);
-                    return null;
+                    iterator.previous().setReenterTransition(this, transition);
                 } else {
-                    getOriginal().super_setReenterTransition((Object) args[0]);
-                    return null;
+                    getOriginal().super_setReenterTransition(transition);
                 }
             }
         };
@@ -1410,17 +1316,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setRetainInstance(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setRetainInstance(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean retain) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setRetainInstance(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setRetainInstance(this, retain);
                 } else {
-                    getOriginal().super_setRetainInstance((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setRetainInstance(retain);
                 }
             }
         };
@@ -1435,17 +1338,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setReturnTransition(Object)") {
+        final CallVoid1<Object> superCall = new CallVoid1<Object>("setReturnTransition(Object)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Object transition) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setReturnTransition(this, (Object) args[0]);
-                    return null;
+                    iterator.previous().setReturnTransition(this, transition);
                 } else {
-                    getOriginal().super_setReturnTransition((Object) args[0]);
-                    return null;
+                    getOriginal().super_setReturnTransition(transition);
                 }
             }
         };
@@ -1460,17 +1360,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Object> superCall = new CallVoid1<Object>(
                 "setSharedElementEnterTransition(Object)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Object transition) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setSharedElementEnterTransition(this, (Object) args[0]);
-                    return null;
+                    iterator.previous().setSharedElementEnterTransition(this, transition);
                 } else {
-                    getOriginal().super_setSharedElementEnterTransition((Object) args[0]);
-                    return null;
+                    getOriginal().super_setSharedElementEnterTransition(transition);
                 }
             }
         };
@@ -1485,17 +1383,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid1<Object> superCall = new CallVoid1<Object>(
                 "setSharedElementReturnTransition(Object)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Object transition) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setSharedElementReturnTransition(this, (Object) args[0]);
-                    return null;
+                    iterator.previous().setSharedElementReturnTransition(this, transition);
                 } else {
-                    getOriginal().super_setSharedElementReturnTransition((Object) args[0]);
-                    return null;
+                    getOriginal().super_setSharedElementReturnTransition(transition);
                 }
             }
         };
@@ -1510,17 +1406,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setTargetFragment(Fragment, int)") {
+        final CallVoid2<Fragment, Integer> superCall = new CallVoid2<Fragment, Integer>(
+                "setTargetFragment(Fragment, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Fragment fragment, final Integer requestCode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setTargetFragment(this, (Fragment) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().setTargetFragment(this, fragment, requestCode);
                 } else {
-                    getOriginal().super_setTargetFragment((Fragment) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_setTargetFragment(fragment, requestCode);
                 }
             }
         };
@@ -1535,17 +1429,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "setUserVisibleHint(boolean)") {
+        final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setUserVisibleHint(Boolean)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Boolean isVisibleToUser) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().setUserVisibleHint(this, (boolean) args[0]);
-                    return null;
+                    iterator.previous().setUserVisibleHint(this, isVisibleToUser);
                 } else {
-                    getOriginal().super_setUserVisibleHint((boolean) args[0]);
-                    return null;
+                    getOriginal().super_setUserVisibleHint(isVisibleToUser);
                 }
             }
         };
@@ -1559,17 +1450,16 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+        final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "shouldShowRequestPermissionRationale(String)") {
 
             @Override
-            public Boolean call(final Object... args) {
+            public Boolean call(final String permission) {
                 if (iterator.hasPrevious()) {
                     return iterator.previous()
-                            .shouldShowRequestPermissionRationale(this, (String) args[0]);
+                            .shouldShowRequestPermissionRationale(this, permission);
                 } else {
-                    return getOriginal()
-                            .super_shouldShowRequestPermissionRationale((String) args[0]);
+                    return getOriginal().super_shouldShowRequestPermissionRationale(permission);
                 }
             }
         };
@@ -1584,16 +1474,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("startActivity(Intent)") {
+        final CallVoid1<Intent> superCall = new CallVoid1<Intent>("startActivity(Intent)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startActivity(this, (Intent) args[0]);
-                    return null;
+                    iterator.previous().startActivity(this, intent);
                 } else {
-                    getOriginal().super_startActivity((Intent) args[0]);
-                    return null;
+                    getOriginal().super_startActivity(intent);
                 }
             }
         };
@@ -1608,17 +1496,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+        final CallVoid2<Intent, Bundle> superCall = new CallVoid2<Intent, Bundle>(
                 "startActivity(Intent, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final Bundle options) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().startActivity(this, (Intent) args[0], (Bundle) args[1]);
-                    return null;
+                    iterator.previous().startActivity(this, intent, options);
                 } else {
-                    getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
-                    return null;
+                    getOriginal().super_startActivity(intent, options);
                 }
             }
         };
@@ -1633,18 +1519,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityForResult(Intent, int)") {
+        final CallVoid2<Intent, Integer> superCall = new CallVoid2<Intent, Integer>(
+                "startActivityForResult(Intent, Integer)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final Integer requestCode) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .startActivityForResult(this, (Intent) args[0], (int) args[1]);
-                    return null;
+                    iterator.previous().startActivityForResult(this, intent, requestCode);
                 } else {
-                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
-                    return null;
+                    getOriginal().super_startActivityForResult(intent, requestCode);
                 }
             }
         };
@@ -1660,20 +1543,15 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "startActivityForResult(Intent, int, Bundle)") {
+        final CallVoid3<Intent, Integer, Bundle> superCall = new CallVoid3<Intent, Integer, Bundle>(
+                "startActivityForResult(Intent, Integer, Bundle)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final Intent intent, final Integer requestCode, final Bundle options) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous()
-                            .startActivityForResult(this, (Intent) args[0], (int) args[1],
-                                    (Bundle) args[2]);
-                    return null;
+                    iterator.previous().startActivityForResult(this, intent, requestCode, options);
                 } else {
-                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
-                            (Bundle) args[2]);
-                    return null;
+                    getOriginal().super_startActivityForResult(intent, requestCode, options);
                 }
             }
         };
@@ -1687,10 +1565,10 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("toString()") {
+        final CallFun0<String> superCall = new CallFun0<String>("toString()") {
 
             @Override
-            public String call(final Object... args) {
+            public String call() {
                 if (iterator.hasPrevious()) {
                     return iterator.previous().toString(this);
                 } else {
@@ -1709,17 +1587,14 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
         final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
-                "unregisterForContextMenu(View)") {
+        final CallVoid1<View> superCall = new CallVoid1<View>("unregisterForContextMenu(View)") {
 
             @Override
-            public Void call(final Object... args) {
+            public void call(final View view) {
                 if (iterator.hasPrevious()) {
-                    iterator.previous().unregisterForContextMenu(this, (View) args[0]);
-                    return null;
+                    iterator.previous().unregisterForContextMenu(this, view);
                 } else {
-                    getOriginal().super_unregisterForContextMenu((View) args[0]);
-                    return null;
+                    getOriginal().super_unregisterForContextMenu(view);
                 }
             }
         };

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
@@ -2,10 +2,6 @@ package com.pascalwelsch.compositeandroid.fragment;
 
 import com.pascalwelsch.compositeandroid.core.AbstractDelegate;
 import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
-import com.pascalwelsch.compositeandroid.core.PluginCall;
-import com.pascalwelsch.compositeandroid.core.PluginCallVoid;
-import com.pascalwelsch.compositeandroid.core.SuperCall;
-import com.pascalwelsch.compositeandroid.core.SuperCallVoid;
 
 import android.app.Activity;
 import android.content.Context;
@@ -29,6 +25,7 @@ import android.view.animation.Animation;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
+import java.util.ListIterator;
 
 public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, FragmentPlugin> {
 
@@ -41,1144 +38,1692 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
     public void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args) {
-        callHook("dump(String, FileDescriptor, PrintWriter, String[])",
-                new PluginCallVoid<FragmentPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-                        plugin.dump(superCall, (String) args[0], (FileDescriptor) args[1],
-                                (PrintWriter) args[2], (String[]) args[3]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
-                                (PrintWriter) args[2], (String[]) args[3]);
-                    }
-                }, prefix, fd, writer, args);
-    }
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_dump(prefix, fd, writer, args);
+            return;
+        }
 
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "dump(String, FileDescriptor, PrintWriter, String[])") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().dump(this, (String) args[0], (FileDescriptor) args[1],
+                            (PrintWriter) args[2], (String[]) args[3]);
+                    return null;
+                } else {
+                    getOriginal().super_dump((String) args[0], (FileDescriptor) args[1],
+                            (PrintWriter) args[2], (String[]) args[3]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(prefix, fd, writer, args);
+    }
 
     public boolean getAllowEnterTransitionOverlap() {
-        return callFunction("getAllowEnterTransitionOverlap()",
-                new PluginCall<FragmentPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getAllowEnterTransitionOverlap();
+        }
 
-                        return plugin.getAllowEnterTransitionOverlap(superCall);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_getAllowEnterTransitionOverlap();
-                    }
-                });
-    }
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "getAllowEnterTransitionOverlap()") {
 
-
-    public boolean getAllowReturnTransitionOverlap() {
-        return callFunction("getAllowReturnTransitionOverlap()",
-                new PluginCall<FragmentPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-
-                        return plugin.getAllowReturnTransitionOverlap(superCall);
-
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_getAllowReturnTransitionOverlap();
-                    }
-                });
-    }
-
-
-    public Context getContext() {
-        return callFunction("getContext()", new PluginCall<FragmentPlugin, Context>() {
-            @Override
-            public Context call(final NamedSuperCall<Context> superCall,
-                    final FragmentPlugin plugin, final Object... args) {
-
-                return plugin.getContext(superCall);
-
-            }
-        }, new SuperCall<Context>() {
-            @Override
-            public Context call(final Object... args) {
-                return getOriginal().super_getContext();
-            }
-        });
-    }
-
-
-    public Object getEnterTransition() {
-        return callFunction("getEnterTransition()", new PluginCall<FragmentPlugin, Object>() {
-            @Override
-            public Object call(final NamedSuperCall<Object> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-
-                return plugin.getEnterTransition(superCall);
-
-            }
-        }, new SuperCall<Object>() {
-            @Override
-            public Object call(final Object... args) {
-                return getOriginal().super_getEnterTransition();
-            }
-        });
-    }
-
-
-    public Object getExitTransition() {
-        return callFunction("getExitTransition()", new PluginCall<FragmentPlugin, Object>() {
-            @Override
-            public Object call(final NamedSuperCall<Object> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-
-                return plugin.getExitTransition(superCall);
-
-            }
-        }, new SuperCall<Object>() {
-            @Override
-            public Object call(final Object... args) {
-                return getOriginal().super_getExitTransition();
-            }
-        });
-    }
-
-
-    public LayoutInflater getLayoutInflater(final Bundle savedInstanceState) {
-        return callFunction("getLayoutInflater(Bundle)",
-                new PluginCall<FragmentPlugin, LayoutInflater>() {
-                    @Override
-                    public LayoutInflater call(final NamedSuperCall<LayoutInflater> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-
-                        return plugin.getLayoutInflater(superCall, (Bundle) args[0]);
-
-                    }
-                }, new SuperCall<LayoutInflater>() {
-                    @Override
-                    public LayoutInflater call(final Object... args) {
-                        return getOriginal().super_getLayoutInflater((Bundle) args[0]);
-                    }
-                }, savedInstanceState);
-    }
-
-
-    public LoaderManager getLoaderManager() {
-        return callFunction("getLoaderManager()", new PluginCall<FragmentPlugin, LoaderManager>() {
-            @Override
-            public LoaderManager call(final NamedSuperCall<LoaderManager> superCall,
-                    final FragmentPlugin plugin, final Object... args) {
-
-                return plugin.getLoaderManager(superCall);
-
-            }
-        }, new SuperCall<LoaderManager>() {
-            @Override
-            public LoaderManager call(final Object... args) {
-                return getOriginal().super_getLoaderManager();
-            }
-        });
-    }
-
-
-    public Object getReenterTransition() {
-        return callFunction("getReenterTransition()", new PluginCall<FragmentPlugin, Object>() {
-            @Override
-            public Object call(final NamedSuperCall<Object> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-
-                return plugin.getReenterTransition(superCall);
-
-            }
-        }, new SuperCall<Object>() {
-            @Override
-            public Object call(final Object... args) {
-                return getOriginal().super_getReenterTransition();
-            }
-        });
-    }
-
-
-    public Object getReturnTransition() {
-        return callFunction("getReturnTransition()", new PluginCall<FragmentPlugin, Object>() {
-            @Override
-            public Object call(final NamedSuperCall<Object> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-
-                return plugin.getReturnTransition(superCall);
-
-            }
-        }, new SuperCall<Object>() {
-            @Override
-            public Object call(final Object... args) {
-                return getOriginal().super_getReturnTransition();
-            }
-        });
-    }
-
-
-    public Object getSharedElementEnterTransition() {
-        return callFunction("getSharedElementEnterTransition()",
-                new PluginCall<FragmentPlugin, Object>() {
-                    @Override
-                    public Object call(final NamedSuperCall<Object> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-
-                        return plugin.getSharedElementEnterTransition(superCall);
-
-                    }
-                }, new SuperCall<Object>() {
-                    @Override
-                    public Object call(final Object... args) {
-                        return getOriginal().super_getSharedElementEnterTransition();
-                    }
-                });
-    }
-
-
-    public Object getSharedElementReturnTransition() {
-        return callFunction("getSharedElementReturnTransition()",
-                new PluginCall<FragmentPlugin, Object>() {
-                    @Override
-                    public Object call(final NamedSuperCall<Object> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-
-                        return plugin.getSharedElementReturnTransition(superCall);
-
-                    }
-                }, new SuperCall<Object>() {
-                    @Override
-                    public Object call(final Object... args) {
-                        return getOriginal().super_getSharedElementReturnTransition();
-                    }
-                });
-    }
-
-
-    public boolean getUserVisibleHint() {
-        return callFunction("getUserVisibleHint()", new PluginCall<FragmentPlugin, Boolean>() {
-            @Override
-            public Boolean call(final NamedSuperCall<Boolean> superCall,
-                    final FragmentPlugin plugin, final Object... args) {
-
-                return plugin.getUserVisibleHint(superCall);
-
-            }
-        }, new SuperCall<Boolean>() {
             @Override
             public Boolean call(final Object... args) {
-                return getOriginal().super_getUserVisibleHint();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getAllowEnterTransitionOverlap(this);
+                } else {
+                    return getOriginal().super_getAllowEnterTransitionOverlap();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
+    public boolean getAllowReturnTransitionOverlap() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getAllowReturnTransitionOverlap();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "getAllowReturnTransitionOverlap()") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getAllowReturnTransitionOverlap(this);
+                } else {
+                    return getOriginal().super_getAllowReturnTransitionOverlap();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public Context getContext() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getContext();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Context> superCall = new NamedSuperCall<Context>("getContext()") {
+
+            @Override
+            public Context call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getContext(this);
+                } else {
+                    return getOriginal().super_getContext();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public Object getEnterTransition() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getEnterTransition();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+                "getEnterTransition()") {
+
+            @Override
+            public Object call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getEnterTransition(this);
+                } else {
+                    return getOriginal().super_getEnterTransition();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public Object getExitTransition() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getExitTransition();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>("getExitTransition()") {
+
+            @Override
+            public Object call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getExitTransition(this);
+                } else {
+                    return getOriginal().super_getExitTransition();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public LayoutInflater getLayoutInflater(final Bundle savedInstanceState) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getLayoutInflater(savedInstanceState);
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<LayoutInflater> superCall = new NamedSuperCall<LayoutInflater>(
+                "getLayoutInflater(Bundle)") {
+
+            @Override
+            public LayoutInflater call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getLayoutInflater(this, (Bundle) args[0]);
+                } else {
+                    return getOriginal().super_getLayoutInflater((Bundle) args[0]);
+                }
+            }
+        };
+        return superCall.call(savedInstanceState);
+    }
+
+    public LoaderManager getLoaderManager() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getLoaderManager();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<LoaderManager> superCall = new NamedSuperCall<LoaderManager>(
+                "getLoaderManager()") {
+
+            @Override
+            public LoaderManager call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getLoaderManager(this);
+                } else {
+                    return getOriginal().super_getLoaderManager();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public Object getReenterTransition() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getReenterTransition();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+                "getReenterTransition()") {
+
+            @Override
+            public Object call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getReenterTransition(this);
+                } else {
+                    return getOriginal().super_getReenterTransition();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public Object getReturnTransition() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getReturnTransition();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+                "getReturnTransition()") {
+
+            @Override
+            public Object call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getReturnTransition(this);
+                } else {
+                    return getOriginal().super_getReturnTransition();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public Object getSharedElementEnterTransition() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSharedElementEnterTransition();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+                "getSharedElementEnterTransition()") {
+
+            @Override
+            public Object call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSharedElementEnterTransition(this);
+                } else {
+                    return getOriginal().super_getSharedElementEnterTransition();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public Object getSharedElementReturnTransition() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getSharedElementReturnTransition();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Object> superCall = new NamedSuperCall<Object>(
+                "getSharedElementReturnTransition()") {
+
+            @Override
+            public Object call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getSharedElementReturnTransition(this);
+                } else {
+                    return getOriginal().super_getSharedElementReturnTransition();
+                }
+            }
+        };
+        return superCall.call();
+    }
+
+    public boolean getUserVisibleHint() {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getUserVisibleHint();
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "getUserVisibleHint()") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getUserVisibleHint(this);
+                } else {
+                    return getOriginal().super_getUserVisibleHint();
+                }
+            }
+        };
+        return superCall.call();
+    }
 
     public View getView() {
-        return callFunction("getView()", new PluginCall<FragmentPlugin, View>() {
-            @Override
-            public View call(final NamedSuperCall<View> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_getView();
+        }
 
-                return plugin.getView(superCall);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<View>() {
+        final NamedSuperCall<View> superCall = new NamedSuperCall<View>("getView()") {
+
             @Override
             public View call(final Object... args) {
-                return getOriginal().super_getView();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().getView(this);
+                } else {
+                    return getOriginal().super_getView();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
-        callHook("onActivityCreated(Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onActivityCreated(savedInstanceState);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onActivityCreated(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onActivityCreated(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onActivityCreated(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onActivityCreated((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onActivityCreated((Bundle) args[0]);
-            }
-        }, savedInstanceState);
+        };
+        superCall.call(savedInstanceState);
     }
 
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        callHook("onActivityResult(int, int, Intent)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onActivityResult(requestCode, resultCode, data);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onActivityResult(int, int, Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onActivityResult(superCall, (int) args[0], (int) args[1], (Intent) args[2]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onActivityResult(this, (int) args[0], (int) args[1], (Intent) args[2]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal()
-                        .super_onActivityResult((int) args[0], (int) args[1], (Intent) args[2]);
-            }
-        }, requestCode, resultCode, data);
+        };
+        superCall.call(requestCode, resultCode, data);
     }
 
     public void onAttach(final Context context) {
-        callHook("onAttach(Context)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onAttach(context);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onAttach(Context)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onAttach(superCall, (Context) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onAttach(this, (Context) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onAttach((Context) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onAttach((Context) args[0]);
-            }
-        }, context);
+        };
+        superCall.call(context);
     }
 
     public void onAttach(final Activity activity) {
-        callHook("onAttach(Activity)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onAttach(activity);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onAttach(Activity)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onAttach(superCall, (Activity) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onAttach(this, (Activity) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onAttach((Activity) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onAttach((Activity) args[0]);
-            }
-        }, activity);
+        };
+        superCall.call(activity);
     }
 
     public void onConfigurationChanged(final Configuration newConfig) {
-        callHook("onConfigurationChanged(Configuration)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onConfigurationChanged(newConfig);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onConfigurationChanged(Configuration)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onConfigurationChanged(superCall, (Configuration) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onConfigurationChanged(this, (Configuration) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onConfigurationChanged((Configuration) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onConfigurationChanged((Configuration) args[0]);
-            }
-        }, newConfig);
+        };
+        superCall.call(newConfig);
     }
 
-
     public boolean onContextItemSelected(final MenuItem item) {
-        return callFunction("onContextItemSelected(MenuItem)",
-                new PluginCall<FragmentPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onContextItemSelected(item);
+        }
 
-                        return plugin.onContextItemSelected(superCall, (MenuItem) args[0]);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
-                    }
-                }, item);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onContextItemSelected(MenuItem)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onContextItemSelected(this, (MenuItem) args[0]);
+                } else {
+                    return getOriginal().super_onContextItemSelected((MenuItem) args[0]);
+                }
+            }
+        };
+        return superCall.call(item);
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
-        callHook("onCreate(Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreate(savedInstanceState);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onCreate(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onCreate(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onCreate(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreate((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onCreate((Bundle) args[0]);
-            }
-        }, savedInstanceState);
+        };
+        superCall.call(savedInstanceState);
     }
 
-
     public Animation onCreateAnimation(final int transit, final boolean enter, final int nextAnim) {
-        return callFunction("onCreateAnimation(int, boolean, int)",
-                new PluginCall<FragmentPlugin, Animation>() {
-                    @Override
-                    public Animation call(final NamedSuperCall<Animation> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateAnimation(transit, enter, nextAnim);
+        }
 
-                        return plugin.onCreateAnimation(superCall, (int) args[0], (boolean) args[1],
-                                (int) args[2]);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Animation>() {
-                    @Override
-                    public Animation call(final Object... args) {
-                        return getOriginal()
-                                .super_onCreateAnimation((int) args[0], (boolean) args[1],
-                                        (int) args[2]);
-                    }
-                }, transit, enter, nextAnim);
+        final NamedSuperCall<Animation> superCall = new NamedSuperCall<Animation>(
+                "onCreateAnimation(int, boolean, int)") {
+
+            @Override
+            public Animation call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onCreateAnimation(this, (int) args[0], (boolean) args[1],
+                                    (int) args[2]);
+                } else {
+                    return getOriginal().super_onCreateAnimation((int) args[0], (boolean) args[1],
+                            (int) args[2]);
+                }
+            }
+        };
+        return superCall.call(transit, enter, nextAnim);
     }
 
     public void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo) {
-        callHook("onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)",
-                new PluginCallVoid<FragmentPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-                        plugin.onCreateContextMenu(superCall, (ContextMenu) args[0], (View) args[1],
-                                (ContextMenu.ContextMenuInfo) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
-                                        (ContextMenu.ContextMenuInfo) args[2]);
-                    }
-                }, menu, v, menuInfo);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreateContextMenu(menu, v, menuInfo);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onCreateContextMenu(this, (ContextMenu) args[0], (View) args[1],
+                                    (ContextMenu.ContextMenuInfo) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreateContextMenu((ContextMenu) args[0], (View) args[1],
+                            (ContextMenu.ContextMenuInfo) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(menu, v, menuInfo);
     }
 
     public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
-        callHook("onCreateOptionsMenu(Menu, MenuInflater)", new PluginCallVoid<FragmentPlugin>() {
-            @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onCreateOptionsMenu(superCall, (Menu) args[0], (MenuInflater) args[1]);
-            }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onCreateOptionsMenu((Menu) args[0], (MenuInflater) args[1]);
-            }
-        }, menu, inflater);
-    }
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onCreateOptionsMenu(menu, inflater);
+            return;
+        }
 
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onCreateOptionsMenu(Menu, MenuInflater)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onCreateOptionsMenu(this, (Menu) args[0], (MenuInflater) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onCreateOptionsMenu((Menu) args[0], (MenuInflater) args[1]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(menu, inflater);
+    }
 
     public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
             @Nullable final Bundle savedInstanceState) {
-        return callFunction("onCreateView(LayoutInflater, ViewGroup, Bundle)",
-                new PluginCall<FragmentPlugin, View>() {
-                    @Override
-                    public View call(final NamedSuperCall<View> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onCreateView(inflater, container, savedInstanceState);
+        }
 
-                        return plugin.onCreateView(superCall, (LayoutInflater) args[0],
-                                (ViewGroup) args[1], (Bundle) args[2]);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<View>() {
-                    @Override
-                    public View call(final Object... args) {
-                        return getOriginal()
-                                .super_onCreateView((LayoutInflater) args[0], (ViewGroup) args[1],
-                                        (Bundle) args[2]);
-                    }
-                }, inflater, container, savedInstanceState);
+        final NamedSuperCall<View> superCall = new NamedSuperCall<View>(
+                "onCreateView(LayoutInflater, ViewGroup, Bundle)") {
+
+            @Override
+            public View call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .onCreateView(this, (LayoutInflater) args[0], (ViewGroup) args[1],
+                                    (Bundle) args[2]);
+                } else {
+                    return getOriginal()
+                            .super_onCreateView((LayoutInflater) args[0], (ViewGroup) args[1],
+                                    (Bundle) args[2]);
+                }
+            }
+        };
+        return superCall.call(inflater, container, savedInstanceState);
     }
 
     public void onDestroy() {
-        callHook("onDestroy()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onDestroy();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroy()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onDestroy(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onDestroy(this);
+                    return null;
+                } else {
+                    getOriginal().super_onDestroy();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onDestroy();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onDestroyOptionsMenu() {
-        callHook("onDestroyOptionsMenu()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onDestroyOptionsMenu();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroyOptionsMenu()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onDestroyOptionsMenu(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onDestroyOptionsMenu(this);
+                    return null;
+                } else {
+                    getOriginal().super_onDestroyOptionsMenu();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onDestroyOptionsMenu();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onDestroyView() {
-        callHook("onDestroyView()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onDestroyView();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDestroyView()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onDestroyView(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onDestroyView(this);
+                    return null;
+                } else {
+                    getOriginal().super_onDestroyView();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onDestroyView();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onDetach() {
-        callHook("onDetach()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onDetach();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onDetach()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onDetach(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onDetach(this);
+                    return null;
+                } else {
+                    getOriginal().super_onDetach();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onDetach();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onHiddenChanged(final boolean hidden) {
-        callHook("onHiddenChanged(boolean)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onHiddenChanged(hidden);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onHiddenChanged(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onHiddenChanged(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onHiddenChanged(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onHiddenChanged((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onHiddenChanged((boolean) args[0]);
-            }
-        }, hidden);
+        };
+        superCall.call(hidden);
     }
 
     public void onInflate(final Context context, final AttributeSet attrs,
             final Bundle savedInstanceState) {
-        callHook("onInflate(Context, AttributeSet, Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onInflate(context, attrs, savedInstanceState);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onInflate(Context, AttributeSet, Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onInflate(superCall, (Context) args[0], (AttributeSet) args[1],
-                        (Bundle) args[2]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onInflate(this, (Context) args[0], (AttributeSet) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_onInflate((Context) args[0], (AttributeSet) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onInflate((Context) args[0], (AttributeSet) args[1],
-                        (Bundle) args[2]);
-            }
-        }, context, attrs, savedInstanceState);
+        };
+        superCall.call(context, attrs, savedInstanceState);
     }
 
     public void onInflate(final Activity activity, final AttributeSet attrs,
             final Bundle savedInstanceState) {
-        callHook("onInflate(Activity, AttributeSet, Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onInflate(activity, attrs, savedInstanceState);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onInflate(Activity, AttributeSet, Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onInflate(superCall, (Activity) args[0], (AttributeSet) args[1],
-                        (Bundle) args[2]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onInflate(this, (Activity) args[0], (AttributeSet) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_onInflate((Activity) args[0], (AttributeSet) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onInflate((Activity) args[0], (AttributeSet) args[1],
-                        (Bundle) args[2]);
-            }
-        }, activity, attrs, savedInstanceState);
+        };
+        superCall.call(activity, attrs, savedInstanceState);
     }
 
     public void onLowMemory() {
-        callHook("onLowMemory()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onLowMemory();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onLowMemory()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onLowMemory(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onLowMemory(this);
+                    return null;
+                } else {
+                    getOriginal().super_onLowMemory();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onLowMemory();
-            }
-        });
+        };
+        superCall.call();
     }
 
-
     public boolean onOptionsItemSelected(final MenuItem item) {
-        return callFunction("onOptionsItemSelected(MenuItem)",
-                new PluginCall<FragmentPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_onOptionsItemSelected(item);
+        }
 
-                        return plugin.onOptionsItemSelected(superCall, (MenuItem) args[0]);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
-                    }
-                }, item);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "onOptionsItemSelected(MenuItem)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().onOptionsItemSelected(this, (MenuItem) args[0]);
+                } else {
+                    return getOriginal().super_onOptionsItemSelected((MenuItem) args[0]);
+                }
+            }
+        };
+        return superCall.call(item);
     }
 
     public void onOptionsMenuClosed(final Menu menu) {
-        callHook("onOptionsMenuClosed(Menu)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onOptionsMenuClosed(menu);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onOptionsMenuClosed(Menu)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onOptionsMenuClosed(superCall, (Menu) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onOptionsMenuClosed(this, (Menu) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onOptionsMenuClosed((Menu) args[0]);
-            }
-        }, menu);
+        };
+        superCall.call(menu);
     }
 
     public void onPause() {
-        callHook("onPause()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPause();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onPause()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onPause(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPause(this);
+                    return null;
+                } else {
+                    getOriginal().super_onPause();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPause();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onPrepareOptionsMenu(final Menu menu) {
-        callHook("onPrepareOptionsMenu(Menu)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onPrepareOptionsMenu(menu);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onPrepareOptionsMenu(Menu)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onPrepareOptionsMenu(superCall, (Menu) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onPrepareOptionsMenu(this, (Menu) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onPrepareOptionsMenu((Menu) args[0]);
-            }
-        }, menu);
+        };
+        superCall.call(menu);
     }
 
     public void onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        callHook("onRequestPermissionsResult(int, String[], int[])",
-                new PluginCallVoid<FragmentPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-                        plugin.onRequestPermissionsResult(superCall, (int) args[0],
-                                (String[]) args[1], (int[]) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal()
-                                .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
-                                        (int[]) args[2]);
-                    }
-                }, requestCode, permissions, grantResults);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onRequestPermissionsResult(requestCode, permissions, grantResults);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onRequestPermissionsResult(int, String[], int[])") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .onRequestPermissionsResult(this, (int) args[0], (String[]) args[1],
+                                    (int[]) args[2]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_onRequestPermissionsResult((int) args[0], (String[]) args[1],
+                                    (int[]) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(requestCode, permissions, grantResults);
     }
 
     public void onResume() {
-        callHook("onResume()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onResume();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onResume()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onResume(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onResume(this);
+                    return null;
+                } else {
+                    getOriginal().super_onResume();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onResume();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onSaveInstanceState(final Bundle outState) {
-        callHook("onSaveInstanceState(Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onSaveInstanceState(outState);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onSaveInstanceState(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onSaveInstanceState(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onSaveInstanceState(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onSaveInstanceState((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onSaveInstanceState((Bundle) args[0]);
-            }
-        }, outState);
+        };
+        superCall.call(outState);
     }
 
     public void onStart() {
-        callHook("onStart()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onStart();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStart()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onStart(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onStart(this);
+                    return null;
+                } else {
+                    getOriginal().super_onStart();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onStart();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onStop() {
-        callHook("onStop()", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onStop();
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("onStop()") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onStop(superCall);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onStop(this);
+                    return null;
+                } else {
+                    getOriginal().super_onStop();
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onStop();
-            }
-        });
+        };
+        superCall.call();
     }
 
     public void onViewCreated(final View view, @Nullable final Bundle savedInstanceState) {
-        callHook("onViewCreated(View, Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onViewCreated(view, savedInstanceState);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onViewCreated(View, Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onViewCreated(superCall, (View) args[0], (Bundle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onViewCreated(this, (View) args[0], (Bundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_onViewCreated((View) args[0], (Bundle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onViewCreated((View) args[0], (Bundle) args[1]);
-            }
-        }, view, savedInstanceState);
+        };
+        superCall.call(view, savedInstanceState);
     }
 
     public void onViewStateRestored(@Nullable final Bundle savedInstanceState) {
-        callHook("onViewStateRestored(Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_onViewStateRestored(savedInstanceState);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "onViewStateRestored(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.onViewStateRestored(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().onViewStateRestored(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_onViewStateRestored((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_onViewStateRestored((Bundle) args[0]);
-            }
-        }, savedInstanceState);
+        };
+        superCall.call(savedInstanceState);
     }
 
     public void registerForContextMenu(final View view) {
-        callHook("registerForContextMenu(View)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_registerForContextMenu(view);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "registerForContextMenu(View)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.registerForContextMenu(superCall, (View) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().registerForContextMenu(this, (View) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_registerForContextMenu((View) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_registerForContextMenu((View) args[0]);
-            }
-        }, view);
+        };
+        superCall.call(view);
     }
 
     public void setAllowEnterTransitionOverlap(final boolean allow) {
-        callHook("setAllowEnterTransitionOverlap(boolean)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setAllowEnterTransitionOverlap(allow);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setAllowEnterTransitionOverlap(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setAllowEnterTransitionOverlap(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setAllowEnterTransitionOverlap(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setAllowEnterTransitionOverlap((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setAllowEnterTransitionOverlap((boolean) args[0]);
-            }
-        }, allow);
+        };
+        superCall.call(allow);
     }
 
     public void setAllowReturnTransitionOverlap(final boolean allow) {
-        callHook("setAllowReturnTransitionOverlap(boolean)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setAllowReturnTransitionOverlap(allow);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setAllowReturnTransitionOverlap(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setAllowReturnTransitionOverlap(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setAllowReturnTransitionOverlap(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setAllowReturnTransitionOverlap((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setAllowReturnTransitionOverlap((boolean) args[0]);
-            }
-        }, allow);
+        };
+        superCall.call(allow);
     }
 
     public void setArguments(final Bundle args) {
-        callHook("setArguments(Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setArguments(args);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("setArguments(Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setArguments(superCall, (Bundle) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setArguments(this, (Bundle) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setArguments((Bundle) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setArguments((Bundle) args[0]);
-            }
-        }, args);
+        };
+        superCall.call(args);
     }
 
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
-        callHook("setEnterSharedElementCallback(SharedElementCallback)",
-                new PluginCallVoid<FragmentPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-                        plugin.setEnterSharedElementCallback(superCall,
-                                (SharedElementCallback) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setEnterSharedElementCallback(
-                                (SharedElementCallback) args[0]);
-                    }
-                }, callback);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setEnterSharedElementCallback(callback);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setEnterSharedElementCallback(SharedElementCallback)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setEnterSharedElementCallback(this, (SharedElementCallback) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setEnterSharedElementCallback((SharedElementCallback) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(callback);
     }
 
     public void setEnterTransition(final Object transition) {
-        callHook("setEnterTransition(Object)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setEnterTransition(transition);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setEnterTransition(Object)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setEnterTransition(superCall, (Object) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setEnterTransition(this, (Object) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setEnterTransition((Object) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setEnterTransition((Object) args[0]);
-            }
-        }, transition);
+        };
+        superCall.call(transition);
     }
 
     public void setExitSharedElementCallback(final SharedElementCallback callback) {
-        callHook("setExitSharedElementCallback(SharedElementCallback)",
-                new PluginCallVoid<FragmentPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-                        plugin.setExitSharedElementCallback(superCall,
-                                (SharedElementCallback) args[0]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_setExitSharedElementCallback(
-                                (SharedElementCallback) args[0]);
-                    }
-                }, callback);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setExitSharedElementCallback(callback);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setExitSharedElementCallback(SharedElementCallback)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .setExitSharedElementCallback(this, (SharedElementCallback) args[0]);
+                    return null;
+                } else {
+                    getOriginal()
+                            .super_setExitSharedElementCallback((SharedElementCallback) args[0]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(callback);
     }
 
     public void setExitTransition(final Object transition) {
-        callHook("setExitTransition(Object)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setExitTransition(transition);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setExitTransition(Object)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setExitTransition(superCall, (Object) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setExitTransition(this, (Object) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setExitTransition((Object) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setExitTransition((Object) args[0]);
-            }
-        }, transition);
+        };
+        superCall.call(transition);
     }
 
     public void setHasOptionsMenu(final boolean hasMenu) {
-        callHook("setHasOptionsMenu(boolean)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setHasOptionsMenu(hasMenu);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setHasOptionsMenu(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setHasOptionsMenu(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setHasOptionsMenu(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setHasOptionsMenu((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setHasOptionsMenu((boolean) args[0]);
-            }
-        }, hasMenu);
+        };
+        superCall.call(hasMenu);
     }
 
     public void setInitialSavedState(final Fragment.SavedState state) {
-        callHook("setInitialSavedState(Fragment.SavedState)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setInitialSavedState(state);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setInitialSavedState(Fragment.SavedState)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setInitialSavedState(superCall, (Fragment.SavedState) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setInitialSavedState(this, (Fragment.SavedState) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setInitialSavedState((Fragment.SavedState) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setInitialSavedState((Fragment.SavedState) args[0]);
-            }
-        }, state);
+        };
+        superCall.call(state);
     }
 
     public void setMenuVisibility(final boolean menuVisible) {
-        callHook("setMenuVisibility(boolean)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setMenuVisibility(menuVisible);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setMenuVisibility(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setMenuVisibility(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setMenuVisibility(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setMenuVisibility((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setMenuVisibility((boolean) args[0]);
-            }
-        }, menuVisible);
+        };
+        superCall.call(menuVisible);
     }
 
     public void setReenterTransition(final Object transition) {
-        callHook("setReenterTransition(Object)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setReenterTransition(transition);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setReenterTransition(Object)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setReenterTransition(superCall, (Object) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setReenterTransition(this, (Object) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setReenterTransition((Object) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setReenterTransition((Object) args[0]);
-            }
-        }, transition);
+        };
+        superCall.call(transition);
     }
 
     public void setRetainInstance(final boolean retain) {
-        callHook("setRetainInstance(boolean)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setRetainInstance(retain);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setRetainInstance(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setRetainInstance(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setRetainInstance(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setRetainInstance((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setRetainInstance((boolean) args[0]);
-            }
-        }, retain);
+        };
+        superCall.call(retain);
     }
 
     public void setReturnTransition(final Object transition) {
-        callHook("setReturnTransition(Object)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setReturnTransition(transition);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setReturnTransition(Object)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setReturnTransition(superCall, (Object) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setReturnTransition(this, (Object) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setReturnTransition((Object) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setReturnTransition((Object) args[0]);
-            }
-        }, transition);
+        };
+        superCall.call(transition);
     }
 
     public void setSharedElementEnterTransition(final Object transition) {
-        callHook("setSharedElementEnterTransition(Object)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setSharedElementEnterTransition(transition);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setSharedElementEnterTransition(Object)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setSharedElementEnterTransition(superCall, (Object) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setSharedElementEnterTransition(this, (Object) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setSharedElementEnterTransition((Object) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setSharedElementEnterTransition((Object) args[0]);
-            }
-        }, transition);
+        };
+        superCall.call(transition);
     }
 
     public void setSharedElementReturnTransition(final Object transition) {
-        callHook("setSharedElementReturnTransition(Object)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setSharedElementReturnTransition(transition);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setSharedElementReturnTransition(Object)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setSharedElementReturnTransition(superCall, (Object) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setSharedElementReturnTransition(this, (Object) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setSharedElementReturnTransition((Object) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setSharedElementReturnTransition((Object) args[0]);
-            }
-        }, transition);
+        };
+        superCall.call(transition);
     }
 
     public void setTargetFragment(final Fragment fragment, final int requestCode) {
-        callHook("setTargetFragment(Fragment, int)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setTargetFragment(fragment, requestCode);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setTargetFragment(Fragment, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setTargetFragment(superCall, (Fragment) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setTargetFragment(this, (Fragment) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_setTargetFragment((Fragment) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setTargetFragment((Fragment) args[0], (int) args[1]);
-            }
-        }, fragment, requestCode);
+        };
+        superCall.call(fragment, requestCode);
     }
 
     public void setUserVisibleHint(final boolean isVisibleToUser) {
-        callHook("setUserVisibleHint(boolean)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_setUserVisibleHint(isVisibleToUser);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "setUserVisibleHint(boolean)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.setUserVisibleHint(superCall, (boolean) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().setUserVisibleHint(this, (boolean) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_setUserVisibleHint((boolean) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_setUserVisibleHint((boolean) args[0]);
-            }
-        }, isVisibleToUser);
+        };
+        superCall.call(isVisibleToUser);
     }
 
-
     public boolean shouldShowRequestPermissionRationale(@NonNull final String permission) {
-        return callFunction("shouldShowRequestPermissionRationale(String)",
-                new PluginCall<FragmentPlugin, Boolean>() {
-                    @Override
-                    public Boolean call(final NamedSuperCall<Boolean> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_shouldShowRequestPermissionRationale(permission);
+        }
 
-                        return plugin
-                                .shouldShowRequestPermissionRationale(superCall, (String) args[0]);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-                    }
-                }, new SuperCall<Boolean>() {
-                    @Override
-                    public Boolean call(final Object... args) {
-                        return getOriginal()
-                                .super_shouldShowRequestPermissionRationale((String) args[0]);
-                    }
-                }, permission);
+        final NamedSuperCall<Boolean> superCall = new NamedSuperCall<Boolean>(
+                "shouldShowRequestPermissionRationale(String)") {
+
+            @Override
+            public Boolean call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    return iterator.previous()
+                            .shouldShowRequestPermissionRationale(this, (String) args[0]);
+                } else {
+                    return getOriginal()
+                            .super_shouldShowRequestPermissionRationale((String) args[0]);
+                }
+            }
+        };
+        return superCall.call(permission);
     }
 
     public void startActivity(final Intent intent) {
-        callHook("startActivity(Intent)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivity(intent);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("startActivity(Intent)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.startActivity(superCall, (Intent) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startActivity(this, (Intent) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivity((Intent) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivity((Intent) args[0]);
-            }
-        }, intent);
+        };
+        superCall.call(intent);
     }
 
     public void startActivity(final Intent intent, @Nullable final Bundle options) {
-        callHook("startActivity(Intent, Bundle)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivity(intent, options);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivity(Intent, Bundle)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.startActivity(superCall, (Intent) args[0], (Bundle) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().startActivity(this, (Intent) args[0], (Bundle) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivity((Intent) args[0], (Bundle) args[1]);
-            }
-        }, intent, options);
+        };
+        superCall.call(intent, options);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode) {
-        callHook("startActivityForResult(Intent, int)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityForResult(intent, requestCode);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityForResult(Intent, int)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.startActivityForResult(superCall, (Intent) args[0], (int) args[1]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityForResult(this, (Intent) args[0], (int) args[1]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1]);
-            }
-        }, intent, requestCode);
+        };
+        superCall.call(intent, requestCode);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode,
             @Nullable final Bundle options) {
-        callHook("startActivityForResult(Intent, int, Bundle)",
-                new PluginCallVoid<FragmentPlugin>() {
-                    @Override
-                    public void call(final NamedSuperCall<Void> superCall,
-                            final FragmentPlugin plugin, final Object... args) {
-                        plugin.startActivityForResult(superCall, (Intent) args[0], (int) args[1],
-                                (Bundle) args[2]);
-                    }
-                }, new SuperCallVoid() {
-                    @Override
-                    public void call(final Object... args) {
-                        getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
-                                (Bundle) args[2]);
-                    }
-                }, intent, requestCode, options);
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_startActivityForResult(intent, requestCode, options);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "startActivityForResult(Intent, int, Bundle)") {
+
+            @Override
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous()
+                            .startActivityForResult(this, (Intent) args[0], (int) args[1],
+                                    (Bundle) args[2]);
+                    return null;
+                } else {
+                    getOriginal().super_startActivityForResult((Intent) args[0], (int) args[1],
+                            (Bundle) args[2]);
+                    return null;
+                }
+            }
+        };
+        superCall.call(intent, requestCode, options);
     }
 
-
     public String toString() {
-        return callFunction("toString()", new PluginCall<FragmentPlugin, String>() {
-            @Override
-            public String call(final NamedSuperCall<String> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
+        if (mPlugins.isEmpty()) {
+            return getOriginal().super_toString();
+        }
 
-                return plugin.toString(superCall);
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
 
-            }
-        }, new SuperCall<String>() {
+        final NamedSuperCall<String> superCall = new NamedSuperCall<String>("toString()") {
+
             @Override
             public String call(final Object... args) {
-                return getOriginal().super_toString();
+                if (iterator.hasPrevious()) {
+                    return iterator.previous().toString(this);
+                } else {
+                    return getOriginal().super_toString();
+                }
             }
-        });
+        };
+        return superCall.call();
     }
 
     public void unregisterForContextMenu(final View view) {
-        callHook("unregisterForContextMenu(View)", new PluginCallVoid<FragmentPlugin>() {
+        if (mPlugins.isEmpty()) {
+            getOriginal().super_unregisterForContextMenu(view);
+            return;
+        }
+
+        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+
+        final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>(
+                "unregisterForContextMenu(View)") {
+
             @Override
-            public void call(final NamedSuperCall<Void> superCall, final FragmentPlugin plugin,
-                    final Object... args) {
-                plugin.unregisterForContextMenu(superCall, (View) args[0]);
+            public Void call(final Object... args) {
+                if (iterator.hasPrevious()) {
+                    iterator.previous().unregisterForContextMenu(this, (View) args[0]);
+                    return null;
+                } else {
+                    getOriginal().super_unregisterForContextMenu((View) args[0]);
+                    return null;
+                }
             }
-        }, new SuperCallVoid() {
-            @Override
-            public void call(final Object... args) {
-                getOriginal().super_unregisterForContextMenu((View) args[0]);
-            }
-        }, view);
+        };
+        superCall.call(view);
     }
 
 

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentPlugin.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentPlugin.java
@@ -1,7 +1,14 @@
 package com.pascalwelsch.compositeandroid.fragment;
 
 import com.pascalwelsch.compositeandroid.core.AbstractPlugin;
-import com.pascalwelsch.compositeandroid.core.NamedSuperCall;
+import com.pascalwelsch.compositeandroid.core.CallFun0;
+import com.pascalwelsch.compositeandroid.core.CallFun1;
+import com.pascalwelsch.compositeandroid.core.CallFun3;
+import com.pascalwelsch.compositeandroid.core.CallVoid0;
+import com.pascalwelsch.compositeandroid.core.CallVoid1;
+import com.pascalwelsch.compositeandroid.core.CallVoid2;
+import com.pascalwelsch.compositeandroid.core.CallVoid3;
+import com.pascalwelsch.compositeandroid.core.CallVoid4;
 
 import android.app.Activity;
 import android.content.Context;
@@ -32,32 +39,33 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
     public void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args) {
         verifyMethodCalledFromDelegate("dump(String, FileDescriptor, PrintWriter, String[])");
-        mSuperListeners.pop().call(prefix, fd, writer, args);
+        ((CallVoid4<String, FileDescriptor, PrintWriter, String[]>) mSuperListeners.pop())
+                .call(prefix, fd, writer, args);
     }
 
     public boolean getAllowEnterTransitionOverlap() {
         verifyMethodCalledFromDelegate("getAllowEnterTransitionOverlap()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public boolean getAllowReturnTransitionOverlap() {
         verifyMethodCalledFromDelegate("getAllowReturnTransitionOverlap()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public Context getContext() {
         verifyMethodCalledFromDelegate("getContext()");
-        return (Context) mSuperListeners.pop().call();
+        return ((CallFun0<Context>) mSuperListeners.pop()).call();
     }
 
     public Object getEnterTransition() {
         verifyMethodCalledFromDelegate("getEnterTransition()");
-        return (Object) mSuperListeners.pop().call();
+        return ((CallFun0<Object>) mSuperListeners.pop()).call();
     }
 
     public Object getExitTransition() {
         verifyMethodCalledFromDelegate("getExitTransition()");
-        return (Object) mSuperListeners.pop().call();
+        return ((CallFun0<Object>) mSuperListeners.pop()).call();
     }
 
     public Fragment getFragment() {
@@ -66,370 +74,379 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
 
     public LayoutInflater getLayoutInflater(final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("getLayoutInflater(Bundle)");
-        return (LayoutInflater) mSuperListeners.pop().call(savedInstanceState);
+        return ((CallFun1<LayoutInflater, Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public LoaderManager getLoaderManager() {
         verifyMethodCalledFromDelegate("getLoaderManager()");
-        return (LoaderManager) mSuperListeners.pop().call();
+        return ((CallFun0<LoaderManager>) mSuperListeners.pop()).call();
     }
 
     public Object getReenterTransition() {
         verifyMethodCalledFromDelegate("getReenterTransition()");
-        return (Object) mSuperListeners.pop().call();
+        return ((CallFun0<Object>) mSuperListeners.pop()).call();
     }
 
     public Object getReturnTransition() {
         verifyMethodCalledFromDelegate("getReturnTransition()");
-        return (Object) mSuperListeners.pop().call();
+        return ((CallFun0<Object>) mSuperListeners.pop()).call();
     }
 
     public Object getSharedElementEnterTransition() {
         verifyMethodCalledFromDelegate("getSharedElementEnterTransition()");
-        return (Object) mSuperListeners.pop().call();
+        return ((CallFun0<Object>) mSuperListeners.pop()).call();
     }
 
     public Object getSharedElementReturnTransition() {
         verifyMethodCalledFromDelegate("getSharedElementReturnTransition()");
-        return (Object) mSuperListeners.pop().call();
+        return ((CallFun0<Object>) mSuperListeners.pop()).call();
     }
 
     public boolean getUserVisibleHint() {
         verifyMethodCalledFromDelegate("getUserVisibleHint()");
-        return (Boolean) mSuperListeners.pop().call();
+        return ((CallFun0<Boolean>) mSuperListeners.pop()).call();
     }
 
     public View getView() {
         verifyMethodCalledFromDelegate("getView()");
-        return (View) mSuperListeners.pop().call();
+        return ((CallFun0<View>) mSuperListeners.pop()).call();
     }
 
     public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onActivityCreated(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        verifyMethodCalledFromDelegate("onActivityResult(int, int, Intent)");
-        mSuperListeners.pop().call(requestCode, resultCode, data);
+        verifyMethodCalledFromDelegate("onActivityResult(Integer, Integer, Intent)");
+        ((CallVoid3<Integer, Integer, Intent>) mSuperListeners.pop())
+                .call(requestCode, resultCode, data);
     }
 
     public void onAttach(final Context context) {
         verifyMethodCalledFromDelegate("onAttach(Context)");
-        mSuperListeners.pop().call(context);
+        ((CallVoid1<Context>) mSuperListeners.pop()).call(context);
     }
 
     public void onAttach(final Activity activity) {
         verifyMethodCalledFromDelegate("onAttach(Activity)");
-        mSuperListeners.pop().call(activity);
+        ((CallVoid1<Activity>) mSuperListeners.pop()).call(activity);
     }
 
     public void onConfigurationChanged(final Configuration newConfig) {
         verifyMethodCalledFromDelegate("onConfigurationChanged(Configuration)");
-        mSuperListeners.pop().call(newConfig);
+        ((CallVoid1<Configuration>) mSuperListeners.pop()).call(newConfig);
     }
 
     public boolean onContextItemSelected(final MenuItem item) {
         verifyMethodCalledFromDelegate("onContextItemSelected(MenuItem)");
-        return (Boolean) mSuperListeners.pop().call(item);
+        return ((CallFun1<Boolean, MenuItem>) mSuperListeners.pop()).call(item);
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onCreate(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public Animation onCreateAnimation(final int transit, final boolean enter, final int nextAnim) {
-        verifyMethodCalledFromDelegate("onCreateAnimation(int, boolean, int)");
-        return (Animation) mSuperListeners.pop().call(transit, enter, nextAnim);
+        verifyMethodCalledFromDelegate("onCreateAnimation(Integer, Boolean, Integer)");
+        return ((CallFun3<Animation, Integer, Boolean, Integer>) mSuperListeners.pop())
+                .call(transit, enter, nextAnim);
     }
 
     public void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo) {
         verifyMethodCalledFromDelegate(
                 "onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)");
-        mSuperListeners.pop().call(menu, v, menuInfo);
+        ((CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo>) mSuperListeners.pop())
+                .call(menu, v, menuInfo);
     }
 
     public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
         verifyMethodCalledFromDelegate("onCreateOptionsMenu(Menu, MenuInflater)");
-        mSuperListeners.pop().call(menu, inflater);
+        ((CallVoid2<Menu, MenuInflater>) mSuperListeners.pop()).call(menu, inflater);
     }
 
     public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
             @Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onCreateView(LayoutInflater, ViewGroup, Bundle)");
-        return (View) mSuperListeners.pop().call(inflater, container, savedInstanceState);
+        return ((CallFun3<View, LayoutInflater, ViewGroup, Bundle>) mSuperListeners.pop())
+                .call(inflater, container, savedInstanceState);
     }
 
     public void onDestroy() {
         verifyMethodCalledFromDelegate("onDestroy()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onDestroyOptionsMenu() {
         verifyMethodCalledFromDelegate("onDestroyOptionsMenu()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onDestroyView() {
         verifyMethodCalledFromDelegate("onDestroyView()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onDetach() {
         verifyMethodCalledFromDelegate("onDetach()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onHiddenChanged(final boolean hidden) {
-        verifyMethodCalledFromDelegate("onHiddenChanged(boolean)");
-        mSuperListeners.pop().call(hidden);
+        verifyMethodCalledFromDelegate("onHiddenChanged(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(hidden);
     }
 
     public void onInflate(final Context context, final AttributeSet attrs,
             final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onInflate(Context, AttributeSet, Bundle)");
-        mSuperListeners.pop().call(context, attrs, savedInstanceState);
+        ((CallVoid3<Context, AttributeSet, Bundle>) mSuperListeners.pop())
+                .call(context, attrs, savedInstanceState);
     }
 
     public void onInflate(final Activity activity, final AttributeSet attrs,
             final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onInflate(Activity, AttributeSet, Bundle)");
-        mSuperListeners.pop().call(activity, attrs, savedInstanceState);
+        ((CallVoid3<Activity, AttributeSet, Bundle>) mSuperListeners.pop())
+                .call(activity, attrs, savedInstanceState);
     }
 
     public void onLowMemory() {
         verifyMethodCalledFromDelegate("onLowMemory()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public boolean onOptionsItemSelected(final MenuItem item) {
         verifyMethodCalledFromDelegate("onOptionsItemSelected(MenuItem)");
-        return (Boolean) mSuperListeners.pop().call(item);
+        return ((CallFun1<Boolean, MenuItem>) mSuperListeners.pop()).call(item);
     }
 
     public void onOptionsMenuClosed(final Menu menu) {
         verifyMethodCalledFromDelegate("onOptionsMenuClosed(Menu)");
-        mSuperListeners.pop().call(menu);
+        ((CallVoid1<Menu>) mSuperListeners.pop()).call(menu);
     }
 
     public void onPause() {
         verifyMethodCalledFromDelegate("onPause()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onPrepareOptionsMenu(final Menu menu) {
         verifyMethodCalledFromDelegate("onPrepareOptionsMenu(Menu)");
-        mSuperListeners.pop().call(menu);
+        ((CallVoid1<Menu>) mSuperListeners.pop()).call(menu);
     }
 
     public void onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        verifyMethodCalledFromDelegate("onRequestPermissionsResult(int, String[], int[])");
-        mSuperListeners.pop().call(requestCode, permissions, grantResults);
+        verifyMethodCalledFromDelegate("onRequestPermissionsResult(Integer, String[], int[])");
+        ((CallVoid3<Integer, String[], int[]>) mSuperListeners.pop())
+                .call(requestCode, permissions, grantResults);
     }
 
     public void onResume() {
         verifyMethodCalledFromDelegate("onResume()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onSaveInstanceState(final Bundle outState) {
         verifyMethodCalledFromDelegate("onSaveInstanceState(Bundle)");
-        mSuperListeners.pop().call(outState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(outState);
     }
 
     public void onStart() {
         verifyMethodCalledFromDelegate("onStart()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onStop() {
         verifyMethodCalledFromDelegate("onStop()");
-        mSuperListeners.pop().call();
+        ((CallVoid0) mSuperListeners.pop()).call();
     }
 
     public void onViewCreated(final View view, @Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onViewCreated(View, Bundle)");
-        mSuperListeners.pop().call(view, savedInstanceState);
+        ((CallVoid2<View, Bundle>) mSuperListeners.pop()).call(view, savedInstanceState);
     }
 
     public void onViewStateRestored(@Nullable final Bundle savedInstanceState) {
         verifyMethodCalledFromDelegate("onViewStateRestored(Bundle)");
-        mSuperListeners.pop().call(savedInstanceState);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(savedInstanceState);
     }
 
     public void registerForContextMenu(final View view) {
         verifyMethodCalledFromDelegate("registerForContextMenu(View)");
-        mSuperListeners.pop().call(view);
+        ((CallVoid1<View>) mSuperListeners.pop()).call(view);
     }
 
     public void setAllowEnterTransitionOverlap(final boolean allow) {
-        verifyMethodCalledFromDelegate("setAllowEnterTransitionOverlap(boolean)");
-        mSuperListeners.pop().call(allow);
+        verifyMethodCalledFromDelegate("setAllowEnterTransitionOverlap(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(allow);
     }
 
     public void setAllowReturnTransitionOverlap(final boolean allow) {
-        verifyMethodCalledFromDelegate("setAllowReturnTransitionOverlap(boolean)");
-        mSuperListeners.pop().call(allow);
+        verifyMethodCalledFromDelegate("setAllowReturnTransitionOverlap(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(allow);
     }
 
     public void setArguments(final Bundle args) {
         verifyMethodCalledFromDelegate("setArguments(Bundle)");
-        mSuperListeners.pop().call(args);
+        ((CallVoid1<Bundle>) mSuperListeners.pop()).call(args);
     }
 
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
         verifyMethodCalledFromDelegate("setEnterSharedElementCallback(SharedElementCallback)");
-        mSuperListeners.pop().call(callback);
+        ((CallVoid1<SharedElementCallback>) mSuperListeners.pop()).call(callback);
     }
 
     public void setEnterTransition(final Object transition) {
         verifyMethodCalledFromDelegate("setEnterTransition(Object)");
-        mSuperListeners.pop().call(transition);
+        ((CallVoid1<Object>) mSuperListeners.pop()).call(transition);
     }
 
     public void setExitSharedElementCallback(final SharedElementCallback callback) {
         verifyMethodCalledFromDelegate("setExitSharedElementCallback(SharedElementCallback)");
-        mSuperListeners.pop().call(callback);
+        ((CallVoid1<SharedElementCallback>) mSuperListeners.pop()).call(callback);
     }
 
     public void setExitTransition(final Object transition) {
         verifyMethodCalledFromDelegate("setExitTransition(Object)");
-        mSuperListeners.pop().call(transition);
+        ((CallVoid1<Object>) mSuperListeners.pop()).call(transition);
     }
 
     public void setHasOptionsMenu(final boolean hasMenu) {
-        verifyMethodCalledFromDelegate("setHasOptionsMenu(boolean)");
-        mSuperListeners.pop().call(hasMenu);
+        verifyMethodCalledFromDelegate("setHasOptionsMenu(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(hasMenu);
     }
 
     public void setInitialSavedState(final Fragment.SavedState state) {
         verifyMethodCalledFromDelegate("setInitialSavedState(Fragment.SavedState)");
-        mSuperListeners.pop().call(state);
+        ((CallVoid1<Fragment.SavedState>) mSuperListeners.pop()).call(state);
     }
 
     public void setMenuVisibility(final boolean menuVisible) {
-        verifyMethodCalledFromDelegate("setMenuVisibility(boolean)");
-        mSuperListeners.pop().call(menuVisible);
+        verifyMethodCalledFromDelegate("setMenuVisibility(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(menuVisible);
     }
 
     public void setReenterTransition(final Object transition) {
         verifyMethodCalledFromDelegate("setReenterTransition(Object)");
-        mSuperListeners.pop().call(transition);
+        ((CallVoid1<Object>) mSuperListeners.pop()).call(transition);
     }
 
     public void setRetainInstance(final boolean retain) {
-        verifyMethodCalledFromDelegate("setRetainInstance(boolean)");
-        mSuperListeners.pop().call(retain);
+        verifyMethodCalledFromDelegate("setRetainInstance(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(retain);
     }
 
     public void setReturnTransition(final Object transition) {
         verifyMethodCalledFromDelegate("setReturnTransition(Object)");
-        mSuperListeners.pop().call(transition);
+        ((CallVoid1<Object>) mSuperListeners.pop()).call(transition);
     }
 
     public void setSharedElementEnterTransition(final Object transition) {
         verifyMethodCalledFromDelegate("setSharedElementEnterTransition(Object)");
-        mSuperListeners.pop().call(transition);
+        ((CallVoid1<Object>) mSuperListeners.pop()).call(transition);
     }
 
     public void setSharedElementReturnTransition(final Object transition) {
         verifyMethodCalledFromDelegate("setSharedElementReturnTransition(Object)");
-        mSuperListeners.pop().call(transition);
+        ((CallVoid1<Object>) mSuperListeners.pop()).call(transition);
     }
 
     public void setTargetFragment(final Fragment fragment, final int requestCode) {
-        verifyMethodCalledFromDelegate("setTargetFragment(Fragment, int)");
-        mSuperListeners.pop().call(fragment, requestCode);
+        verifyMethodCalledFromDelegate("setTargetFragment(Fragment, Integer)");
+        ((CallVoid2<Fragment, Integer>) mSuperListeners.pop()).call(fragment, requestCode);
     }
 
     public void setUserVisibleHint(final boolean isVisibleToUser) {
-        verifyMethodCalledFromDelegate("setUserVisibleHint(boolean)");
-        mSuperListeners.pop().call(isVisibleToUser);
+        verifyMethodCalledFromDelegate("setUserVisibleHint(Boolean)");
+        ((CallVoid1<Boolean>) mSuperListeners.pop()).call(isVisibleToUser);
     }
 
     public boolean shouldShowRequestPermissionRationale(@NonNull final String permission) {
         verifyMethodCalledFromDelegate("shouldShowRequestPermissionRationale(String)");
-        return (Boolean) mSuperListeners.pop().call(permission);
+        return ((CallFun1<Boolean, String>) mSuperListeners.pop()).call(permission);
     }
 
     public void startActivity(final Intent intent) {
         verifyMethodCalledFromDelegate("startActivity(Intent)");
-        mSuperListeners.pop().call(intent);
+        ((CallVoid1<Intent>) mSuperListeners.pop()).call(intent);
     }
 
     public void startActivity(final Intent intent, @Nullable final Bundle options) {
         verifyMethodCalledFromDelegate("startActivity(Intent, Bundle)");
-        mSuperListeners.pop().call(intent, options);
+        ((CallVoid2<Intent, Bundle>) mSuperListeners.pop()).call(intent, options);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode) {
-        verifyMethodCalledFromDelegate("startActivityForResult(Intent, int)");
-        mSuperListeners.pop().call(intent, requestCode);
+        verifyMethodCalledFromDelegate("startActivityForResult(Intent, Integer)");
+        ((CallVoid2<Intent, Integer>) mSuperListeners.pop()).call(intent, requestCode);
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode,
             @Nullable final Bundle options) {
-        verifyMethodCalledFromDelegate("startActivityForResult(Intent, int, Bundle)");
-        mSuperListeners.pop().call(intent, requestCode, options);
+        verifyMethodCalledFromDelegate("startActivityForResult(Intent, Integer, Bundle)");
+        ((CallVoid3<Intent, Integer, Bundle>) mSuperListeners.pop())
+                .call(intent, requestCode, options);
     }
 
     public String toString() {
         verifyMethodCalledFromDelegate("toString()");
-        return (String) mSuperListeners.pop().call();
+        return ((CallFun0<String>) mSuperListeners.pop()).call();
     }
 
     public void unregisterForContextMenu(final View view) {
         verifyMethodCalledFromDelegate("unregisterForContextMenu(View)");
-        mSuperListeners.pop().call(view);
+        ((CallVoid1<View>) mSuperListeners.pop()).call(view);
     }
 
-    void dump(final NamedSuperCall<Void> superCall, final String prefix, final FileDescriptor fd,
-            final PrintWriter writer, final String[] args) {
+    void dump(final CallVoid4<String, FileDescriptor, PrintWriter, String[]> superCall,
+            final String prefix, final FileDescriptor fd, final PrintWriter writer,
+            final String[] args) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             dump(prefix, fd, writer, args);
         }
     }
 
-    boolean getAllowEnterTransitionOverlap(final NamedSuperCall<Boolean> superCall) {
+    boolean getAllowEnterTransitionOverlap(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getAllowEnterTransitionOverlap();
         }
     }
 
-    boolean getAllowReturnTransitionOverlap(final NamedSuperCall<Boolean> superCall) {
+    boolean getAllowReturnTransitionOverlap(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getAllowReturnTransitionOverlap();
         }
     }
 
-    Context getContext(final NamedSuperCall<Context> superCall) {
+    Context getContext(final CallFun0<Context> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getContext();
         }
     }
 
-    Object getEnterTransition(final NamedSuperCall<Object> superCall) {
+    Object getEnterTransition(final CallFun0<Object> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getEnterTransition();
         }
     }
 
-    Object getExitTransition(final NamedSuperCall<Object> superCall) {
+    Object getExitTransition(final CallFun0<Object> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getExitTransition();
         }
     }
 
-    LayoutInflater getLayoutInflater(final NamedSuperCall<LayoutInflater> superCall,
+    LayoutInflater getLayoutInflater(final CallFun1<LayoutInflater, Bundle> superCall,
             final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -437,56 +454,56 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    LoaderManager getLoaderManager(final NamedSuperCall<LoaderManager> superCall) {
+    LoaderManager getLoaderManager(final CallFun0<LoaderManager> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getLoaderManager();
         }
     }
 
-    Object getReenterTransition(final NamedSuperCall<Object> superCall) {
+    Object getReenterTransition(final CallFun0<Object> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getReenterTransition();
         }
     }
 
-    Object getReturnTransition(final NamedSuperCall<Object> superCall) {
+    Object getReturnTransition(final CallFun0<Object> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getReturnTransition();
         }
     }
 
-    Object getSharedElementEnterTransition(final NamedSuperCall<Object> superCall) {
+    Object getSharedElementEnterTransition(final CallFun0<Object> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSharedElementEnterTransition();
         }
     }
 
-    Object getSharedElementReturnTransition(final NamedSuperCall<Object> superCall) {
+    Object getSharedElementReturnTransition(final CallFun0<Object> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getSharedElementReturnTransition();
         }
     }
 
-    boolean getUserVisibleHint(final NamedSuperCall<Boolean> superCall) {
+    boolean getUserVisibleHint(final CallFun0<Boolean> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getUserVisibleHint();
         }
     }
 
-    View getView(final NamedSuperCall<View> superCall) {
+    View getView(final CallFun0<View> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return getView();
         }
     }
 
-    void onActivityCreated(final NamedSuperCall<Void> superCall,
+    void onActivityCreated(final CallVoid1<Bundle> superCall,
             @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -494,29 +511,29 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void onActivityResult(final NamedSuperCall<Void> superCall, final int requestCode,
-            final int resultCode, final Intent data) {
+    void onActivityResult(final CallVoid3<Integer, Integer, Intent> superCall,
+            final int requestCode, final int resultCode, final Intent data) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onActivityResult(requestCode, resultCode, data);
         }
     }
 
-    void onAttach(final NamedSuperCall<Void> superCall, final Context context) {
+    void onAttach(final CallVoid1<Context> superCall, final Context context) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onAttach(context);
         }
     }
 
-    void onAttach(final NamedSuperCall<Void> superCall, final Activity activity) {
+    void onAttach(final CallVoid1<Activity> superCall, final Activity activity) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onAttach(activity);
         }
     }
 
-    void onConfigurationChanged(final NamedSuperCall<Void> superCall,
+    void onConfigurationChanged(final CallVoid1<Configuration> superCall,
             final Configuration newConfig) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -524,37 +541,39 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    boolean onContextItemSelected(final NamedSuperCall<Boolean> superCall, final MenuItem item) {
+    boolean onContextItemSelected(final CallFun1<Boolean, MenuItem> superCall,
+            final MenuItem item) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onContextItemSelected(item);
         }
     }
 
-    void onCreate(final NamedSuperCall<Void> superCall, @Nullable final Bundle savedInstanceState) {
+    void onCreate(final CallVoid1<Bundle> superCall, @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onCreate(savedInstanceState);
         }
     }
 
-    Animation onCreateAnimation(final NamedSuperCall<Animation> superCall, final int transit,
-            final boolean enter, final int nextAnim) {
+    Animation onCreateAnimation(final CallFun3<Animation, Integer, Boolean, Integer> superCall,
+            final int transit, final boolean enter, final int nextAnim) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateAnimation(transit, enter, nextAnim);
         }
     }
 
-    void onCreateContextMenu(final NamedSuperCall<Void> superCall, final ContextMenu menu,
-            final View v, final ContextMenu.ContextMenuInfo menuInfo) {
+    void onCreateContextMenu(
+            final CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo> superCall,
+            final ContextMenu menu, final View v, final ContextMenu.ContextMenuInfo menuInfo) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onCreateContextMenu(menu, v, menuInfo);
         }
     }
 
-    void onCreateOptionsMenu(final NamedSuperCall<Void> superCall, final Menu menu,
+    void onCreateOptionsMenu(final CallVoid2<Menu, MenuInflater> superCall, final Menu menu,
             final MenuInflater inflater) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -562,50 +581,51 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    View onCreateView(final NamedSuperCall<View> superCall, final LayoutInflater inflater,
-            @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
+    View onCreateView(final CallFun3<View, LayoutInflater, ViewGroup, Bundle> superCall,
+            final LayoutInflater inflater, @Nullable final ViewGroup container,
+            @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onCreateView(inflater, container, savedInstanceState);
         }
     }
 
-    void onDestroy(final NamedSuperCall<Void> superCall) {
+    void onDestroy(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDestroy();
         }
     }
 
-    void onDestroyOptionsMenu(final NamedSuperCall<Void> superCall) {
+    void onDestroyOptionsMenu(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDestroyOptionsMenu();
         }
     }
 
-    void onDestroyView(final NamedSuperCall<Void> superCall) {
+    void onDestroyView(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDestroyView();
         }
     }
 
-    void onDetach(final NamedSuperCall<Void> superCall) {
+    void onDetach(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onDetach();
         }
     }
 
-    void onHiddenChanged(final NamedSuperCall<Void> superCall, final boolean hidden) {
+    void onHiddenChanged(final CallVoid1<Boolean> superCall, final boolean hidden) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onHiddenChanged(hidden);
         }
     }
 
-    void onInflate(final NamedSuperCall<Void> superCall, final Context context,
+    void onInflate(final CallVoid3<Context, AttributeSet, Bundle> superCall, final Context context,
             final AttributeSet attrs, final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -613,86 +633,88 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void onInflate(final NamedSuperCall<Void> superCall, final Activity activity,
-            final AttributeSet attrs, final Bundle savedInstanceState) {
+    void onInflate(final CallVoid3<Activity, AttributeSet, Bundle> superCall,
+            final Activity activity, final AttributeSet attrs, final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onInflate(activity, attrs, savedInstanceState);
         }
     }
 
-    void onLowMemory(final NamedSuperCall<Void> superCall) {
+    void onLowMemory(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onLowMemory();
         }
     }
 
-    boolean onOptionsItemSelected(final NamedSuperCall<Boolean> superCall, final MenuItem item) {
+    boolean onOptionsItemSelected(final CallFun1<Boolean, MenuItem> superCall,
+            final MenuItem item) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return onOptionsItemSelected(item);
         }
     }
 
-    void onOptionsMenuClosed(final NamedSuperCall<Void> superCall, final Menu menu) {
+    void onOptionsMenuClosed(final CallVoid1<Menu> superCall, final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onOptionsMenuClosed(menu);
         }
     }
 
-    void onPause(final NamedSuperCall<Void> superCall) {
+    void onPause(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPause();
         }
     }
 
-    void onPrepareOptionsMenu(final NamedSuperCall<Void> superCall, final Menu menu) {
+    void onPrepareOptionsMenu(final CallVoid1<Menu> superCall, final Menu menu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onPrepareOptionsMenu(menu);
         }
     }
 
-    void onRequestPermissionsResult(final NamedSuperCall<Void> superCall, final int requestCode,
-            @NonNull final String[] permissions, @NonNull final int[] grantResults) {
+    void onRequestPermissionsResult(final CallVoid3<Integer, String[], int[]> superCall,
+            final int requestCode, @NonNull final String[] permissions,
+            @NonNull final int[] grantResults) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onRequestPermissionsResult(requestCode, permissions, grantResults);
         }
     }
 
-    void onResume(final NamedSuperCall<Void> superCall) {
+    void onResume(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onResume();
         }
     }
 
-    void onSaveInstanceState(final NamedSuperCall<Void> superCall, final Bundle outState) {
+    void onSaveInstanceState(final CallVoid1<Bundle> superCall, final Bundle outState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onSaveInstanceState(outState);
         }
     }
 
-    void onStart(final NamedSuperCall<Void> superCall) {
+    void onStart(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onStart();
         }
     }
 
-    void onStop(final NamedSuperCall<Void> superCall) {
+    void onStop(final CallVoid0 superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             onStop();
         }
     }
 
-    void onViewCreated(final NamedSuperCall<Void> superCall, final View view,
+    void onViewCreated(final CallVoid2<View, Bundle> superCall, final View view,
             @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -700,7 +722,7 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void onViewStateRestored(final NamedSuperCall<Void> superCall,
+    void onViewStateRestored(final CallVoid1<Bundle> superCall,
             @Nullable final Bundle savedInstanceState) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -708,36 +730,35 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void registerForContextMenu(final NamedSuperCall<Void> superCall, final View view) {
+    void registerForContextMenu(final CallVoid1<View> superCall, final View view) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             registerForContextMenu(view);
         }
     }
 
-    void setAllowEnterTransitionOverlap(final NamedSuperCall<Void> superCall, final boolean allow) {
+    void setAllowEnterTransitionOverlap(final CallVoid1<Boolean> superCall, final boolean allow) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setAllowEnterTransitionOverlap(allow);
         }
     }
 
-    void setAllowReturnTransitionOverlap(final NamedSuperCall<Void> superCall,
-            final boolean allow) {
+    void setAllowReturnTransitionOverlap(final CallVoid1<Boolean> superCall, final boolean allow) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setAllowReturnTransitionOverlap(allow);
         }
     }
 
-    void setArguments(final NamedSuperCall<Void> superCall, final Bundle args) {
+    void setArguments(final CallVoid1<Bundle> superCall, final Bundle args) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setArguments(args);
         }
     }
 
-    void setEnterSharedElementCallback(final NamedSuperCall<Void> superCall,
+    void setEnterSharedElementCallback(final CallVoid1<SharedElementCallback> superCall,
             final SharedElementCallback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -745,14 +766,14 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void setEnterTransition(final NamedSuperCall<Void> superCall, final Object transition) {
+    void setEnterTransition(final CallVoid1<Object> superCall, final Object transition) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setEnterTransition(transition);
         }
     }
 
-    void setExitSharedElementCallback(final NamedSuperCall<Void> superCall,
+    void setExitSharedElementCallback(final CallVoid1<SharedElementCallback> superCall,
             final SharedElementCallback callback) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -760,21 +781,21 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void setExitTransition(final NamedSuperCall<Void> superCall, final Object transition) {
+    void setExitTransition(final CallVoid1<Object> superCall, final Object transition) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setExitTransition(transition);
         }
     }
 
-    void setHasOptionsMenu(final NamedSuperCall<Void> superCall, final boolean hasMenu) {
+    void setHasOptionsMenu(final CallVoid1<Boolean> superCall, final boolean hasMenu) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setHasOptionsMenu(hasMenu);
         }
     }
 
-    void setInitialSavedState(final NamedSuperCall<Void> superCall,
+    void setInitialSavedState(final CallVoid1<Fragment.SavedState> superCall,
             final Fragment.SavedState state) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -782,35 +803,35 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void setMenuVisibility(final NamedSuperCall<Void> superCall, final boolean menuVisible) {
+    void setMenuVisibility(final CallVoid1<Boolean> superCall, final boolean menuVisible) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setMenuVisibility(menuVisible);
         }
     }
 
-    void setReenterTransition(final NamedSuperCall<Void> superCall, final Object transition) {
+    void setReenterTransition(final CallVoid1<Object> superCall, final Object transition) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setReenterTransition(transition);
         }
     }
 
-    void setRetainInstance(final NamedSuperCall<Void> superCall, final boolean retain) {
+    void setRetainInstance(final CallVoid1<Boolean> superCall, final boolean retain) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setRetainInstance(retain);
         }
     }
 
-    void setReturnTransition(final NamedSuperCall<Void> superCall, final Object transition) {
+    void setReturnTransition(final CallVoid1<Object> superCall, final Object transition) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setReturnTransition(transition);
         }
     }
 
-    void setSharedElementEnterTransition(final NamedSuperCall<Void> superCall,
+    void setSharedElementEnterTransition(final CallVoid1<Object> superCall,
             final Object transition) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -818,7 +839,7 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void setSharedElementReturnTransition(final NamedSuperCall<Void> superCall,
+    void setSharedElementReturnTransition(final CallVoid1<Object> superCall,
             final Object transition) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -826,7 +847,7 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void setTargetFragment(final NamedSuperCall<Void> superCall, final Fragment fragment,
+    void setTargetFragment(final CallVoid2<Fragment, Integer> superCall, final Fragment fragment,
             final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -834,14 +855,14 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void setUserVisibleHint(final NamedSuperCall<Void> superCall, final boolean isVisibleToUser) {
+    void setUserVisibleHint(final CallVoid1<Boolean> superCall, final boolean isVisibleToUser) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             setUserVisibleHint(isVisibleToUser);
         }
     }
 
-    boolean shouldShowRequestPermissionRationale(final NamedSuperCall<Boolean> superCall,
+    boolean shouldShowRequestPermissionRationale(final CallFun1<Boolean, String> superCall,
             @NonNull final String permission) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -849,14 +870,14 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void startActivity(final NamedSuperCall<Void> superCall, final Intent intent) {
+    void startActivity(final CallVoid1<Intent> superCall, final Intent intent) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivity(intent);
         }
     }
 
-    void startActivity(final NamedSuperCall<Void> superCall, final Intent intent,
+    void startActivity(final CallVoid2<Intent, Bundle> superCall, final Intent intent,
             @Nullable final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -864,7 +885,7 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void startActivityForResult(final NamedSuperCall<Void> superCall, final Intent intent,
+    void startActivityForResult(final CallVoid2<Intent, Integer> superCall, final Intent intent,
             final int requestCode) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
@@ -872,22 +893,22 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         }
     }
 
-    void startActivityForResult(final NamedSuperCall<Void> superCall, final Intent intent,
-            final int requestCode, @Nullable final Bundle options) {
+    void startActivityForResult(final CallVoid3<Intent, Integer, Bundle> superCall,
+            final Intent intent, final int requestCode, @Nullable final Bundle options) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             startActivityForResult(intent, requestCode, options);
         }
     }
 
-    String toString(final NamedSuperCall<String> superCall) {
+    String toString(final CallFun0<String> superCall) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             return toString();
         }
     }
 
-    void unregisterForContextMenu(final NamedSuperCall<Void> superCall, final View view) {
+    void unregisterForContextMenu(final CallVoid1<View> superCall, final View view) {
         synchronized (mSuperListeners) {
             mSuperListeners.push(superCall);
             unregisterForContextMenu(view);

--- a/generator/src/main/kotlin/parse/AnalyzedJavaFile.kt
+++ b/generator/src/main/kotlin/parse/AnalyzedJavaFile.kt
@@ -20,7 +20,8 @@ data class AnalyzedJavaMethod(
             rawParameters.split(',').forEach {
                 it.trim()
                 val split = it.split(' ')
-                paramTypes.add(split.elementAt(split.size - 2))
+                val type = split.elementAt(split.size - 2).trim()
+                paramTypes.add(type.toBoxedType())
             }
         }
         paramTypes.toList()
@@ -47,10 +48,16 @@ data class AnalyzedJavaMethod(
     }
 
     val boxedReturnType: String by lazy {
-        when (returnType) {
+        returnType.toBoxedType()
+    }
+
+    private fun String.toBoxedType(): String {
+        return when (this) {
             "boolean" -> "Boolean"
             "int" -> "Integer"
-            else -> returnType
+            "void" -> "Void"
+        // add others when needed
+            else -> this
         }
     }
 
@@ -65,4 +72,18 @@ data class AnalyzedJavaMethod(
 
     val throws: Boolean = exceptionType != null
     val signature: String = "#$name($rawParameters):$returnType"
+
+    val rawParametersBoxed: List<String> by lazy {
+        if (rawParameters != null && !rawParameters.trim().isEmpty()) {
+            rawParameters.split(',').map {
+                it.trim()
+                val split = it.split(' ')
+                val type = split.elementAt(split.size - 2).trim()
+                val name = split.elementAt(split.size - 1).trim()
+                "final ${type.toBoxedType()} $name"
+            }.toList()
+        } else {
+            emptyList()
+        }
+    }
 }

--- a/generator/src/main/kotlin/types/Activity.kt
+++ b/generator/src/main/kotlin/types/Activity.kt
@@ -38,8 +38,8 @@ fun generateActivity() {
             "ActivityDelegate",
             "ICompositeActivity",
             "ActivityPlugin",
-            "getOriginal()",
             extends = "AbstractDelegate<ICompositeActivity, ActivityPlugin>",
+            additionalImports = "import java.util.ListIterator;",
             addCodeToClass = delegate_custom_nonConfigurationInstance_handling)
 
     writePlugin(outPath,

--- a/generator/src/main/kotlin/types/Fragment.kt
+++ b/generator/src/main/kotlin/types/Fragment.kt
@@ -62,7 +62,6 @@ private fun generateDialogFragment(fragment: AnalyzedJavaFile) {
             "DialogFragmentDelegate",
             "ICompositeDialogFragment",
             "DialogFragmentPlugin",
-            "getOriginal()",
             additionalImports = """
             |import android.support.v4.app.*;
             |import java.io.*;
@@ -114,10 +113,10 @@ private fun generateFragment(fragment: AnalyzedJavaFile) {
             "FragmentDelegate",
             "ICompositeFragment",
             "FragmentPlugin",
-            "getOriginal()",
             additionalImports =
             """
             |import android.support.v4.app.*;
+            |import java.util.ListIterator;
             """.replaceIndentByMargin(),
             extends = "AbstractDelegate<ICompositeFragment, FragmentPlugin>",
             transform = replaceSavedState)

--- a/generator/src/main/kotlin/types/Fragment.kt
+++ b/generator/src/main/kotlin/types/Fragment.kt
@@ -30,6 +30,7 @@ fun generateFragments() {
 val replaceSavedState: (String) -> String = {
     it.replace(" SavedState", " Fragment.SavedState")
             .replace("(SavedState)", "(Fragment.SavedState)")
+            .replace("<SavedState", "<Fragment.SavedState")
 }
 
 private fun generateDialogFragment(fragment: AnalyzedJavaFile) {
@@ -70,6 +71,7 @@ private fun generateDialogFragment(fragment: AnalyzedJavaFile) {
             |import android.view.animation.*;
             |import android.util.*;
             |import android.content.res.*;
+            |import java.util.ListIterator;
             """.replaceIndentByMargin(),
             transform = replaceSavedState,
             extends = "AbstractDelegate<ICompositeDialogFragment, DialogFragmentPlugin>",

--- a/generator/src/main/kotlin/writer/DelegateWriter.kt
+++ b/generator/src/main/kotlin/writer/DelegateWriter.kt
@@ -11,7 +11,6 @@ fun writeDelegate(outPath: String,
                   javaClassName: String,
                   compositeName: String,
                   pluginName: String,
-                  originalGetterName: String = "getOriginal()",
                   extends: String,
                   additionalImports: String? = null,
                   transform: ((String) -> String)? = null,
@@ -45,9 +44,9 @@ fun writeDelegate(outPath: String,
         //        "//${method.signature} inSuperComposite: $definedInSuperComposite, inComposite: $definedInComposite")
         methodsSb.appendln(when {
             definedInComposite && !definedInSuperComposite && isVoid ->
-                method.hook(originalGetterName, pluginName)
+                method.hook(pluginName)
             definedInComposite && !definedInSuperComposite && !isVoid ->
-                method.callFunction(originalGetterName, pluginName)
+                method.callFunction(pluginName)
 
             definedInSuperComposite && isVoid ->
                 method.forwardToDelegate(superClassDelegateName)
@@ -150,7 +149,7 @@ fun AnalyzedJavaMethod.forwardToDelegateWithReturn(delegateName: String): String
 }
 
 
-fun AnalyzedJavaMethod.hook(originalGetterName: String = "getOriginal()",
+/*fun AnalyzedJavaMethod.hook(originalGetterName: String = "getOriginal()",
                             pluginType: String = "Plugin"): String {
 
 
@@ -194,11 +193,9 @@ fun AnalyzedJavaMethod.hook(originalGetterName: String = "getOriginal()",
     sb.appendln("    }")
 
     return sb.toString();
-}
+}*/
 
-
-fun AnalyzedJavaMethod.callFunction(originalGetterName: String = "getOriginal()",
-                                    pluginType: String = "Plugin"): String {
+fun AnalyzedJavaMethod.hook(pluginType: String = "Plugin"): String {
     val typedArgs = parameterTypes.mapIndexed { i, type -> "($type) args[$i]" }
 
     val varargs = if (parameterNames.size == 1 && parameterNames[0].contains("[]")) {
@@ -206,28 +203,75 @@ fun AnalyzedJavaMethod.callFunction(originalGetterName: String = "getOriginal()"
     } else parameterNames.joinToString()
 
     return """
-    public $returnType $name($rawParameters) {
-        return callFunction("$name(${parameterTypes.joinToString()})", new PluginCall<$pluginType, $boxedReturnType>() {
-            @Override
-            public $boxedReturnType call(final NamedSuperCall<$boxedReturnType> superCall, final $pluginType plugin, final Object... args) {
-            ${if (throws) "                try {" else ""}
-                return plugin.$name(${listOf("superCall").plus(typedArgs).joinToString()});
-                ${if (throws) {
-        val sb = StringBuilder()
-        sb.appendln("            } catch ($exceptionType e) {")
-        sb.appendln("                throw new SuppressedException(e);")
-        sb.appendln("            }").toString()
-    } else ""}
-            }
-        }, new SuperCall<$boxedReturnType>() {
-            @Override
-            public $boxedReturnType call(final Object... args) { ${if (throws) "\ntry {" else ""}
-                return $originalGetterName.super_${name}(${typedArgs.joinToString()}); ${if (throws) "\n} catch ($exceptionType e) {\n throw new SuppressedException(e);\n }" else ""}
-            }
-        }${if (parameterNames.size > 0) ", " else ""}$varargs);
-    }
-    """
+    |public void $name($rawParameters) $exceptions {
+    |    if (mPlugins.isEmpty()) {
+    |${"getOriginal().super_$name($varargs);"
+            .wrapWithTryCatch(exceptionType).prependIndent("            ")}
+    |        return;
+    |    }
+    |
+    |    final ListIterator<$pluginType> iterator = mPlugins.listIterator(mPlugins.size());
+    |
+    |    final NamedSuperCall<Void> superCall = new NamedSuperCall<Void>("$name(${parameterTypes.joinToString()})") {
+    |
+    |        @Override
+    |        public Void call(final Object... args) {
+    |            if (iterator.hasPrevious()) {
+    |${"iterator.previous().$name(this${if (parameterNames.size > 0) ", " else ""}${typedArgs.joinToString()}); return null;"
+            .wrapWithTryCatch(exceptionType).prependIndent("                    ")}
+    |            } else {
+    |${"getOriginal().super_$name(${typedArgs.joinToString()}); return null;"
+            .wrapWithTryCatch(exceptionType).prependIndent("                    ")}
+    |            }
+    |        }
+    |    };
+    |    superCall.call($varargs);
+    |}
+    """.replaceIndentByMargin("    ")
 }
+
+fun AnalyzedJavaMethod.callFunction(pluginType: String = "Plugin"): String {
+    val typedArgs = parameterTypes.mapIndexed { i, type -> "($type) args[$i]" }
+
+    val varargs = if (parameterNames.size == 1 && parameterNames[0].contains("[]")) {
+        "new Object[]{${parameterNames[0]}}"
+    } else parameterNames.joinToString()
+
+    return """
+    |public $returnType $name($rawParameters) $exceptions {
+    |    if (mPlugins.isEmpty()) {
+    |${"return getOriginal().super_$name($varargs);"
+            .wrapWithTryCatch(exceptionType).prependIndent("            ")}
+    |    }
+    |
+    |    final ListIterator<$pluginType> iterator = mPlugins.listIterator(mPlugins.size());
+    |
+    |    final NamedSuperCall<$boxedReturnType> superCall = new NamedSuperCall<$boxedReturnType>("$name(${parameterTypes.joinToString()})") {
+    |
+    |        @Override
+    |        public $boxedReturnType call(final Object... args) {
+    |            if (iterator.hasPrevious()) {
+    |${"return iterator.previous().$name(this${if (parameterNames.size > 0) ", " else ""}${typedArgs.joinToString()});"
+            .wrapWithTryCatch(exceptionType).prependIndent("                    ")}
+    |            } else {
+    |${"return getOriginal().super_$name(${typedArgs.joinToString()});"
+            .wrapWithTryCatch(exceptionType).prependIndent("                    ")}
+    |            }
+    |        }
+    |    };
+    |    return superCall.call($varargs);
+    |}
+    """.replaceIndentByMargin("    ")
+}
+
+fun String.wrapWithTryCatch(exceptionType: String?): String =
+        if (exceptionType == null) this else """
+            |try{
+            |    $this
+            |} catch ($exceptionType e) {
+            |    throw new SuppressedException(e);
+            |}
+            """.replaceIndentByMargin()
 
 
 fun AnalyzedJavaMethod.notImplemented(): String {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-all.zip

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -15,6 +15,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity android:name=".performance.CompositePerformanceTestActivity" />
+        <activity android:name=".performance.PerformanceTestActivity" />
     </application>
 
 </manifest>

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/CompositePerformanceTestActivity.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/CompositePerformanceTestActivity.java
@@ -41,7 +41,7 @@ public class CompositePerformanceTestActivity extends CompositeActivity {
 
     private static final String TAG = CompositePerformanceTestActivity.class.getSimpleName();
 
-    public static final int ITERATIONS = 50000;
+    public static final int ITERATIONS = 10000;
 
     private final String mName = "0";
 
@@ -107,7 +107,6 @@ public class CompositePerformanceTestActivity extends CompositeActivity {
                 duration += testGetCacheDir();
             }
             duration /= iterations;
-            duration /= ITERATIONS;
             Log.v(TAG, number + "getCacheDir() in " + duration + "ms");
 
             duration = 0;
@@ -115,7 +114,6 @@ public class CompositePerformanceTestActivity extends CompositeActivity {
                 duration += testGetResources();
             }
             duration /= iterations;
-            duration /= ITERATIONS;
             Log.v(TAG, number + "getResources() in " + duration + "ms");
 
             duration = 0;
@@ -123,7 +121,6 @@ public class CompositePerformanceTestActivity extends CompositeActivity {
                 duration += testGetDelegate();
             }
             duration /= iterations;
-            duration /= ITERATIONS;
             Log.v(TAG, number + "getDelegate() in " + duration + "ms");
 
             duration = 0;
@@ -131,7 +128,6 @@ public class CompositePerformanceTestActivity extends CompositeActivity {
                 duration += testGetFile();
             }
             duration /= iterations;
-            duration /= ITERATIONS;
             Log.v(TAG, number + "getFile() in " + duration + "ms");
 
             duration = 0;
@@ -139,7 +135,6 @@ public class CompositePerformanceTestActivity extends CompositeActivity {
                 duration += testOnSaveInstanceState();
             }
             duration /= iterations;
-            duration /= ITERATIONS;
             Log.v(TAG, number + "onSaveInstanceState() in " + duration + "ms");
 
 

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/CompositePerformanceTestActivity.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/CompositePerformanceTestActivity.java
@@ -1,0 +1,208 @@
+package com.pascalwelsch.compositeandroid.performance;
+
+import com.pascalwelsch.compositeandroid.R;
+import com.pascalwelsch.compositeandroid.activity.ActivityPlugin;
+import com.pascalwelsch.compositeandroid.activity.CompositeActivity;
+
+import android.annotation.SuppressLint;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatDelegate;
+import android.util.Log;
+import android.view.View;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class CompositePerformanceTestActivity extends CompositeActivity {
+
+    private static class PerformanceTestPlugin extends ActivityPlugin {
+
+        private final String mName;
+
+        public PerformanceTestPlugin(final String name) {
+
+            mName = name;
+        }
+
+        @Override
+        public Resources getResources() {
+            return super.getResources();
+        }
+
+        @Override
+        public void onSaveInstanceState(final Bundle outState) {
+            super.onSaveInstanceState(outState);
+            outState.putString(mName, mName);
+        }
+    }
+
+    private static final String TAG = CompositePerformanceTestActivity.class.getSimpleName();
+
+    public static final int ITERATIONS = 50000;
+
+    private final String mName = "0";
+
+    public CompositePerformanceTestActivity() {
+        addPlugin(new PerformanceTestPlugin("1"));
+        addPlugin(new PerformanceTestPlugin("2"));
+        addPlugin(new PerformanceTestPlugin("3"));
+        addPlugin(new PerformanceTestPlugin("4"));
+        addPlugin(new PerformanceTestPlugin("5"));
+        /*addPlugin(new PerformanceTestPlugin("6"));
+        addPlugin(new PerformanceTestPlugin("7"));
+        addPlugin(new PerformanceTestPlugin("8"));
+        addPlugin(new PerformanceTestPlugin("9"));
+        addPlugin(new PerformanceTestPlugin("10"));
+        addPlugin(new PerformanceTestPlugin("12"));
+        addPlugin(new PerformanceTestPlugin("13"));
+        addPlugin(new PerformanceTestPlugin("14"));
+        addPlugin(new PerformanceTestPlugin("15"));
+        addPlugin(new PerformanceTestPlugin("16"));
+        addPlugin(new PerformanceTestPlugin("17"));
+        addPlugin(new PerformanceTestPlugin("18"));
+        addPlugin(new PerformanceTestPlugin("19"));
+        addPlugin(new PerformanceTestPlugin("20"));*/
+    }
+
+    @Override
+    public File getCacheDir() {
+        return super_getCacheDir();
+    }
+
+    @Override
+    public void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_performance);
+        final View start = findViewById(R.id.start);
+        assert start != null;
+        start.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(final View v) {
+                runPerformanceTest();
+            }
+        });
+    }
+
+    @Override
+    public void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(mName, mName);
+    }
+
+    private void runPerformanceTest() {
+
+        for (int j = 0; j < 10; j++) {
+
+            String number = j + " plugins: ";
+
+            System.gc();
+            final int iterations = 2;
+            float duration = 0;
+
+            duration = 0;
+            for (int i = 0; i < iterations; i++) {
+                duration += testGetCacheDir();
+            }
+            duration /= iterations;
+            duration /= ITERATIONS;
+            Log.v(TAG, number + "getCacheDir() in " + duration + "ms");
+
+            duration = 0;
+            for (int i = 0; i < iterations; i++) {
+                duration += testGetResources();
+            }
+            duration /= iterations;
+            duration /= ITERATIONS;
+            Log.v(TAG, number + "getResources() in " + duration + "ms");
+
+            duration = 0;
+            for (int i = 0; i < iterations; i++) {
+                duration += testGetDelegate();
+            }
+            duration /= iterations;
+            duration /= ITERATIONS;
+            Log.v(TAG, number + "getDelegate() in " + duration + "ms");
+
+            duration = 0;
+            for (int i = 0; i < iterations; i++) {
+                duration += testGetFile();
+            }
+            duration /= iterations;
+            duration /= ITERATIONS;
+            Log.v(TAG, number + "getFile() in " + duration + "ms");
+
+            duration = 0;
+            for (int i = 0; i < iterations; i++) {
+                duration += testOnSaveInstanceState();
+            }
+            duration /= iterations;
+            duration /= ITERATIONS;
+            Log.v(TAG, number + "onSaveInstanceState() in " + duration + "ms");
+
+
+            addPlugin(new PerformanceTestPlugin(String.valueOf(j)));
+        }
+    }
+
+    private long testGetCacheDir() {
+        final List<File> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final File file = getCacheDir();
+            results.add(file);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    private long testGetDelegate() {
+        final List<AppCompatDelegate> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final AppCompatDelegate delegate = getDelegate();
+            results.add(delegate);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    private long testGetFile() {
+        final List<File> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final File file = getFilesDir();
+            results.add(file);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    private long testGetResources() {
+        final List<Resources> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final Resources resources = getResources();
+            results.add(resources);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    @SuppressLint("Assert")
+    private long testOnSaveInstanceState() {
+        final List<Bundle> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final Bundle outState = new Bundle();
+            onSaveInstanceState(outState);
+            results.add(outState);
+        }
+        final long end = System.currentTimeMillis();
+
+        assert results.get(0).getString("1") == "1";
+        assert results.get(0).getString("20") == "20";
+        assert results.get(results.size()).getString("1") == "1";
+        assert results.get(results.size()).getString("20") == "20";
+
+        return end - start;
+    }
+}

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity.java
@@ -1,0 +1,158 @@
+package com.pascalwelsch.compositeandroid.performance;
+
+import com.pascalwelsch.compositeandroid.R;
+
+import android.annotation.SuppressLint;
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatDelegate;
+import android.util.Log;
+import android.view.View;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class PerformanceTestActivity extends PerformanceTestActivity1 {
+
+    private static final String TAG = PerformanceTestActivity.class.getSimpleName();
+
+    public static final int ITERATIONS = 10000;
+
+    private final String mName = "0";
+
+    @Override
+    public Resources getResources() {
+        return super.getResources();
+    }
+
+    @Override
+    protected void onCreate(@Nullable final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_performance);
+        final View start = findViewById(R.id.start);
+        assert start != null;
+        start.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(final View v) {
+                runPerformanceTest();
+            }
+        });
+    }
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(mName, mName);
+    }
+
+    private void runPerformanceTest() {
+
+        String number = "5 stages: ";
+
+        System.gc();
+        final int iterations = 2;
+        float duration = 0;
+
+        duration = 0;
+        for (int i = 0; i < iterations; i++) {
+            duration += testGetCacheDir();
+        }
+        duration /= iterations;
+        duration /= ITERATIONS;
+        Log.v(TAG, number + "getCacheDir() in " + duration + "ms");
+
+        duration = 0;
+        for (int i = 0; i < iterations; i++) {
+            duration += testGetResources();
+        }
+        duration /= iterations;
+        duration /= ITERATIONS;
+        Log.v(TAG, number + "getResources() in " + duration + "ms");
+
+        duration = 0;
+        for (int i = 0; i < iterations; i++) {
+            duration += testGetDelegate();
+        }
+        duration /= iterations;
+        duration /= ITERATIONS;
+        Log.v(TAG, number + "getDelegate() in " + duration + "ms");
+
+        duration = 0;
+        for (int i = 0; i < iterations; i++) {
+            duration += testGetFile();
+        }
+        duration /= iterations;
+        duration /= ITERATIONS;
+        Log.v(TAG, number + "getFile() in " + duration + "ms");
+
+        duration = 0;
+        for (int i = 0; i < iterations; i++) {
+            duration += testOnSaveInstanceState();
+        }
+        duration /= iterations;
+        duration /= ITERATIONS;
+        Log.v(TAG, number + "onSaveInstanceState() in " + duration + "ms");
+
+    }
+
+    private long testGetCacheDir() {
+        final List<File> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final File file = getCacheDir();
+            results.add(file);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    private long testGetDelegate() {
+        final List<AppCompatDelegate> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final AppCompatDelegate delegate = getDelegate();
+            results.add(delegate);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    private long testGetFile() {
+        final List<File> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final File file = getFilesDir();
+            results.add(file);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    private long testGetResources() {
+        final List<Resources> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final Resources resources = getResources();
+            results.add(resources);
+        }
+        return System.currentTimeMillis() - start;
+    }
+
+    @SuppressLint("Assert")
+    private long testOnSaveInstanceState() {
+        final List<Bundle> results = new ArrayList<>();
+        final long start = System.currentTimeMillis();
+        for (long i = 0; i < ITERATIONS; i++) {
+            final Bundle outState = new Bundle();
+            onSaveInstanceState(outState);
+            results.add(outState);
+        }
+        final long end = System.currentTimeMillis();
+
+        assert results.get(0).getString("1") == "1";
+        assert results.get(0).getString("20") == "20";
+        assert results.get(results.size()).getString("1") == "1";
+        assert results.get(results.size()).getString("20") == "20";
+
+        return end - start;
+    }
+}

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity.java
@@ -18,7 +18,7 @@ public class PerformanceTestActivity extends PerformanceTestActivity1 {
 
     private static final String TAG = PerformanceTestActivity.class.getSimpleName();
 
-    public static final int ITERATIONS = 10000;
+    public static final int ITERATIONS = 50000;
 
     private final String mName = "0";
 
@@ -52,7 +52,7 @@ public class PerformanceTestActivity extends PerformanceTestActivity1 {
         String number = "5 stages: ";
 
         System.gc();
-        final int iterations = 2;
+        final int iterations = 1;
         float duration = 0;
 
         duration = 0;
@@ -60,7 +60,6 @@ public class PerformanceTestActivity extends PerformanceTestActivity1 {
             duration += testGetCacheDir();
         }
         duration /= iterations;
-        duration /= ITERATIONS;
         Log.v(TAG, number + "getCacheDir() in " + duration + "ms");
 
         duration = 0;
@@ -68,7 +67,6 @@ public class PerformanceTestActivity extends PerformanceTestActivity1 {
             duration += testGetResources();
         }
         duration /= iterations;
-        duration /= ITERATIONS;
         Log.v(TAG, number + "getResources() in " + duration + "ms");
 
         duration = 0;
@@ -76,7 +74,6 @@ public class PerformanceTestActivity extends PerformanceTestActivity1 {
             duration += testGetDelegate();
         }
         duration /= iterations;
-        duration /= ITERATIONS;
         Log.v(TAG, number + "getDelegate() in " + duration + "ms");
 
         duration = 0;
@@ -84,7 +81,6 @@ public class PerformanceTestActivity extends PerformanceTestActivity1 {
             duration += testGetFile();
         }
         duration /= iterations;
-        duration /= ITERATIONS;
         Log.v(TAG, number + "getFile() in " + duration + "ms");
 
         duration = 0;
@@ -92,7 +88,6 @@ public class PerformanceTestActivity extends PerformanceTestActivity1 {
             duration += testOnSaveInstanceState();
         }
         duration /= iterations;
-        duration /= ITERATIONS;
         Log.v(TAG, number + "onSaveInstanceState() in " + duration + "ms");
 
     }

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity1.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity1.java
@@ -1,0 +1,20 @@
+package com.pascalwelsch.compositeandroid.performance;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+
+public class PerformanceTestActivity1 extends PerformanceTestActivity2 {
+
+    private final String mName = "1";
+
+    @Override
+    public Resources getResources() {
+        return super.getResources();
+    }
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(mName, mName);
+    }
+}

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity2.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity2.java
@@ -1,0 +1,20 @@
+package com.pascalwelsch.compositeandroid.performance;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+
+public class PerformanceTestActivity2 extends PerformanceTestActivity3 {
+
+    private final String mName = "2";
+
+    @Override
+    public Resources getResources() {
+        return super.getResources();
+    }
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(mName, mName);
+    }
+}

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity3.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity3.java
@@ -1,0 +1,20 @@
+package com.pascalwelsch.compositeandroid.performance;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+
+public class PerformanceTestActivity3 extends PerformanceTestActivity4 {
+
+    private final String mName = "3";
+
+    @Override
+    public Resources getResources() {
+        return super.getResources();
+    }
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(mName, mName);
+    }
+}

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity4.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity4.java
@@ -1,0 +1,20 @@
+package com.pascalwelsch.compositeandroid.performance;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+
+public class PerformanceTestActivity4 extends PerformanceTestActivity5 {
+
+    private final String mName = "4";
+
+    @Override
+    public Resources getResources() {
+        return super.getResources();
+    }
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(mName, mName);
+    }
+}

--- a/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity5.java
+++ b/sample/src/main/java/com/pascalwelsch/compositeandroid/performance/PerformanceTestActivity5.java
@@ -1,0 +1,21 @@
+package com.pascalwelsch.compositeandroid.performance;
+
+import android.content.res.Resources;
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+
+public class PerformanceTestActivity5 extends AppCompatActivity {
+
+    private final String mName = "5";
+
+    @Override
+    public Resources getResources() {
+        return super.getResources();
+    }
+
+    @Override
+    protected void onSaveInstanceState(final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putString(mName, mName);
+    }
+}

--- a/sample/src/main/res/layout/activity_performance.xml
+++ b/sample/src/main/res/layout/activity_performance.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <Button
+        android:id="@+id/start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="start" />
+
+</LinearLayout>


### PR DESCRIPTION
- Elimination of unnecessary `Object[]` allocation due to varargs.
- Reduce superCallback instances to one per method call instead of one per layer

I tested caching the superCall object per method as well as caching the iterator. But the results haven't been noticeable on Dalvik and Art. The allocation of the `Object[]` was the main reason for bad performance on Dalvik.

Results on Genymotion Android 5.0:
##### Normal 5 Layer inheritance `50.000` iterations

```
V/PerformanceTestActivity: 5 stages: getCacheDir() in 115.0ms
V/PerformanceTestActivity: 5 stages: getResources() in 3.0ms
V/PerformanceTestActivity: 5 stages: getDelegate() in 1.0ms
V/PerformanceTestActivity: 5 stages: getFile() in 97.0ms
V/PerformanceTestActivity: 5 stages: onSaveInstanceState() in 287.0ms
```
##### CompositeAndroid `0.3.0` 5 plugins `50.000` iterations with optimizations

```
V/CompositePerformanceTestActivity: 5 plugins: getCacheDir() in 256.0ms
V/CompositePerformanceTestActivity: 5 plugins: getCacheDir() in 90.0ms  (direct)
V/CompositePerformanceTestActivity: 5 plugins: getResources() in 143.0ms
V/CompositePerformanceTestActivity: 5 plugins: getResources() in 2.0ms (direct) *
V/CompositePerformanceTestActivity: 5 plugins: onSaveInstanceState() in 389.0ms
V/CompositePerformanceTestActivity: 5 plugins: onSaveInstanceState() in 247.0ms (direct)
```
##### CompositeAndroid `0.2.1` 5 plugins `50.000` iterations with optimizations

```
V/CompositePerformanceTestActivity: 5 plugins: getCacheDir() in 364.0ms
V/CompositePerformanceTestActivity: 5 plugins: getCacheDir() in 96.0ms  (direct)
V/CompositePerformanceTestActivity: 5 plugins: getResources() in 238.0ms
V/CompositePerformanceTestActivity: 5 plugins: getResources() in 2.0ms (direct) *
V/CompositePerformanceTestActivity: 5 plugins: onSaveInstanceState() in 596.0ms
V/CompositePerformanceTestActivity: 5 plugins: onSaveInstanceState() in 350.0ms (direct)
```

\* Compiler optimizations for getters as we see it for `getResources()` are not applied when doing composition. This makes the overhead much larger but mostly acceptable.

(direct) calls call the super method directly without any delegate logic and without calling any plugin. The diff between direct and non direct calls is the overhead from CompositeAndroid which is between 50% and 400%. Nothing to worry.

I also tried optimizations via reflection, not calling a plugin when the plugin doesn't override the calling method. This results in a big overhead for the first call but all future calls get very close the results of the normal 4 layer inheritance. My tests showed it's only worth the initial overhead after over `1.000.000` calls.

I also discovered  that some methods are far more called than others. Especially `getApplicationInfo()` with often 100.000 times per `Activity` and `getResources()` a few thousand times. `getApplicationInfo()` is used inside the `View` constructor. When inflating a layout this gets called thousands of times. Therefore I'm looking forward to the reflection solution for those performance critical methods in a separate PR.
