### PR TITLE
Feature/performance 2

### DIFF
--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -100,13 +100,1272 @@ import java.util.ListIterator;
 
 public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, ActivityPlugin> {
 
-
     @VisibleForTesting
     static final int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
 
-    private int mGetResourcesCallCount = 0;
+    private int mCallCount_addContentViewVwVs = 0;
 
-    private transient boolean mIsGetResourcesOverridden = false;
+    private int mCallCount_applyOverrideConfigurationCn = 0;
+
+    private int mCallCount_attachBaseContextCt = 0;
+
+    private int mCallCount_bindServiceItSnIr = 0;
+
+    private int mCallCount_checkCallingOrSelfPermissionSg = 0;
+
+    private int mCallCount_checkCallingOrSelfUriPermissionUiIr = 0;
+
+    private int mCallCount_checkCallingPermissionSg = 0;
+
+    private int mCallCount_checkCallingUriPermissionUiIr = 0;
+
+    private int mCallCount_checkPermissionSgIrIr = 0;
+
+    private int mCallCount_checkSelfPermissionSg = 0;
+
+    private int mCallCount_checkUriPermissionUiIrIrIr = 0;
+
+    private int mCallCount_checkUriPermissionUiSgSgIrIrIr = 0;
+
+    private int mCallCount_clearWallpaper = 0;
+
+    private int mCallCount_closeContextMenu = 0;
+
+    private int mCallCount_closeOptionsMenu = 0;
+
+    private int mCallCount_createConfigurationContextCn = 0;
+
+    private int mCallCount_createDisplayContextDy = 0;
+
+    private int mCallCount_createPackageContextSgIr = 0;
+
+    private int mCallCount_createPendingResultIrItIr = 0;
+
+    private int mCallCount_databaseList = 0;
+
+    private int mCallCount_deleteDatabaseSg = 0;
+
+    private int mCallCount_deleteFileSg = 0;
+
+    private int mCallCount_dispatchGenericMotionEventMt = 0;
+
+    private int mCallCount_dispatchKeyEventKt = 0;
+
+    private int mCallCount_dispatchKeyShortcutEventKt = 0;
+
+    private int mCallCount_dispatchPopulateAccessibilityEventAt = 0;
+
+    private int mCallCount_dispatchTouchEventMt = 0;
+
+    private int mCallCount_dispatchTrackballEventMt = 0;
+
+    private int mCallCount_dumpSgFrPrSg = 0;
+
+    private int mCallCount_enforceCallingOrSelfPermissionSgSg = 0;
+
+    private int mCallCount_enforceCallingOrSelfUriPermissionUiIrSg = 0;
+
+    private int mCallCount_enforceCallingPermissionSgSg = 0;
+
+    private int mCallCount_enforceCallingUriPermissionUiIrSg = 0;
+
+    private int mCallCount_enforcePermissionSgIrIrSg = 0;
+
+    private int mCallCount_enforceUriPermissionUiIrIrIrSg = 0;
+
+    private int mCallCount_enforceUriPermissionUiSgSgIrIrIrSg = 0;
+
+    private int mCallCount_fileList = 0;
+
+    private int mCallCount_findViewByIdIr = 0;
+
+    private int mCallCount_finish = 0;
+
+    private int mCallCount_finishActivityFromChildAyIr = 0;
+
+    private int mCallCount_finishActivityIr = 0;
+
+    private int mCallCount_finishAffinity = 0;
+
+    private int mCallCount_finishAfterTransition = 0;
+
+    private int mCallCount_finishAndRemoveTask = 0;
+
+    private int mCallCount_finishFromChildAy = 0;
+
+    private int mCallCount_getActionBar = 0;
+
+    private int mCallCount_getApplicationContext = 0;
+
+    private int mCallCount_getApplicationInfo = 0;
+
+    private int mCallCount_getAssets = 0;
+
+    private int mCallCount_getBaseContext = 0;
+
+    private int mCallCount_getCacheDir = 0;
+
+    private int mCallCount_getCallingActivity = 0;
+
+    private int mCallCount_getCallingPackage = 0;
+
+    private int mCallCount_getChangingConfigurations = 0;
+
+    private int mCallCount_getClassLoader = 0;
+
+    private int mCallCount_getCodeCacheDir = 0;
+
+    private int mCallCount_getComponentName = 0;
+
+    private int mCallCount_getContentResolver = 0;
+
+    private int mCallCount_getContentScene = 0;
+
+    private int mCallCount_getContentTransitionManager = 0;
+
+    private int mCallCount_getCurrentFocus = 0;
+
+    private int mCallCount_getDatabasePathSg = 0;
+
+    private int mCallCount_getDelegate = 0;
+
+    private int mCallCount_getDirSgIr = 0;
+
+    private int mCallCount_getDrawerToggleDelegate = 0;
+
+    private int mCallCount_getExternalCacheDir = 0;
+
+    private int mCallCount_getExternalCacheDirs = 0;
+
+    private int mCallCount_getExternalFilesDirSg = 0;
+
+    private int mCallCount_getExternalFilesDirsSg = 0;
+
+    private int mCallCount_getExternalMediaDirs = 0;
+
+    private int mCallCount_getFileStreamPathSg = 0;
+
+    private int mCallCount_getFilesDir = 0;
+
+    private int mCallCount_getFragmentManager = 0;
+
+    private int mCallCount_getIntent = 0;
+
+    private int mCallCount_getLayoutInflater = 0;
+
+    private int mCallCount_getLoaderManager = 0;
+
+    private int mCallCount_getLocalClassName = 0;
+
+    private int mCallCount_getMainLooper = 0;
+
+    private int mCallCount_getMenuInflater = 0;
+
+    private int mCallCount_getNoBackupFilesDir = 0;
+
+    private int mCallCount_getObbDir = 0;
+
+    private int mCallCount_getObbDirs = 0;
+
+    private int mCallCount_getPackageCodePath = 0;
+
+    private int mCallCount_getPackageManager = 0;
+
+    private int mCallCount_getPackageName = 0;
+
+    private int mCallCount_getPackageResourcePath = 0;
+
+    private int mCallCount_getParentActivityIntent = 0;
+
+    private int mCallCount_getPreferencesIr = 0;
+
+    private int mCallCount_getReferrer = 0;
+
+    private int mCallCount_getRequestedOrientation = 0;
+
+    private int mCallCount_getResources = 0;
+
+    private int mCallCount_getSharedPreferencesSgIr = 0;
+
+    private int mCallCount_getSupportActionBar = 0;
+
+    private int mCallCount_getSupportFragmentManager = 0;
+
+    private int mCallCount_getSupportLoaderManager = 0;
+
+    private int mCallCount_getSupportParentActivityIntent = 0;
+
+    private int mCallCount_getSystemServiceNameCs = 0;
+
+    private int mCallCount_getSystemServiceSg = 0;
+
+    private int mCallCount_getTaskId = 0;
+
+    private int mCallCount_getTheme = 0;
+
+    private int mCallCount_getVoiceInteractor = 0;
+
+    private int mCallCount_getWallpaper = 0;
+
+    private int mCallCount_getWallpaperDesiredMinimumHeight = 0;
+
+    private int mCallCount_getWallpaperDesiredMinimumWidth = 0;
+
+    private int mCallCount_getWindow = 0;
+
+    private int mCallCount_getWindowManager = 0;
+
+    private int mCallCount_grantUriPermissionSgUiIr = 0;
+
+    private int mCallCount_hasWindowFocus = 0;
+
+    private int mCallCount_invalidateOptionsMenu = 0;
+
+    private int mCallCount_isChangingConfigurations = 0;
+
+    private int mCallCount_isDestroyed = 0;
+
+    private int mCallCount_isFinishing = 0;
+
+    private int mCallCount_isImmersive = 0;
+
+    private int mCallCount_isRestricted = 0;
+
+    private int mCallCount_isTaskRoot = 0;
+
+    private int mCallCount_isVoiceInteraction = 0;
+
+    private int mCallCount_isVoiceInteractionRoot = 0;
+
+    private int mCallCount_moveTaskToBackBn = 0;
+
+    private int mCallCount_navigateUpToFromChildAyIt = 0;
+
+    private int mCallCount_navigateUpToIt = 0;
+
+    private int mCallCount_onActionModeFinishedae = 0;
+
+    private int mCallCount_onActionModeStartedae = 0;
+
+    private int mCallCount_onActivityReenterIrIt = 0;
+
+    private int mCallCount_onActivityResultIrIrIt = 0;
+
+    private int mCallCount_onApplyThemeResourceReIrBn = 0;
+
+    private int mCallCount_onAttachFragmentFt = 0;
+
+    private int mCallCount_onAttachFragmentat = 0;
+
+    private int mCallCount_onAttachedToWindow = 0;
+
+    private int mCallCount_onBackPressed = 0;
+
+    private int mCallCount_onChildTitleChangedAyCe = 0;
+
+    private int mCallCount_onConfigurationChangedCn = 0;
+
+    private int mCallCount_onContentChanged = 0;
+
+    private int mCallCount_onContextItemSelectedMm = 0;
+
+    private int mCallCount_onContextMenuClosedMu = 0;
+
+    private int mCallCount_onCreateBe = 0;
+
+    private int mCallCount_onCreateBePe = 0;
+
+    private int mCallCount_onCreateContextMenuCuVwCo = 0;
+
+    private int mCallCount_onCreateDescription = 0;
+
+    private int mCallCount_onCreateDialogIr = 0;
+
+    private int mCallCount_onCreateDialogIrBe = 0;
+
+    private int mCallCount_onCreateNavigateUpTaskStackTr = 0;
+
+    private int mCallCount_onCreateOptionsMenuMu = 0;
+
+    private int mCallCount_onCreatePanelMenuIrMu = 0;
+
+    private int mCallCount_onCreatePanelViewIr = 0;
+
+    private int mCallCount_onCreateSupportNavigateUpTaskStackar = 0;
+
+    private int mCallCount_onCreateThumbnailBpCs = 0;
+
+    private int mCallCount_onCreateViewSgCtAt = 0;
+
+    private int mCallCount_onCreateViewVwSgCtAt = 0;
+
+    private int mCallCount_onDestroy = 0;
+
+    private int mCallCount_onDetachedFromWindow = 0;
+
+    private int mCallCount_onEnterAnimationComplete = 0;
+
+    private int mCallCount_onGenericMotionEventMt = 0;
+
+    private int mCallCount_onKeyDownIrKt = 0;
+
+    private int mCallCount_onKeyLongPressIrKt = 0;
+
+    private int mCallCount_onKeyMultipleIrIrKt = 0;
+
+    private int mCallCount_onKeyShortcutIrKt = 0;
+
+    private int mCallCount_onKeyUpIrKt = 0;
+
+    private int mCallCount_onLowMemory = 0;
+
+    private int mCallCount_onMenuOpenedIrMu = 0;
+
+    private int mCallCount_onNavigateUp = 0;
+
+    private int mCallCount_onNavigateUpFromChildAy = 0;
+
+    private int mCallCount_onNewIntentIt = 0;
+
+    private int mCallCount_onOptionsItemSelectedMm = 0;
+
+    private int mCallCount_onOptionsMenuClosedMu = 0;
+
+    private int mCallCount_onPanelClosedIrMu = 0;
+
+    private int mCallCount_onPause = 0;
+
+    private int mCallCount_onPostCreateBe = 0;
+
+    private int mCallCount_onPostCreateBePe = 0;
+
+    private int mCallCount_onPostResume = 0;
+
+    private int mCallCount_onPrepareDialogIrDg = 0;
+
+    private int mCallCount_onPrepareDialogIrDgBe = 0;
+
+    private int mCallCount_onPrepareNavigateUpTaskStackTr = 0;
+
+    private int mCallCount_onPrepareOptionsMenuMu = 0;
+
+    private int mCallCount_onPrepareOptionsPanelVwMu = 0;
+
+    private int mCallCount_onPreparePanelIrVwMu = 0;
+
+    private int mCallCount_onPrepareSupportNavigateUpTaskStackar = 0;
+
+    private int mCallCount_onProvideAssistContentAt = 0;
+
+    private int mCallCount_onProvideAssistDataBe = 0;
+
+    private int mCallCount_onProvideReferrer = 0;
+
+    private int mCallCount_onRequestPermissionsResultIrSgit = 0;
+
+    private int mCallCount_onRestart = 0;
+
+    private int mCallCount_onRestoreInstanceStateBe = 0;
+
+    private int mCallCount_onRestoreInstanceStateBePe = 0;
+
+    private int mCallCount_onResume = 0;
+
+    private int mCallCount_onResumeFragments = 0;
+
+    private int mCallCount_onSaveInstanceStateBe = 0;
+
+    private int mCallCount_onSaveInstanceStateBePe = 0;
+
+    private int mCallCount_onSearchRequested = 0;
+
+    private int mCallCount_onSearchRequestedSt = 0;
+
+    private int mCallCount_onStart = 0;
+
+    private int mCallCount_onStateNotSaved = 0;
+
+    private int mCallCount_onStop = 0;
+
+    private int mCallCount_onSupportActionModeFinishedAe = 0;
+
+    private int mCallCount_onSupportActionModeStartedAe = 0;
+
+    private int mCallCount_onSupportContentChanged = 0;
+
+    private int mCallCount_onSupportNavigateUp = 0;
+
+    private int mCallCount_onTitleChangedCeIr = 0;
+
+    private int mCallCount_onTouchEventMt = 0;
+
+    private int mCallCount_onTrackballEventMt = 0;
+
+    private int mCallCount_onTrimMemoryIr = 0;
+
+    private int mCallCount_onUserInteraction = 0;
+
+    private int mCallCount_onUserLeaveHint = 0;
+
+    private int mCallCount_onVisibleBehindCanceled = 0;
+
+    private int mCallCount_onWindowAttributesChangedWs = 0;
+
+    private int mCallCount_onWindowFocusChangedBn = 0;
+
+    private int mCallCount_onWindowStartingActionModeak = 0;
+
+    private int mCallCount_onWindowStartingActionModeakIr = 0;
+
+    private int mCallCount_onWindowStartingSupportActionModeAk = 0;
+
+    private int mCallCount_openContextMenuVw = 0;
+
+    private int mCallCount_openFileInputSg = 0;
+
+    private int mCallCount_openFileOutputSgIr = 0;
+
+    private int mCallCount_openOptionsMenu = 0;
+
+    private int mCallCount_openOrCreateDatabaseSgIrSy = 0;
+
+    private int mCallCount_openOrCreateDatabaseSgIrSyDr = 0;
+
+    private int mCallCount_overridePendingTransitionIrIr = 0;
+
+    private int mCallCount_peekWallpaper = 0;
+
+    private int mCallCount_postponeEnterTransition = 0;
+
+    private int mCallCount_recreate = 0;
+
+    private int mCallCount_registerComponentCallbacksCs = 0;
+
+    private int mCallCount_registerForContextMenuVw = 0;
+
+    private int mCallCount_registerReceiverBrIr = 0;
+
+    private int mCallCount_registerReceiverBrIrSgHr = 0;
+
+    private int mCallCount_releaseInstance = 0;
+
+    private int mCallCount_removeStickyBroadcastAsUserItUe = 0;
+
+    private int mCallCount_removeStickyBroadcastIt = 0;
+
+    private int mCallCount_reportFullyDrawn = 0;
+
+    private int mCallCount_requestVisibleBehindBn = 0;
+
+    private int mCallCount_revokeUriPermissionUiIr = 0;
+
+    private int mCallCount_sendBroadcastAsUserItUe = 0;
+
+    private int mCallCount_sendBroadcastAsUserItUeSg = 0;
+
+    private int mCallCount_sendBroadcastIt = 0;
+
+    private int mCallCount_sendBroadcastItSg = 0;
+
+    private int mCallCount_sendOrderedBroadcastAsUserItUeSgBrHrIrSgBe = 0;
+
+    private int mCallCount_sendOrderedBroadcastItSg = 0;
+
+    private int mCallCount_sendOrderedBroadcastItSgBrHrIrSgBe = 0;
+
+    private int mCallCount_sendStickyBroadcastAsUserItUe = 0;
+
+    private int mCallCount_sendStickyBroadcastIt = 0;
+
+    private int mCallCount_sendStickyOrderedBroadcastAsUserItUeBrHrIrSgBe = 0;
+
+    private int mCallCount_sendStickyOrderedBroadcastItBrHrIrSgBe = 0;
+
+    private int mCallCount_setActionBarTr = 0;
+
+    private int mCallCount_setContentTransitionManagerTr = 0;
+
+    private int mCallCount_setContentViewIr = 0;
+
+    private int mCallCount_setContentViewVw = 0;
+
+    private int mCallCount_setContentViewVwVs = 0;
+
+    private int mCallCount_setEnterSharedElementCallbackSk = 0;
+
+    private int mCallCount_setEnterSharedElementCallbackak = 0;
+
+    private int mCallCount_setExitSharedElementCallbackSk = 0;
+
+    private int mCallCount_setExitSharedElementCallbackak = 0;
+
+    private int mCallCount_setFinishOnTouchOutsideBn = 0;
+
+    private int mCallCount_setImmersiveBn = 0;
+
+    private int mCallCount_setIntentIt = 0;
+
+    private int mCallCount_setRequestedOrientationIr = 0;
+
+    private int mCallCount_setSupportActionBarar = 0;
+
+    private int mCallCount_setSupportProgressBarIndeterminateBn = 0;
+
+    private int mCallCount_setSupportProgressBarIndeterminateVisibilityBn = 0;
+
+    private int mCallCount_setSupportProgressBarVisibilityBn = 0;
+
+    private int mCallCount_setSupportProgressIr = 0;
+
+    private int mCallCount_setTaskDescriptionAn = 0;
+
+    private int mCallCount_setThemeIr = 0;
+
+    private int mCallCount_setTitleCe = 0;
+
+    private int mCallCount_setTitleColorIr = 0;
+
+    private int mCallCount_setTitleIr = 0;
+
+    private int mCallCount_setVisibleBn = 0;
+
+    private int mCallCount_setWallpaperBp = 0;
+
+    private int mCallCount_setWallpaperIm = 0;
+
+    private int mCallCount_shouldShowRequestPermissionRationaleSg = 0;
+
+    private int mCallCount_shouldUpRecreateTaskIt = 0;
+
+    private int mCallCount_showAssistBe = 0;
+
+    private int mCallCount_showLockTaskEscapeMessage = 0;
+
+    private int mCallCount_startActionModeak = 0;
+
+    private int mCallCount_startActionModeakIr = 0;
+
+    private int mCallCount_startActivitiesIt = 0;
+
+    private int mCallCount_startActivitiesItBe = 0;
+
+    private int mCallCount_startActivityForResultItIr = 0;
+
+    private int mCallCount_startActivityForResultItIrBe = 0;
+
+    private int mCallCount_startActivityFromChildAyItIr = 0;
+
+    private int mCallCount_startActivityFromChildAyItIrBe = 0;
+
+    private int mCallCount_startActivityFromFragmentFtItIr = 0;
+
+    private int mCallCount_startActivityFromFragmentFtItIrBe = 0;
+
+    private int mCallCount_startActivityFromFragmentatItIr = 0;
+
+    private int mCallCount_startActivityFromFragmentatItIrBe = 0;
+
+    private int mCallCount_startActivityIfNeededItIr = 0;
+
+    private int mCallCount_startActivityIfNeededItIrBe = 0;
+
+    private int mCallCount_startActivityIt = 0;
+
+    private int mCallCount_startActivityItBe = 0;
+
+    private int mCallCount_startInstrumentationCeSgBe = 0;
+
+    private int mCallCount_startIntentSenderForResultIrIrItIrIrIr = 0;
+
+    private int mCallCount_startIntentSenderForResultIrIrItIrIrIrBe = 0;
+
+    private int mCallCount_startIntentSenderFromChildAyIrIrItIrIrIr = 0;
+
+    private int mCallCount_startIntentSenderFromChildAyIrIrItIrIrIrBe = 0;
+
+    private int mCallCount_startIntentSenderIrItIrIrIr = 0;
+
+    private int mCallCount_startIntentSenderIrItIrIrIrBe = 0;
+
+    private int mCallCount_startLockTask = 0;
+
+    private int mCallCount_startManagingCursorCr = 0;
+
+    private int mCallCount_startNextMatchingActivityIt = 0;
+
+    private int mCallCount_startNextMatchingActivityItBe = 0;
+
+    private int mCallCount_startPostponedEnterTransition = 0;
+
+    private int mCallCount_startSearchSgBnBeBn = 0;
+
+    private int mCallCount_startServiceIt = 0;
+
+    private int mCallCount_startSupportActionModeAk = 0;
+
+    private int mCallCount_stopLockTask = 0;
+
+    private int mCallCount_stopManagingCursorCr = 0;
+
+    private int mCallCount_stopServiceIt = 0;
+
+    private int mCallCount_supportFinishAfterTransition = 0;
+
+    private int mCallCount_supportInvalidateOptionsMenu = 0;
+
+    private int mCallCount_supportNavigateUpToIt = 0;
+
+    private int mCallCount_supportPostponeEnterTransition = 0;
+
+    private int mCallCount_supportRequestWindowFeatureIr = 0;
+
+    private int mCallCount_supportShouldUpRecreateTaskIt = 0;
+
+    private int mCallCount_supportStartPostponedEnterTransition = 0;
+
+    private int mCallCount_takeKeyEventsBn = 0;
+
+    private int mCallCount_triggerSearchSgBe = 0;
+
+    private int mCallCount_unbindServiceSn = 0;
+
+    private int mCallCount_unregisterComponentCallbacksCs = 0;
+
+    private int mCallCount_unregisterForContextMenuVw = 0;
+
+    private int mCallCount_unregisterReceiverBr = 0;
+
+    private boolean mIsOverridden_addContentViewVwVs = false;
+
+    private boolean mIsOverridden_applyOverrideConfigurationCn = false;
+
+    private boolean mIsOverridden_attachBaseContextCt = false;
+
+    private boolean mIsOverridden_bindServiceItSnIr = false;
+
+    private boolean mIsOverridden_checkCallingOrSelfPermissionSg = false;
+
+    private boolean mIsOverridden_checkCallingOrSelfUriPermissionUiIr = false;
+
+    private boolean mIsOverridden_checkCallingPermissionSg = false;
+
+    private boolean mIsOverridden_checkCallingUriPermissionUiIr = false;
+
+    private boolean mIsOverridden_checkPermissionSgIrIr = false;
+
+    private boolean mIsOverridden_checkSelfPermissionSg = false;
+
+    private boolean mIsOverridden_checkUriPermissionUiIrIrIr = false;
+
+    private boolean mIsOverridden_checkUriPermissionUiSgSgIrIrIr = false;
+
+    private boolean mIsOverridden_clearWallpaper = false;
+
+    private boolean mIsOverridden_closeContextMenu = false;
+
+    private boolean mIsOverridden_closeOptionsMenu = false;
+
+    private boolean mIsOverridden_createConfigurationContextCn = false;
+
+    private boolean mIsOverridden_createDisplayContextDy = false;
+
+    private boolean mIsOverridden_createPackageContextSgIr = false;
+
+    private boolean mIsOverridden_createPendingResultIrItIr = false;
+
+    private boolean mIsOverridden_databaseList = false;
+
+    private boolean mIsOverridden_deleteDatabaseSg = false;
+
+    private boolean mIsOverridden_deleteFileSg = false;
+
+    private boolean mIsOverridden_dispatchGenericMotionEventMt = false;
+
+    private boolean mIsOverridden_dispatchKeyEventKt = false;
+
+    private boolean mIsOverridden_dispatchKeyShortcutEventKt = false;
+
+    private boolean mIsOverridden_dispatchPopulateAccessibilityEventAt = false;
+
+    private boolean mIsOverridden_dispatchTouchEventMt = false;
+
+    private boolean mIsOverridden_dispatchTrackballEventMt = false;
+
+    private boolean mIsOverridden_dumpSgFrPrSg = false;
+
+    private boolean mIsOverridden_enforceCallingOrSelfPermissionSgSg = false;
+
+    private boolean mIsOverridden_enforceCallingOrSelfUriPermissionUiIrSg = false;
+
+    private boolean mIsOverridden_enforceCallingPermissionSgSg = false;
+
+    private boolean mIsOverridden_enforceCallingUriPermissionUiIrSg = false;
+
+    private boolean mIsOverridden_enforcePermissionSgIrIrSg = false;
+
+    private boolean mIsOverridden_enforceUriPermissionUiIrIrIrSg = false;
+
+    private boolean mIsOverridden_enforceUriPermissionUiSgSgIrIrIrSg = false;
+
+    private boolean mIsOverridden_fileList = false;
+
+    private boolean mIsOverridden_findViewByIdIr = false;
+
+    private boolean mIsOverridden_finish = false;
+
+    private boolean mIsOverridden_finishActivityFromChildAyIr = false;
+
+    private boolean mIsOverridden_finishActivityIr = false;
+
+    private boolean mIsOverridden_finishAffinity = false;
+
+    private boolean mIsOverridden_finishAfterTransition = false;
+
+    private boolean mIsOverridden_finishAndRemoveTask = false;
+
+    private boolean mIsOverridden_finishFromChildAy = false;
+
+    private boolean mIsOverridden_getActionBar = false;
+
+    private boolean mIsOverridden_getApplicationContext = false;
+
+    private boolean mIsOverridden_getApplicationInfo = false;
+
+    private boolean mIsOverridden_getAssets = false;
+
+    private boolean mIsOverridden_getBaseContext = false;
+
+    private boolean mIsOverridden_getCacheDir = false;
+
+    private boolean mIsOverridden_getCallingActivity = false;
+
+    private boolean mIsOverridden_getCallingPackage = false;
+
+    private boolean mIsOverridden_getChangingConfigurations = false;
+
+    private boolean mIsOverridden_getClassLoader = false;
+
+    private boolean mIsOverridden_getCodeCacheDir = false;
+
+    private boolean mIsOverridden_getComponentName = false;
+
+    private boolean mIsOverridden_getContentResolver = false;
+
+    private boolean mIsOverridden_getContentScene = false;
+
+    private boolean mIsOverridden_getContentTransitionManager = false;
+
+    private boolean mIsOverridden_getCurrentFocus = false;
+
+    private boolean mIsOverridden_getDatabasePathSg = false;
+
+    private boolean mIsOverridden_getDelegate = false;
+
+    private boolean mIsOverridden_getDirSgIr = false;
+
+    private boolean mIsOverridden_getDrawerToggleDelegate = false;
+
+    private boolean mIsOverridden_getExternalCacheDir = false;
+
+    private boolean mIsOverridden_getExternalCacheDirs = false;
+
+    private boolean mIsOverridden_getExternalFilesDirSg = false;
+
+    private boolean mIsOverridden_getExternalFilesDirsSg = false;
+
+    private boolean mIsOverridden_getExternalMediaDirs = false;
+
+    private boolean mIsOverridden_getFileStreamPathSg = false;
+
+    private boolean mIsOverridden_getFilesDir = false;
+
+    private boolean mIsOverridden_getFragmentManager = false;
+
+    private boolean mIsOverridden_getIntent = false;
+
+    private boolean mIsOverridden_getLayoutInflater = false;
+
+    private boolean mIsOverridden_getLoaderManager = false;
+
+    private boolean mIsOverridden_getLocalClassName = false;
+
+    private boolean mIsOverridden_getMainLooper = false;
+
+    private boolean mIsOverridden_getMenuInflater = false;
+
+    private boolean mIsOverridden_getNoBackupFilesDir = false;
+
+    private boolean mIsOverridden_getObbDir = false;
+
+    private boolean mIsOverridden_getObbDirs = false;
+
+    private boolean mIsOverridden_getPackageCodePath = false;
+
+    private boolean mIsOverridden_getPackageManager = false;
+
+    private boolean mIsOverridden_getPackageName = false;
+
+    private boolean mIsOverridden_getPackageResourcePath = false;
+
+    private boolean mIsOverridden_getParentActivityIntent = false;
+
+    private boolean mIsOverridden_getPreferencesIr = false;
+
+    private boolean mIsOverridden_getReferrer = false;
+
+    private boolean mIsOverridden_getRequestedOrientation = false;
+
+    private boolean mIsOverridden_getResources = false;
+
+    private boolean mIsOverridden_getSharedPreferencesSgIr = false;
+
+    private boolean mIsOverridden_getSupportActionBar = false;
+
+    private boolean mIsOverridden_getSupportFragmentManager = false;
+
+    private boolean mIsOverridden_getSupportLoaderManager = false;
+
+    private boolean mIsOverridden_getSupportParentActivityIntent = false;
+
+    private boolean mIsOverridden_getSystemServiceNameCs = false;
+
+    private boolean mIsOverridden_getSystemServiceSg = false;
+
+    private boolean mIsOverridden_getTaskId = false;
+
+    private boolean mIsOverridden_getTheme = false;
+
+    private boolean mIsOverridden_getVoiceInteractor = false;
+
+    private boolean mIsOverridden_getWallpaper = false;
+
+    private boolean mIsOverridden_getWallpaperDesiredMinimumHeight = false;
+
+    private boolean mIsOverridden_getWallpaperDesiredMinimumWidth = false;
+
+    private boolean mIsOverridden_getWindow = false;
+
+    private boolean mIsOverridden_getWindowManager = false;
+
+    private boolean mIsOverridden_grantUriPermissionSgUiIr = false;
+
+    private boolean mIsOverridden_hasWindowFocus = false;
+
+    private boolean mIsOverridden_invalidateOptionsMenu = false;
+
+    private boolean mIsOverridden_isChangingConfigurations = false;
+
+    private boolean mIsOverridden_isDestroyed = false;
+
+    private boolean mIsOverridden_isFinishing = false;
+
+    private boolean mIsOverridden_isImmersive = false;
+
+    private boolean mIsOverridden_isRestricted = false;
+
+    private boolean mIsOverridden_isTaskRoot = false;
+
+    private boolean mIsOverridden_isVoiceInteraction = false;
+
+    private boolean mIsOverridden_isVoiceInteractionRoot = false;
+
+    private boolean mIsOverridden_moveTaskToBackBn = false;
+
+    private boolean mIsOverridden_navigateUpToFromChildAyIt = false;
+
+    private boolean mIsOverridden_navigateUpToIt = false;
+
+    private boolean mIsOverridden_onActionModeFinishedae = false;
+
+    private boolean mIsOverridden_onActionModeStartedae = false;
+
+    private boolean mIsOverridden_onActivityReenterIrIt = false;
+
+    private boolean mIsOverridden_onActivityResultIrIrIt = false;
+
+    private boolean mIsOverridden_onApplyThemeResourceReIrBn = false;
+
+    private boolean mIsOverridden_onAttachFragmentFt = false;
+
+    private boolean mIsOverridden_onAttachFragmentat = false;
+
+    private boolean mIsOverridden_onAttachedToWindow = false;
+
+    private boolean mIsOverridden_onBackPressed = false;
+
+    private boolean mIsOverridden_onChildTitleChangedAyCe = false;
+
+    private boolean mIsOverridden_onConfigurationChangedCn = false;
+
+    private boolean mIsOverridden_onContentChanged = false;
+
+    private boolean mIsOverridden_onContextItemSelectedMm = false;
+
+    private boolean mIsOverridden_onContextMenuClosedMu = false;
+
+    private boolean mIsOverridden_onCreateBe = false;
+
+    private boolean mIsOverridden_onCreateBePe = false;
+
+    private boolean mIsOverridden_onCreateContextMenuCuVwCo = false;
+
+    private boolean mIsOverridden_onCreateDescription = false;
+
+    private boolean mIsOverridden_onCreateDialogIr = false;
+
+    private boolean mIsOverridden_onCreateDialogIrBe = false;
+
+    private boolean mIsOverridden_onCreateNavigateUpTaskStackTr = false;
+
+    private boolean mIsOverridden_onCreateOptionsMenuMu = false;
+
+    private boolean mIsOverridden_onCreatePanelMenuIrMu = false;
+
+    private boolean mIsOverridden_onCreatePanelViewIr = false;
+
+    private boolean mIsOverridden_onCreateSupportNavigateUpTaskStackar = false;
+
+    private boolean mIsOverridden_onCreateThumbnailBpCs = false;
+
+    private boolean mIsOverridden_onCreateViewSgCtAt = false;
+
+    private boolean mIsOverridden_onCreateViewVwSgCtAt = false;
+
+    private boolean mIsOverridden_onDestroy = false;
+
+    private boolean mIsOverridden_onDetachedFromWindow = false;
+
+    private boolean mIsOverridden_onEnterAnimationComplete = false;
+
+    private boolean mIsOverridden_onGenericMotionEventMt = false;
+
+    private boolean mIsOverridden_onKeyDownIrKt = false;
+
+    private boolean mIsOverridden_onKeyLongPressIrKt = false;
+
+    private boolean mIsOverridden_onKeyMultipleIrIrKt = false;
+
+    private boolean mIsOverridden_onKeyShortcutIrKt = false;
+
+    private boolean mIsOverridden_onKeyUpIrKt = false;
+
+    private boolean mIsOverridden_onLowMemory = false;
+
+    private boolean mIsOverridden_onMenuOpenedIrMu = false;
+
+    private boolean mIsOverridden_onNavigateUp = false;
+
+    private boolean mIsOverridden_onNavigateUpFromChildAy = false;
+
+    private boolean mIsOverridden_onNewIntentIt = false;
+
+    private boolean mIsOverridden_onOptionsItemSelectedMm = false;
+
+    private boolean mIsOverridden_onOptionsMenuClosedMu = false;
+
+    private boolean mIsOverridden_onPanelClosedIrMu = false;
+
+    private boolean mIsOverridden_onPause = false;
+
+    private boolean mIsOverridden_onPostCreateBe = false;
+
+    private boolean mIsOverridden_onPostCreateBePe = false;
+
+    private boolean mIsOverridden_onPostResume = false;
+
+    private boolean mIsOverridden_onPrepareDialogIrDg = false;
+
+    private boolean mIsOverridden_onPrepareDialogIrDgBe = false;
+
+    private boolean mIsOverridden_onPrepareNavigateUpTaskStackTr = false;
+
+    private boolean mIsOverridden_onPrepareOptionsMenuMu = false;
+
+    private boolean mIsOverridden_onPrepareOptionsPanelVwMu = false;
+
+    private boolean mIsOverridden_onPreparePanelIrVwMu = false;
+
+    private boolean mIsOverridden_onPrepareSupportNavigateUpTaskStackar = false;
+
+    private boolean mIsOverridden_onProvideAssistContentAt = false;
+
+    private boolean mIsOverridden_onProvideAssistDataBe = false;
+
+    private boolean mIsOverridden_onProvideReferrer = false;
+
+    private boolean mIsOverridden_onRequestPermissionsResultIrSgit = false;
+
+    private boolean mIsOverridden_onRestart = false;
+
+    private boolean mIsOverridden_onRestoreInstanceStateBe = false;
+
+    private boolean mIsOverridden_onRestoreInstanceStateBePe = false;
+
+    private boolean mIsOverridden_onResume = false;
+
+    private boolean mIsOverridden_onResumeFragments = false;
+
+    private boolean mIsOverridden_onSaveInstanceStateBe = false;
+
+    private boolean mIsOverridden_onSaveInstanceStateBePe = false;
+
+    private boolean mIsOverridden_onSearchRequested = false;
+
+    private boolean mIsOverridden_onSearchRequestedSt = false;
+
+    private boolean mIsOverridden_onStart = false;
+
+    private boolean mIsOverridden_onStateNotSaved = false;
+
+    private boolean mIsOverridden_onStop = false;
+
+    private boolean mIsOverridden_onSupportActionModeFinishedAe = false;
+
+    private boolean mIsOverridden_onSupportActionModeStartedAe = false;
+
+    private boolean mIsOverridden_onSupportContentChanged = false;
+
+    private boolean mIsOverridden_onSupportNavigateUp = false;
+
+    private boolean mIsOverridden_onTitleChangedCeIr = false;
+
+    private boolean mIsOverridden_onTouchEventMt = false;
+
+    private boolean mIsOverridden_onTrackballEventMt = false;
+
+    private boolean mIsOverridden_onTrimMemoryIr = false;
+
+    private boolean mIsOverridden_onUserInteraction = false;
+
+    private boolean mIsOverridden_onUserLeaveHint = false;
+
+    private boolean mIsOverridden_onVisibleBehindCanceled = false;
+
+    private boolean mIsOverridden_onWindowAttributesChangedWs = false;
+
+    private boolean mIsOverridden_onWindowFocusChangedBn = false;
+
+    private boolean mIsOverridden_onWindowStartingActionModeak = false;
+
+    private boolean mIsOverridden_onWindowStartingActionModeakIr = false;
+
+    private boolean mIsOverridden_onWindowStartingSupportActionModeAk = false;
+
+    private boolean mIsOverridden_openContextMenuVw = false;
+
+    private boolean mIsOverridden_openFileInputSg = false;
+
+    private boolean mIsOverridden_openFileOutputSgIr = false;
+
+    private boolean mIsOverridden_openOptionsMenu = false;
+
+    private boolean mIsOverridden_openOrCreateDatabaseSgIrSy = false;
+
+    private boolean mIsOverridden_openOrCreateDatabaseSgIrSyDr = false;
+
+    private boolean mIsOverridden_overridePendingTransitionIrIr = false;
+
+    private boolean mIsOverridden_peekWallpaper = false;
+
+    private boolean mIsOverridden_postponeEnterTransition = false;
+
+    private boolean mIsOverridden_recreate = false;
+
+    private boolean mIsOverridden_registerComponentCallbacksCs = false;
+
+    private boolean mIsOverridden_registerForContextMenuVw = false;
+
+    private boolean mIsOverridden_registerReceiverBrIr = false;
+
+    private boolean mIsOverridden_registerReceiverBrIrSgHr = false;
+
+    private boolean mIsOverridden_releaseInstance = false;
+
+    private boolean mIsOverridden_removeStickyBroadcastAsUserItUe = false;
+
+    private boolean mIsOverridden_removeStickyBroadcastIt = false;
+
+    private boolean mIsOverridden_reportFullyDrawn = false;
+
+    private boolean mIsOverridden_requestVisibleBehindBn = false;
+
+    private boolean mIsOverridden_revokeUriPermissionUiIr = false;
+
+    private boolean mIsOverridden_sendBroadcastAsUserItUe = false;
+
+    private boolean mIsOverridden_sendBroadcastAsUserItUeSg = false;
+
+    private boolean mIsOverridden_sendBroadcastIt = false;
+
+    private boolean mIsOverridden_sendBroadcastItSg = false;
+
+    private boolean mIsOverridden_sendOrderedBroadcastAsUserItUeSgBrHrIrSgBe = false;
+
+    private boolean mIsOverridden_sendOrderedBroadcastItSg = false;
+
+    private boolean mIsOverridden_sendOrderedBroadcastItSgBrHrIrSgBe = false;
+
+    private boolean mIsOverridden_sendStickyBroadcastAsUserItUe = false;
+
+    private boolean mIsOverridden_sendStickyBroadcastIt = false;
+
+    private boolean mIsOverridden_sendStickyOrderedBroadcastAsUserItUeBrHrIrSgBe = false;
+
+    private boolean mIsOverridden_sendStickyOrderedBroadcastItBrHrIrSgBe = false;
+
+    private boolean mIsOverridden_setActionBarTr = false;
+
+    private boolean mIsOverridden_setContentTransitionManagerTr = false;
+
+    private boolean mIsOverridden_setContentViewIr = false;
+
+    private boolean mIsOverridden_setContentViewVw = false;
+
+    private boolean mIsOverridden_setContentViewVwVs = false;
+
+    private boolean mIsOverridden_setEnterSharedElementCallbackSk = false;
+
+    private boolean mIsOverridden_setEnterSharedElementCallbackak = false;
+
+    private boolean mIsOverridden_setExitSharedElementCallbackSk = false;
+
+    private boolean mIsOverridden_setExitSharedElementCallbackak = false;
+
+    private boolean mIsOverridden_setFinishOnTouchOutsideBn = false;
+
+    private boolean mIsOverridden_setImmersiveBn = false;
+
+    private boolean mIsOverridden_setIntentIt = false;
+
+    private boolean mIsOverridden_setRequestedOrientationIr = false;
+
+    private boolean mIsOverridden_setSupportActionBarar = false;
+
+    private boolean mIsOverridden_setSupportProgressBarIndeterminateBn = false;
+
+    private boolean mIsOverridden_setSupportProgressBarIndeterminateVisibilityBn = false;
+
+    private boolean mIsOverridden_setSupportProgressBarVisibilityBn = false;
+
+    private boolean mIsOverridden_setSupportProgressIr = false;
+
+    private boolean mIsOverridden_setTaskDescriptionAn = false;
+
+    private boolean mIsOverridden_setThemeIr = false;
+
+    private boolean mIsOverridden_setTitleCe = false;
+
+    private boolean mIsOverridden_setTitleColorIr = false;
+
+    private boolean mIsOverridden_setTitleIr = false;
+
+    private boolean mIsOverridden_setVisibleBn = false;
+
+    private boolean mIsOverridden_setWallpaperBp = false;
+
+    private boolean mIsOverridden_setWallpaperIm = false;
+
+    private boolean mIsOverridden_shouldShowRequestPermissionRationaleSg = false;
+
+    private boolean mIsOverridden_shouldUpRecreateTaskIt = false;
+
+    private boolean mIsOverridden_showAssistBe = false;
+
+    private boolean mIsOverridden_showLockTaskEscapeMessage = false;
+
+    private boolean mIsOverridden_startActionModeak = false;
+
+    private boolean mIsOverridden_startActionModeakIr = false;
+
+    private boolean mIsOverridden_startActivitiesIt = false;
+
+    private boolean mIsOverridden_startActivitiesItBe = false;
+
+    private boolean mIsOverridden_startActivityForResultItIr = false;
+
+    private boolean mIsOverridden_startActivityForResultItIrBe = false;
+
+    private boolean mIsOverridden_startActivityFromChildAyItIr = false;
+
+    private boolean mIsOverridden_startActivityFromChildAyItIrBe = false;
+
+    private boolean mIsOverridden_startActivityFromFragmentFtItIr = false;
+
+    private boolean mIsOverridden_startActivityFromFragmentFtItIrBe = false;
+
+    private boolean mIsOverridden_startActivityFromFragmentatItIr = false;
+
+    private boolean mIsOverridden_startActivityFromFragmentatItIrBe = false;
+
+    private boolean mIsOverridden_startActivityIfNeededItIr = false;
+
+    private boolean mIsOverridden_startActivityIfNeededItIrBe = false;
+
+    private boolean mIsOverridden_startActivityIt = false;
+
+    private boolean mIsOverridden_startActivityItBe = false;
+
+    private boolean mIsOverridden_startInstrumentationCeSgBe = false;
+
+    private boolean mIsOverridden_startIntentSenderForResultIrIrItIrIrIr = false;
+
+    private boolean mIsOverridden_startIntentSenderForResultIrIrItIrIrIrBe = false;
+
+    private boolean mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIr = false;
+
+    private boolean mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIrBe = false;
+
+    private boolean mIsOverridden_startIntentSenderIrItIrIrIr = false;
+
+    private boolean mIsOverridden_startIntentSenderIrItIrIrIrBe = false;
+
+    private boolean mIsOverridden_startLockTask = false;
+
+    private boolean mIsOverridden_startManagingCursorCr = false;
+
+    private boolean mIsOverridden_startNextMatchingActivityIt = false;
+
+    private boolean mIsOverridden_startNextMatchingActivityItBe = false;
+
+    private boolean mIsOverridden_startPostponedEnterTransition = false;
+
+    private boolean mIsOverridden_startSearchSgBnBeBn = false;
+
+    private boolean mIsOverridden_startServiceIt = false;
+
+    private boolean mIsOverridden_startSupportActionModeAk = false;
+
+    private boolean mIsOverridden_stopLockTask = false;
+
+    private boolean mIsOverridden_stopManagingCursorCr = false;
+
+    private boolean mIsOverridden_stopServiceIt = false;
+
+    private boolean mIsOverridden_supportFinishAfterTransition = false;
+
+    private boolean mIsOverridden_supportInvalidateOptionsMenu = false;
+
+    private boolean mIsOverridden_supportNavigateUpToIt = false;
+
+    private boolean mIsOverridden_supportPostponeEnterTransition = false;
+
+    private boolean mIsOverridden_supportRequestWindowFeatureIr = false;
+
+    private boolean mIsOverridden_supportShouldUpRecreateTaskIt = false;
+
+    private boolean mIsOverridden_supportStartPostponedEnterTransition = false;
+
+    private boolean mIsOverridden_takeKeyEventsBn = false;
+
+    private boolean mIsOverridden_triggerSearchSgBe = false;
+
+    private boolean mIsOverridden_unbindServiceSn = false;
+
+    private boolean mIsOverridden_unregisterComponentCallbacksCs = false;
+
+    private boolean mIsOverridden_unregisterForContextMenuVw = false;
+
+    private boolean mIsOverridden_unregisterReceiverBr = false;
 
     private final HashMap<String, List<ActivityPlugin>> mMethodImplementingPlugins
             = new HashMap<>();
@@ -117,12 +1376,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void addContentView(final View view, final ViewGroup.LayoutParams params) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_addContentViewVwVs) {
             getOriginal().super_addContentView(view, params);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_addContentViewVwVs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_addContentViewVwVs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("addContentView(View, ViewGroup.LayoutParams)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("addContentView", View.class,
+                        ViewGroup.LayoutParams.class);
+                mMethodImplementingPlugins
+                        .put("addContentView(View, ViewGroup.LayoutParams)", implementingPlugins);
+                mIsOverridden_addContentViewVwVs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<View, ViewGroup.LayoutParams> superCall
                 = new CallVoid2<View, ViewGroup.LayoutParams>(
@@ -142,20 +1417,350 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     @Override
     public Removable addPlugin(final ActivityPlugin plugin) {
-        synchronized (mPlugins) {
-            mIsGetResourcesOverridden = true;
-            mMethodImplementingPlugins.clear();
-        }
+        mMethodImplementingPlugins.clear();
+        mIsOverridden_addContentViewVwVs = true;
+        mIsOverridden_applyOverrideConfigurationCn = true;
+        mIsOverridden_bindServiceItSnIr = true;
+        mIsOverridden_checkCallingOrSelfPermissionSg = true;
+        mIsOverridden_checkCallingOrSelfUriPermissionUiIr = true;
+        mIsOverridden_checkCallingPermissionSg = true;
+        mIsOverridden_checkCallingUriPermissionUiIr = true;
+        mIsOverridden_checkPermissionSgIrIr = true;
+        mIsOverridden_checkSelfPermissionSg = true;
+        mIsOverridden_checkUriPermissionUiIrIrIr = true;
+        mIsOverridden_checkUriPermissionUiSgSgIrIrIr = true;
+        mIsOverridden_clearWallpaper = true;
+        mIsOverridden_closeContextMenu = true;
+        mIsOverridden_closeOptionsMenu = true;
+        mIsOverridden_createConfigurationContextCn = true;
+        mIsOverridden_createDisplayContextDy = true;
+        mIsOverridden_createPackageContextSgIr = true;
+        mIsOverridden_createPendingResultIrItIr = true;
+        mIsOverridden_databaseList = true;
+        mIsOverridden_deleteDatabaseSg = true;
+        mIsOverridden_deleteFileSg = true;
+        mIsOverridden_dispatchGenericMotionEventMt = true;
+        mIsOverridden_dispatchKeyEventKt = true;
+        mIsOverridden_dispatchKeyShortcutEventKt = true;
+        mIsOverridden_dispatchPopulateAccessibilityEventAt = true;
+        mIsOverridden_dispatchTouchEventMt = true;
+        mIsOverridden_dispatchTrackballEventMt = true;
+        mIsOverridden_dumpSgFrPrSg = true;
+        mIsOverridden_enforceCallingOrSelfPermissionSgSg = true;
+        mIsOverridden_enforceCallingOrSelfUriPermissionUiIrSg = true;
+        mIsOverridden_enforceCallingPermissionSgSg = true;
+        mIsOverridden_enforceCallingUriPermissionUiIrSg = true;
+        mIsOverridden_enforcePermissionSgIrIrSg = true;
+        mIsOverridden_enforceUriPermissionUiIrIrIrSg = true;
+        mIsOverridden_enforceUriPermissionUiSgSgIrIrIrSg = true;
+        mIsOverridden_fileList = true;
+        mIsOverridden_findViewByIdIr = true;
+        mIsOverridden_finish = true;
+        mIsOverridden_finishActivityIr = true;
+        mIsOverridden_finishActivityFromChildAyIr = true;
+        mIsOverridden_finishAffinity = true;
+        mIsOverridden_finishAfterTransition = true;
+        mIsOverridden_finishAndRemoveTask = true;
+        mIsOverridden_finishFromChildAy = true;
+        mIsOverridden_getActionBar = true;
+        mIsOverridden_getApplicationContext = true;
+        mIsOverridden_getApplicationInfo = true;
+        mIsOverridden_getAssets = true;
+        mIsOverridden_getBaseContext = true;
+        mIsOverridden_getCacheDir = true;
+        mIsOverridden_getCallingActivity = true;
+        mIsOverridden_getCallingPackage = true;
+        mIsOverridden_getChangingConfigurations = true;
+        mIsOverridden_getClassLoader = true;
+        mIsOverridden_getCodeCacheDir = true;
+        mIsOverridden_getComponentName = true;
+        mIsOverridden_getContentResolver = true;
+        mIsOverridden_getContentScene = true;
+        mIsOverridden_getContentTransitionManager = true;
+        mIsOverridden_getCurrentFocus = true;
+        mIsOverridden_getDatabasePathSg = true;
+        mIsOverridden_getDelegate = true;
+        mIsOverridden_getDirSgIr = true;
+        mIsOverridden_getDrawerToggleDelegate = true;
+        mIsOverridden_getExternalCacheDir = true;
+        mIsOverridden_getExternalCacheDirs = true;
+        mIsOverridden_getExternalFilesDirSg = true;
+        mIsOverridden_getExternalFilesDirsSg = true;
+        mIsOverridden_getExternalMediaDirs = true;
+        mIsOverridden_getFileStreamPathSg = true;
+        mIsOverridden_getFilesDir = true;
+        mIsOverridden_getFragmentManager = true;
+        mIsOverridden_getIntent = true;
+        mIsOverridden_getLayoutInflater = true;
+        mIsOverridden_getLoaderManager = true;
+        mIsOverridden_getLocalClassName = true;
+        mIsOverridden_getMainLooper = true;
+        mIsOverridden_getMenuInflater = true;
+        mIsOverridden_getNoBackupFilesDir = true;
+        mIsOverridden_getObbDir = true;
+        mIsOverridden_getObbDirs = true;
+        mIsOverridden_getPackageCodePath = true;
+        mIsOverridden_getPackageManager = true;
+        mIsOverridden_getPackageName = true;
+        mIsOverridden_getPackageResourcePath = true;
+        mIsOverridden_getParentActivityIntent = true;
+        mIsOverridden_getPreferencesIr = true;
+        mIsOverridden_getReferrer = true;
+        mIsOverridden_getRequestedOrientation = true;
+        mIsOverridden_getResources = true;
+        mIsOverridden_getSharedPreferencesSgIr = true;
+        mIsOverridden_getSupportActionBar = true;
+        mIsOverridden_getSupportFragmentManager = true;
+        mIsOverridden_getSupportLoaderManager = true;
+        mIsOverridden_getSupportParentActivityIntent = true;
+        mIsOverridden_getSystemServiceSg = true;
+        mIsOverridden_getSystemServiceNameCs = true;
+        mIsOverridden_getTaskId = true;
+        mIsOverridden_getTheme = true;
+        mIsOverridden_getVoiceInteractor = true;
+        mIsOverridden_getWallpaper = true;
+        mIsOverridden_getWallpaperDesiredMinimumHeight = true;
+        mIsOverridden_getWallpaperDesiredMinimumWidth = true;
+        mIsOverridden_getWindow = true;
+        mIsOverridden_getWindowManager = true;
+        mIsOverridden_grantUriPermissionSgUiIr = true;
+        mIsOverridden_hasWindowFocus = true;
+        mIsOverridden_invalidateOptionsMenu = true;
+        mIsOverridden_isChangingConfigurations = true;
+        mIsOverridden_isDestroyed = true;
+        mIsOverridden_isFinishing = true;
+        mIsOverridden_isImmersive = true;
+        mIsOverridden_isRestricted = true;
+        mIsOverridden_isTaskRoot = true;
+        mIsOverridden_isVoiceInteraction = true;
+        mIsOverridden_isVoiceInteractionRoot = true;
+        mIsOverridden_moveTaskToBackBn = true;
+        mIsOverridden_navigateUpToIt = true;
+        mIsOverridden_navigateUpToFromChildAyIt = true;
+        mIsOverridden_onActionModeFinishedae = true;
+        mIsOverridden_onActionModeStartedae = true;
+        mIsOverridden_onActivityReenterIrIt = true;
+        mIsOverridden_onAttachFragmentFt = true;
+        mIsOverridden_onAttachFragmentat = true;
+        mIsOverridden_onAttachedToWindow = true;
+        mIsOverridden_onBackPressed = true;
+        mIsOverridden_onConfigurationChangedCn = true;
+        mIsOverridden_onContentChanged = true;
+        mIsOverridden_onContextItemSelectedMm = true;
+        mIsOverridden_onContextMenuClosedMu = true;
+        mIsOverridden_onCreateBePe = true;
+        mIsOverridden_onCreateContextMenuCuVwCo = true;
+        mIsOverridden_onCreateDescription = true;
+        mIsOverridden_onCreateNavigateUpTaskStackTr = true;
+        mIsOverridden_onCreateOptionsMenuMu = true;
+        mIsOverridden_onCreatePanelMenuIrMu = true;
+        mIsOverridden_onCreatePanelViewIr = true;
+        mIsOverridden_onCreateSupportNavigateUpTaskStackar = true;
+        mIsOverridden_onCreateThumbnailBpCs = true;
+        mIsOverridden_onCreateViewVwSgCtAt = true;
+        mIsOverridden_onCreateViewSgCtAt = true;
+        mIsOverridden_onDetachedFromWindow = true;
+        mIsOverridden_onEnterAnimationComplete = true;
+        mIsOverridden_onGenericMotionEventMt = true;
+        mIsOverridden_onKeyDownIrKt = true;
+        mIsOverridden_onKeyLongPressIrKt = true;
+        mIsOverridden_onKeyMultipleIrIrKt = true;
+        mIsOverridden_onKeyShortcutIrKt = true;
+        mIsOverridden_onKeyUpIrKt = true;
+        mIsOverridden_onLowMemory = true;
+        mIsOverridden_onMenuOpenedIrMu = true;
+        mIsOverridden_onNavigateUp = true;
+        mIsOverridden_onNavigateUpFromChildAy = true;
+        mIsOverridden_onOptionsItemSelectedMm = true;
+        mIsOverridden_onOptionsMenuClosedMu = true;
+        mIsOverridden_onPanelClosedIrMu = true;
+        mIsOverridden_onPostCreateBePe = true;
+        mIsOverridden_onPrepareNavigateUpTaskStackTr = true;
+        mIsOverridden_onPrepareOptionsMenuMu = true;
+        mIsOverridden_onPreparePanelIrVwMu = true;
+        mIsOverridden_onPrepareSupportNavigateUpTaskStackar = true;
+        mIsOverridden_onProvideAssistContentAt = true;
+        mIsOverridden_onProvideAssistDataBe = true;
+        mIsOverridden_onProvideReferrer = true;
+        mIsOverridden_onRequestPermissionsResultIrSgit = true;
+        mIsOverridden_onRestoreInstanceStateBePe = true;
+        mIsOverridden_onSaveInstanceStateBePe = true;
+        mIsOverridden_onSearchRequestedSt = true;
+        mIsOverridden_onSearchRequested = true;
+        mIsOverridden_onStateNotSaved = true;
+        mIsOverridden_onSupportActionModeFinishedAe = true;
+        mIsOverridden_onSupportActionModeStartedAe = true;
+        mIsOverridden_onSupportContentChanged = true;
+        mIsOverridden_onSupportNavigateUp = true;
+        mIsOverridden_onTouchEventMt = true;
+        mIsOverridden_onTrackballEventMt = true;
+        mIsOverridden_onTrimMemoryIr = true;
+        mIsOverridden_onUserInteraction = true;
+        mIsOverridden_onVisibleBehindCanceled = true;
+        mIsOverridden_onWindowAttributesChangedWs = true;
+        mIsOverridden_onWindowFocusChangedBn = true;
+        mIsOverridden_onWindowStartingActionModeak = true;
+        mIsOverridden_onWindowStartingActionModeakIr = true;
+        mIsOverridden_onWindowStartingSupportActionModeAk = true;
+        mIsOverridden_openContextMenuVw = true;
+        mIsOverridden_openFileInputSg = true;
+        mIsOverridden_openFileOutputSgIr = true;
+        mIsOverridden_openOptionsMenu = true;
+        mIsOverridden_openOrCreateDatabaseSgIrSy = true;
+        mIsOverridden_openOrCreateDatabaseSgIrSyDr = true;
+        mIsOverridden_overridePendingTransitionIrIr = true;
+        mIsOverridden_peekWallpaper = true;
+        mIsOverridden_postponeEnterTransition = true;
+        mIsOverridden_recreate = true;
+        mIsOverridden_registerComponentCallbacksCs = true;
+        mIsOverridden_registerForContextMenuVw = true;
+        mIsOverridden_registerReceiverBrIr = true;
+        mIsOverridden_registerReceiverBrIrSgHr = true;
+        mIsOverridden_releaseInstance = true;
+        mIsOverridden_removeStickyBroadcastIt = true;
+        mIsOverridden_removeStickyBroadcastAsUserItUe = true;
+        mIsOverridden_reportFullyDrawn = true;
+        mIsOverridden_requestVisibleBehindBn = true;
+        mIsOverridden_revokeUriPermissionUiIr = true;
+        mIsOverridden_sendBroadcastIt = true;
+        mIsOverridden_sendBroadcastItSg = true;
+        mIsOverridden_sendBroadcastAsUserItUe = true;
+        mIsOverridden_sendBroadcastAsUserItUeSg = true;
+        mIsOverridden_sendOrderedBroadcastItSg = true;
+        mIsOverridden_sendOrderedBroadcastItSgBrHrIrSgBe = true;
+        mIsOverridden_sendOrderedBroadcastAsUserItUeSgBrHrIrSgBe = true;
+        mIsOverridden_sendStickyBroadcastIt = true;
+        mIsOverridden_sendStickyBroadcastAsUserItUe = true;
+        mIsOverridden_sendStickyOrderedBroadcastItBrHrIrSgBe = true;
+        mIsOverridden_sendStickyOrderedBroadcastAsUserItUeBrHrIrSgBe = true;
+        mIsOverridden_setActionBarTr = true;
+        mIsOverridden_setContentTransitionManagerTr = true;
+        mIsOverridden_setContentViewIr = true;
+        mIsOverridden_setContentViewVw = true;
+        mIsOverridden_setContentViewVwVs = true;
+        mIsOverridden_setEnterSharedElementCallbackSk = true;
+        mIsOverridden_setEnterSharedElementCallbackak = true;
+        mIsOverridden_setExitSharedElementCallbackSk = true;
+        mIsOverridden_setExitSharedElementCallbackak = true;
+        mIsOverridden_setFinishOnTouchOutsideBn = true;
+        mIsOverridden_setImmersiveBn = true;
+        mIsOverridden_setIntentIt = true;
+        mIsOverridden_setRequestedOrientationIr = true;
+        mIsOverridden_setSupportActionBarar = true;
+        mIsOverridden_setSupportProgressIr = true;
+        mIsOverridden_setSupportProgressBarIndeterminateBn = true;
+        mIsOverridden_setSupportProgressBarIndeterminateVisibilityBn = true;
+        mIsOverridden_setSupportProgressBarVisibilityBn = true;
+        mIsOverridden_setTaskDescriptionAn = true;
+        mIsOverridden_setThemeIr = true;
+        mIsOverridden_setTitleCe = true;
+        mIsOverridden_setTitleIr = true;
+        mIsOverridden_setTitleColorIr = true;
+        mIsOverridden_setVisibleBn = true;
+        mIsOverridden_setWallpaperBp = true;
+        mIsOverridden_setWallpaperIm = true;
+        mIsOverridden_shouldShowRequestPermissionRationaleSg = true;
+        mIsOverridden_shouldUpRecreateTaskIt = true;
+        mIsOverridden_showAssistBe = true;
+        mIsOverridden_showLockTaskEscapeMessage = true;
+        mIsOverridden_startActionModeak = true;
+        mIsOverridden_startActionModeakIr = true;
+        mIsOverridden_startActivitiesIt = true;
+        mIsOverridden_startActivitiesItBe = true;
+        mIsOverridden_startActivityIt = true;
+        mIsOverridden_startActivityItBe = true;
+        mIsOverridden_startActivityForResultItIr = true;
+        mIsOverridden_startActivityForResultItIrBe = true;
+        mIsOverridden_startActivityFromChildAyItIr = true;
+        mIsOverridden_startActivityFromChildAyItIrBe = true;
+        mIsOverridden_startActivityFromFragmentFtItIr = true;
+        mIsOverridden_startActivityFromFragmentFtItIrBe = true;
+        mIsOverridden_startActivityFromFragmentatItIr = true;
+        mIsOverridden_startActivityFromFragmentatItIrBe = true;
+        mIsOverridden_startActivityIfNeededItIr = true;
+        mIsOverridden_startActivityIfNeededItIrBe = true;
+        mIsOverridden_startInstrumentationCeSgBe = true;
+        mIsOverridden_startIntentSenderIrItIrIrIr = true;
+        mIsOverridden_startIntentSenderIrItIrIrIrBe = true;
+        mIsOverridden_startIntentSenderForResultIrIrItIrIrIr = true;
+        mIsOverridden_startIntentSenderForResultIrIrItIrIrIrBe = true;
+        mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIr = true;
+        mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIrBe = true;
+        mIsOverridden_startLockTask = true;
+        mIsOverridden_startManagingCursorCr = true;
+        mIsOverridden_startNextMatchingActivityIt = true;
+        mIsOverridden_startNextMatchingActivityItBe = true;
+        mIsOverridden_startPostponedEnterTransition = true;
+        mIsOverridden_startSearchSgBnBeBn = true;
+        mIsOverridden_startServiceIt = true;
+        mIsOverridden_startSupportActionModeAk = true;
+        mIsOverridden_stopLockTask = true;
+        mIsOverridden_stopManagingCursorCr = true;
+        mIsOverridden_stopServiceIt = true;
+        mIsOverridden_supportFinishAfterTransition = true;
+        mIsOverridden_supportInvalidateOptionsMenu = true;
+        mIsOverridden_supportNavigateUpToIt = true;
+        mIsOverridden_supportPostponeEnterTransition = true;
+        mIsOverridden_supportRequestWindowFeatureIr = true;
+        mIsOverridden_supportShouldUpRecreateTaskIt = true;
+        mIsOverridden_supportStartPostponedEnterTransition = true;
+        mIsOverridden_takeKeyEventsBn = true;
+        mIsOverridden_triggerSearchSgBe = true;
+        mIsOverridden_unbindServiceSn = true;
+        mIsOverridden_unregisterComponentCallbacksCs = true;
+        mIsOverridden_unregisterForContextMenuVw = true;
+        mIsOverridden_unregisterReceiverBr = true;
+        mIsOverridden_attachBaseContextCt = true;
+        mIsOverridden_onActivityResultIrIrIt = true;
+        mIsOverridden_onApplyThemeResourceReIrBn = true;
+        mIsOverridden_onChildTitleChangedAyCe = true;
+        mIsOverridden_onCreateBe = true;
+        mIsOverridden_onCreateDialogIr = true;
+        mIsOverridden_onCreateDialogIrBe = true;
+        mIsOverridden_onDestroy = true;
+        mIsOverridden_onNewIntentIt = true;
+        mIsOverridden_onPause = true;
+        mIsOverridden_onPostCreateBe = true;
+        mIsOverridden_onPostResume = true;
+        mIsOverridden_onPrepareDialogIrDg = true;
+        mIsOverridden_onPrepareDialogIrDgBe = true;
+        mIsOverridden_onPrepareOptionsPanelVwMu = true;
+        mIsOverridden_onRestart = true;
+        mIsOverridden_onRestoreInstanceStateBe = true;
+        mIsOverridden_onResume = true;
+        mIsOverridden_onResumeFragments = true;
+        mIsOverridden_onSaveInstanceStateBe = true;
+        mIsOverridden_onStart = true;
+        mIsOverridden_onStop = true;
+        mIsOverridden_onTitleChangedCeIr = true;
+        mIsOverridden_onUserLeaveHint = true;
+
         return super.addPlugin(plugin);
     }
 
     public void applyOverrideConfiguration(final Configuration overrideConfiguration) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_applyOverrideConfigurationCn) {
             getOriginal().super_applyOverrideConfiguration(overrideConfiguration);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_applyOverrideConfigurationCn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_applyOverrideConfigurationCn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("applyOverrideConfiguration(Configuration)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("applyOverrideConfiguration",
+                        Configuration.class);
+                mMethodImplementingPlugins
+                        .put("applyOverrideConfiguration(Configuration)", implementingPlugins);
+                mIsOverridden_applyOverrideConfigurationCn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Configuration> superCall = new CallVoid1<Configuration>(
                 "applyOverrideConfiguration(Configuration)") {
@@ -173,12 +1778,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void attachBaseContext(final Context newBase) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_attachBaseContextCt) {
             getOriginal().super_attachBaseContext(newBase);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_attachBaseContextCt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_attachBaseContextCt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("attachBaseContext(Context)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("attachBaseContext", Context.class);
+                mMethodImplementingPlugins.put("attachBaseContext(Context)", implementingPlugins);
+                mIsOverridden_attachBaseContextCt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Context> superCall = new CallVoid1<Context>("attachBaseContext(Context)") {
 
@@ -196,11 +1815,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public boolean bindService(final Intent service, final ServiceConnection conn,
             final int flags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_bindServiceItSnIr) {
             return getOriginal().super_bindService(service, conn, flags);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_bindServiceItSnIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_bindServiceItSnIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("bindService(Intent, ServiceConnection, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("bindService", Intent.class,
+                        ServiceConnection.class, Integer.class);
+                mMethodImplementingPlugins.put("bindService(Intent, ServiceConnection, Integer)",
+                        implementingPlugins);
+                mIsOverridden_bindServiceItSnIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<Boolean, Intent, ServiceConnection, Integer> superCall
                 = new CallFun3<Boolean, Intent, ServiceConnection, Integer>(
@@ -220,11 +1855,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int checkCallingOrSelfPermission(final String permission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkCallingOrSelfPermissionSg) {
             return getOriginal().super_checkCallingOrSelfPermission(permission);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkCallingOrSelfPermissionSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkCallingOrSelfPermissionSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkCallingOrSelfPermission(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkCallingOrSelfPermission",
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("checkCallingOrSelfPermission(String)", implementingPlugins);
+                mIsOverridden_checkCallingOrSelfPermissionSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Integer, String> superCall = new CallFun1<Integer, String>(
                 "checkCallingOrSelfPermission(String)") {
@@ -242,11 +1893,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int checkCallingOrSelfUriPermission(final Uri uri, final int modeFlags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkCallingOrSelfUriPermissionUiIr) {
             return getOriginal().super_checkCallingOrSelfUriPermission(uri, modeFlags);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkCallingOrSelfUriPermissionUiIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkCallingOrSelfUriPermissionUiIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkCallingOrSelfUriPermission(Uri, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkCallingOrSelfUriPermission",
+                        Uri.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("checkCallingOrSelfUriPermission(Uri, Integer)", implementingPlugins);
+                mIsOverridden_checkCallingOrSelfUriPermissionUiIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Integer, Uri, Integer> superCall = new CallFun2<Integer, Uri, Integer>(
                 "checkCallingOrSelfUriPermission(Uri, Integer)") {
@@ -265,11 +1932,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int checkCallingPermission(final String permission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkCallingPermissionSg) {
             return getOriginal().super_checkCallingPermission(permission);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkCallingPermissionSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkCallingPermissionSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkCallingPermission(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkCallingPermission",
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("checkCallingPermission(String)", implementingPlugins);
+                mIsOverridden_checkCallingPermissionSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Integer, String> superCall = new CallFun1<Integer, String>(
                 "checkCallingPermission(String)") {
@@ -287,11 +1970,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int checkCallingUriPermission(final Uri uri, final int modeFlags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkCallingUriPermissionUiIr) {
             return getOriginal().super_checkCallingUriPermission(uri, modeFlags);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkCallingUriPermissionUiIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkCallingUriPermissionUiIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkCallingUriPermission(Uri, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkCallingUriPermission", Uri.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("checkCallingUriPermission(Uri, Integer)", implementingPlugins);
+                mIsOverridden_checkCallingUriPermissionUiIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Integer, Uri, Integer> superCall = new CallFun2<Integer, Uri, Integer>(
                 "checkCallingUriPermission(Uri, Integer)") {
@@ -309,11 +2008,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int checkPermission(final String permission, final int pid, final int uid) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkPermissionSgIrIr) {
             return getOriginal().super_checkPermission(permission, pid, uid);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkPermissionSgIrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkPermissionSgIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkPermission(String, Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkPermission", String.class,
+                        Integer.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("checkPermission(String, Integer, Integer)", implementingPlugins);
+                mIsOverridden_checkPermissionSgIrIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<Integer, String, Integer, Integer> superCall
                 = new CallFun3<Integer, String, Integer, Integer>(
@@ -332,11 +2047,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int checkSelfPermission(final String permission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkSelfPermissionSg) {
             return getOriginal().super_checkSelfPermission(permission);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkSelfPermissionSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkSelfPermissionSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkSelfPermission(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkSelfPermission", String.class);
+                mMethodImplementingPlugins.put("checkSelfPermission(String)", implementingPlugins);
+                mIsOverridden_checkSelfPermissionSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Integer, String> superCall = new CallFun1<Integer, String>(
                 "checkSelfPermission(String)") {
@@ -355,11 +2084,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public int checkUriPermission(final Uri uri, final int pid, final int uid,
             final int modeFlags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkUriPermissionUiIrIrIr) {
             return getOriginal().super_checkUriPermission(uri, pid, uid, modeFlags);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkUriPermissionUiIrIrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkUriPermissionUiIrIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkUriPermission(Uri, Integer, Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkUriPermission", Uri.class,
+                        Integer.class, Integer.class, Integer.class);
+                mMethodImplementingPlugins.put("checkUriPermission(Uri, Integer, Integer, Integer)",
+                        implementingPlugins);
+                mIsOverridden_checkUriPermissionUiIrIrIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun4<Integer, Uri, Integer, Integer, Integer> superCall
                 = new CallFun4<Integer, Uri, Integer, Integer, Integer>(
@@ -380,13 +2125,30 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public int checkUriPermission(final Uri uri, final String readPermission,
             final String writePermission, final int pid, final int uid, final int modeFlags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_checkUriPermissionUiSgSgIrIrIr) {
             return getOriginal()
                     .super_checkUriPermission(uri, readPermission, writePermission, pid, uid,
                             modeFlags);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_checkUriPermissionUiSgSgIrIrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_checkUriPermissionUiSgSgIrIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("checkUriPermission(Uri, String, String, Integer, Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("checkUriPermission", Uri.class,
+                        String.class, String.class, Integer.class, Integer.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("checkUriPermission(Uri, String, String, Integer, Integer, Integer)",
+                                implementingPlugins);
+                mIsOverridden_checkUriPermissionUiSgSgIrIrIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun6<Integer, Uri, String, String, Integer, Integer, Integer> superCall
                 = new CallFun6<Integer, Uri, String, String, Integer, Integer, Integer>(
@@ -411,16 +2173,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void clearWallpaper() throws IOException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal().super_clearWallpaper();
-            } catch (IOException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_clearWallpaper) {
+            getOriginal().super_clearWallpaper();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_clearWallpaper < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_clearWallpaper++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("clearWallpaper()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("clearWallpaper");
+                mMethodImplementingPlugins.put("clearWallpaper()", implementingPlugins);
+                mIsOverridden_clearWallpaper = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("clearWallpaper()") {
 
@@ -445,12 +2217,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void closeContextMenu() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_closeContextMenu) {
             getOriginal().super_closeContextMenu();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_closeContextMenu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_closeContextMenu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("closeContextMenu()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("closeContextMenu");
+                mMethodImplementingPlugins.put("closeContextMenu()", implementingPlugins);
+                mIsOverridden_closeContextMenu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("closeContextMenu()") {
 
@@ -467,12 +2253,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void closeOptionsMenu() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_closeOptionsMenu) {
             getOriginal().super_closeOptionsMenu();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_closeOptionsMenu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_closeOptionsMenu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("closeOptionsMenu()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("closeOptionsMenu");
+                mMethodImplementingPlugins.put("closeOptionsMenu()", implementingPlugins);
+                mIsOverridden_closeOptionsMenu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("closeOptionsMenu()") {
 
@@ -489,11 +2289,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Context createConfigurationContext(final Configuration overrideConfiguration) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_createConfigurationContextCn) {
             return getOriginal().super_createConfigurationContext(overrideConfiguration);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_createConfigurationContextCn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_createConfigurationContextCn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("createConfigurationContext(Configuration)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("createConfigurationContext",
+                        Configuration.class);
+                mMethodImplementingPlugins
+                        .put("createConfigurationContext(Configuration)", implementingPlugins);
+                mIsOverridden_createConfigurationContextCn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Context, Configuration> superCall = new CallFun1<Context, Configuration>(
                 "createConfigurationContext(Configuration)") {
@@ -512,11 +2328,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Context createDisplayContext(final Display display) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_createDisplayContextDy) {
             return getOriginal().super_createDisplayContext(display);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_createDisplayContextDy < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_createDisplayContextDy++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("createDisplayContext(Display)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("createDisplayContext", Display.class);
+                mMethodImplementingPlugins
+                        .put("createDisplayContext(Display)", implementingPlugins);
+                mIsOverridden_createDisplayContextDy = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Context, Display> superCall = new CallFun1<Context, Display>(
                 "createDisplayContext(Display)") {
@@ -535,15 +2366,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public Context createPackageContext(final String packageName, final int flags)
             throws PackageManager.NameNotFoundException {
-        if (mPlugins.isEmpty()) {
-            try {
-                return getOriginal().super_createPackageContext(packageName, flags);
-            } catch (PackageManager.NameNotFoundException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_createPackageContextSgIr) {
+            return getOriginal().super_createPackageContext(packageName, flags);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_createPackageContextSgIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_createPackageContextSgIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("createPackageContext(String, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("createPackageContext", String.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("createPackageContext(String, Integer)", implementingPlugins);
+                mIsOverridden_createPackageContextSgIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Context, String, Integer> superCall = new CallFun2<Context, String, Integer>(
                 "createPackageContext(String, Integer)") {
@@ -570,11 +2413,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public PendingIntent createPendingResult(final int requestCode, final Intent data,
             final int flags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_createPendingResultIrItIr) {
             return getOriginal().super_createPendingResult(requestCode, data, flags);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_createPendingResultIrItIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_createPendingResultIrItIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("createPendingResult(Integer, Intent, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("createPendingResult", Integer.class,
+                        Intent.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("createPendingResult(Integer, Intent, Integer)", implementingPlugins);
+                mIsOverridden_createPendingResultIrItIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<PendingIntent, Integer, Intent, Integer> superCall
                 = new CallFun3<PendingIntent, Integer, Intent, Integer>(
@@ -594,11 +2453,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String[] databaseList() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_databaseList) {
             return getOriginal().super_databaseList();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_databaseList < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_databaseList++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("databaseList()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("databaseList");
+                mMethodImplementingPlugins.put("databaseList()", implementingPlugins);
+                mIsOverridden_databaseList = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String[]> superCall = new CallFun0<String[]>("databaseList()") {
 
@@ -615,11 +2488,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean deleteDatabase(final String name) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_deleteDatabaseSg) {
             return getOriginal().super_deleteDatabase(name);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_deleteDatabaseSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_deleteDatabaseSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("deleteDatabase(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("deleteDatabase", String.class);
+                mMethodImplementingPlugins.put("deleteDatabase(String)", implementingPlugins);
+                mIsOverridden_deleteDatabaseSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "deleteDatabase(String)") {
@@ -637,11 +2524,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean deleteFile(final String name) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_deleteFileSg) {
             return getOriginal().super_deleteFile(name);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_deleteFileSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_deleteFileSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("deleteFile(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("deleteFile", String.class);
+                mMethodImplementingPlugins.put("deleteFile(String)", implementingPlugins);
+                mIsOverridden_deleteFileSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "deleteFile(String)") {
@@ -659,11 +2560,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean dispatchGenericMotionEvent(final MotionEvent ev) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dispatchGenericMotionEventMt) {
             return getOriginal().super_dispatchGenericMotionEvent(ev);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_dispatchGenericMotionEventMt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dispatchGenericMotionEventMt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dispatchGenericMotionEvent(MotionEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dispatchGenericMotionEvent",
+                        MotionEvent.class);
+                mMethodImplementingPlugins
+                        .put("dispatchGenericMotionEvent(MotionEvent)", implementingPlugins);
+                mIsOverridden_dispatchGenericMotionEventMt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "dispatchGenericMotionEvent(MotionEvent)") {
@@ -681,11 +2598,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean dispatchKeyEvent(final KeyEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dispatchKeyEventKt) {
             return getOriginal().super_dispatchKeyEvent(event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_dispatchKeyEventKt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dispatchKeyEventKt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dispatchKeyEvent(KeyEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dispatchKeyEvent", KeyEvent.class);
+                mMethodImplementingPlugins.put("dispatchKeyEvent(KeyEvent)", implementingPlugins);
+                mIsOverridden_dispatchKeyEventKt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, KeyEvent> superCall = new CallFun1<Boolean, KeyEvent>(
                 "dispatchKeyEvent(KeyEvent)") {
@@ -703,11 +2634,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean dispatchKeyShortcutEvent(final KeyEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dispatchKeyShortcutEventKt) {
             return getOriginal().super_dispatchKeyShortcutEvent(event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_dispatchKeyShortcutEventKt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dispatchKeyShortcutEventKt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dispatchKeyShortcutEvent(KeyEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dispatchKeyShortcutEvent",
+                        KeyEvent.class);
+                mMethodImplementingPlugins
+                        .put("dispatchKeyShortcutEvent(KeyEvent)", implementingPlugins);
+                mIsOverridden_dispatchKeyShortcutEventKt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, KeyEvent> superCall = new CallFun1<Boolean, KeyEvent>(
                 "dispatchKeyShortcutEvent(KeyEvent)") {
@@ -725,11 +2672,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean dispatchPopulateAccessibilityEvent(final AccessibilityEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dispatchPopulateAccessibilityEventAt) {
             return getOriginal().super_dispatchPopulateAccessibilityEvent(event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_dispatchPopulateAccessibilityEventAt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dispatchPopulateAccessibilityEventAt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dispatchPopulateAccessibilityEvent(AccessibilityEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dispatchPopulateAccessibilityEvent",
+                        AccessibilityEvent.class);
+                mMethodImplementingPlugins
+                        .put("dispatchPopulateAccessibilityEvent(AccessibilityEvent)",
+                                implementingPlugins);
+                mIsOverridden_dispatchPopulateAccessibilityEventAt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, AccessibilityEvent> superCall
                 = new CallFun1<Boolean, AccessibilityEvent>(
@@ -748,11 +2712,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean dispatchTouchEvent(final MotionEvent ev) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dispatchTouchEventMt) {
             return getOriginal().super_dispatchTouchEvent(ev);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_dispatchTouchEventMt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dispatchTouchEventMt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dispatchTouchEvent(MotionEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dispatchTouchEvent",
+                        MotionEvent.class);
+                mMethodImplementingPlugins
+                        .put("dispatchTouchEvent(MotionEvent)", implementingPlugins);
+                mIsOverridden_dispatchTouchEventMt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "dispatchTouchEvent(MotionEvent)") {
@@ -770,11 +2750,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean dispatchTrackballEvent(final MotionEvent ev) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dispatchTrackballEventMt) {
             return getOriginal().super_dispatchTrackballEvent(ev);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_dispatchTrackballEventMt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dispatchTrackballEventMt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dispatchTrackballEvent(MotionEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dispatchTrackballEvent",
+                        MotionEvent.class);
+                mMethodImplementingPlugins
+                        .put("dispatchTrackballEvent(MotionEvent)", implementingPlugins);
+                mIsOverridden_dispatchTrackballEventMt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "dispatchTrackballEvent(MotionEvent)") {
@@ -793,12 +2789,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dumpSgFrPrSg) {
             getOriginal().super_dump(prefix, fd, writer, args);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_dumpSgFrPrSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dumpSgFrPrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dump(String, FileDescriptor, PrintWriter, String[])");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dump", String.class,
+                        FileDescriptor.class, PrintWriter.class, String[].class);
+                mMethodImplementingPlugins
+                        .put("dump(String, FileDescriptor, PrintWriter, String[])",
+                                implementingPlugins);
+                mIsOverridden_dumpSgFrPrSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid4<String, FileDescriptor, PrintWriter, String[]> superCall
                 = new CallVoid4<String, FileDescriptor, PrintWriter, String[]>(
@@ -818,12 +2831,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void enforceCallingOrSelfPermission(final String permission, final String message) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_enforceCallingOrSelfPermissionSgSg) {
             getOriginal().super_enforceCallingOrSelfPermission(permission, message);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_enforceCallingOrSelfPermissionSgSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_enforceCallingOrSelfPermissionSgSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("enforceCallingOrSelfPermission(String, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("enforceCallingOrSelfPermission",
+                        String.class, String.class);
+                mMethodImplementingPlugins
+                        .put("enforceCallingOrSelfPermission(String, String)", implementingPlugins);
+                mIsOverridden_enforceCallingOrSelfPermissionSgSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<String, String> superCall = new CallVoid2<String, String>(
                 "enforceCallingOrSelfPermission(String, String)") {
@@ -842,12 +2871,31 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void enforceCallingOrSelfUriPermission(final Uri uri, final int modeFlags,
             final String message) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_enforceCallingOrSelfUriPermissionUiIrSg) {
             getOriginal().super_enforceCallingOrSelfUriPermission(uri, modeFlags, message);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_enforceCallingOrSelfUriPermissionUiIrSg
+                < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_enforceCallingOrSelfUriPermissionUiIrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("enforceCallingOrSelfUriPermission(Uri, Integer, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("enforceCallingOrSelfUriPermission",
+                        Uri.class, Integer.class, String.class);
+                mMethodImplementingPlugins
+                        .put("enforceCallingOrSelfUriPermission(Uri, Integer, String)",
+                                implementingPlugins);
+                mIsOverridden_enforceCallingOrSelfUriPermissionUiIrSg = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Uri, Integer, String> superCall = new CallVoid3<Uri, Integer, String>(
                 "enforceCallingOrSelfUriPermission(Uri, Integer, String)") {
@@ -866,12 +2914,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void enforceCallingPermission(final String permission, final String message) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_enforceCallingPermissionSgSg) {
             getOriginal().super_enforceCallingPermission(permission, message);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_enforceCallingPermissionSgSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_enforceCallingPermissionSgSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("enforceCallingPermission(String, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("enforceCallingPermission",
+                        String.class, String.class);
+                mMethodImplementingPlugins
+                        .put("enforceCallingPermission(String, String)", implementingPlugins);
+                mIsOverridden_enforceCallingPermissionSgSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<String, String> superCall = new CallVoid2<String, String>(
                 "enforceCallingPermission(String, String)") {
@@ -890,12 +2954,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void enforceCallingUriPermission(final Uri uri, final int modeFlags,
             final String message) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_enforceCallingUriPermissionUiIrSg) {
             getOriginal().super_enforceCallingUriPermission(uri, modeFlags, message);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_enforceCallingUriPermissionUiIrSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_enforceCallingUriPermissionUiIrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("enforceCallingUriPermission(Uri, Integer, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("enforceCallingUriPermission",
+                        Uri.class, Integer.class, String.class);
+                mMethodImplementingPlugins.put("enforceCallingUriPermission(Uri, Integer, String)",
+                        implementingPlugins);
+                mIsOverridden_enforceCallingUriPermissionUiIrSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Uri, Integer, String> superCall = new CallVoid3<Uri, Integer, String>(
                 "enforceCallingUriPermission(Uri, Integer, String)") {
@@ -914,12 +2994,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void enforcePermission(final String permission, final int pid, final int uid,
             final String message) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_enforcePermissionSgIrIrSg) {
             getOriginal().super_enforcePermission(permission, pid, uid, message);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_enforcePermissionSgIrIrSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_enforcePermissionSgIrIrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("enforcePermission(String, Integer, Integer, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("enforcePermission", String.class,
+                        Integer.class, Integer.class, String.class);
+                mMethodImplementingPlugins
+                        .put("enforcePermission(String, Integer, Integer, String)",
+                                implementingPlugins);
+                mIsOverridden_enforcePermissionSgIrIrSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid4<String, Integer, Integer, String> superCall
                 = new CallVoid4<String, Integer, Integer, String>(
@@ -940,12 +3037,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void enforceUriPermission(final Uri uri, final int pid, final int uid,
             final int modeFlags, final String message) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_enforceUriPermissionUiIrIrIrSg) {
             getOriginal().super_enforceUriPermission(uri, pid, uid, modeFlags, message);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_enforceUriPermissionUiIrIrIrSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_enforceUriPermissionUiIrIrIrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("enforceUriPermission(Uri, Integer, Integer, Integer, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("enforceUriPermission", Uri.class,
+                        Integer.class, Integer.class, Integer.class, String.class);
+                mMethodImplementingPlugins
+                        .put("enforceUriPermission(Uri, Integer, Integer, Integer, String)",
+                                implementingPlugins);
+                mIsOverridden_enforceUriPermissionUiIrIrIrSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid5<Uri, Integer, Integer, Integer, String> superCall
                 = new CallVoid5<Uri, Integer, Integer, Integer, String>(
@@ -968,13 +3082,31 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void enforceUriPermission(final Uri uri, final String readPermission,
             final String writePermission, final int pid, final int uid, final int modeFlags,
             final String message) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_enforceUriPermissionUiSgSgIrIrIrSg) {
             getOriginal().super_enforceUriPermission(uri, readPermission, writePermission, pid, uid,
                     modeFlags, message);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_enforceUriPermissionUiSgSgIrIrIrSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_enforceUriPermissionUiSgSgIrIrIrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("enforceUriPermission(Uri, String, String, Integer, Integer, Integer, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("enforceUriPermission", Uri.class,
+                        String.class, String.class, Integer.class, Integer.class, Integer.class,
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("enforceUriPermission(Uri, String, String, Integer, Integer, Integer, String)",
+                                implementingPlugins);
+                mIsOverridden_enforceUriPermissionUiSgSgIrIrIrSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid7<Uri, String, String, Integer, Integer, Integer, String> superCall
                 = new CallVoid7<Uri, String, String, Integer, Integer, Integer, String>(
@@ -999,11 +3131,24 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String[] fileList() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_fileList) {
             return getOriginal().super_fileList();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_fileList < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_fileList++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("fileList()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("fileList");
+                mMethodImplementingPlugins.put("fileList()", implementingPlugins);
+                mIsOverridden_fileList = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String[]> superCall = new CallFun0<String[]>("fileList()") {
 
@@ -1020,11 +3165,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public View findViewById(@IdRes final int id) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_findViewByIdIr) {
             return getOriginal().super_findViewById(id);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_findViewByIdIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_findViewByIdIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("findViewById(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("findViewById", Integer.class);
+                mMethodImplementingPlugins.put("findViewById(Integer)", implementingPlugins);
+                mIsOverridden_findViewByIdIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<View, Integer> superCall = new CallFun1<View, Integer>(
                 "findViewById(Integer)") {
@@ -1042,12 +3201,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void finish() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_finish) {
             getOriginal().super_finish();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_finish < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_finish++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("finish()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("finish");
+                mMethodImplementingPlugins.put("finish()", implementingPlugins);
+                mIsOverridden_finish = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("finish()") {
 
@@ -1064,12 +3236,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void finishActivity(final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_finishActivityIr) {
             getOriginal().super_finishActivity(requestCode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_finishActivityIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_finishActivityIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("finishActivity(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("finishActivity", Integer.class);
+                mMethodImplementingPlugins.put("finishActivity(Integer)", implementingPlugins);
+                mIsOverridden_finishActivityIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>("finishActivity(Integer)") {
 
@@ -1086,12 +3272,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void finishActivityFromChild(final Activity child, final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_finishActivityFromChildAyIr) {
             getOriginal().super_finishActivityFromChild(child, requestCode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_finishActivityFromChildAyIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_finishActivityFromChildAyIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("finishActivityFromChild(Activity, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("finishActivityFromChild",
+                        Activity.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("finishActivityFromChild(Activity, Integer)", implementingPlugins);
+                mIsOverridden_finishActivityFromChildAyIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Activity, Integer> superCall = new CallVoid2<Activity, Integer>(
                 "finishActivityFromChild(Activity, Integer)") {
@@ -1109,12 +3311,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void finishAffinity() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_finishAffinity) {
             getOriginal().super_finishAffinity();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_finishAffinity < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_finishAffinity++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("finishAffinity()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("finishAffinity");
+                mMethodImplementingPlugins.put("finishAffinity()", implementingPlugins);
+                mIsOverridden_finishAffinity = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("finishAffinity()") {
 
@@ -1131,12 +3347,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void finishAfterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_finishAfterTransition) {
             getOriginal().super_finishAfterTransition();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_finishAfterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_finishAfterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("finishAfterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("finishAfterTransition");
+                mMethodImplementingPlugins.put("finishAfterTransition()", implementingPlugins);
+                mIsOverridden_finishAfterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("finishAfterTransition()") {
 
@@ -1153,12 +3383,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void finishAndRemoveTask() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_finishAndRemoveTask) {
             getOriginal().super_finishAndRemoveTask();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_finishAndRemoveTask < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_finishAndRemoveTask++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("finishAndRemoveTask()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("finishAndRemoveTask");
+                mMethodImplementingPlugins.put("finishAndRemoveTask()", implementingPlugins);
+                mIsOverridden_finishAndRemoveTask = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("finishAndRemoveTask()") {
 
@@ -1175,12 +3419,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void finishFromChild(final Activity child) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_finishFromChildAy) {
             getOriginal().super_finishFromChild(child);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_finishFromChildAy < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_finishFromChildAy++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("finishFromChild(Activity)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("finishFromChild", Activity.class);
+                mMethodImplementingPlugins.put("finishFromChild(Activity)", implementingPlugins);
+                mIsOverridden_finishFromChildAy = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Activity> superCall = new CallVoid1<Activity>("finishFromChild(Activity)") {
 
@@ -1197,11 +3455,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public android.app.ActionBar getActionBar() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getActionBar) {
             return getOriginal().super_getActionBar();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getActionBar < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getActionBar++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getActionBar()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getActionBar");
+                mMethodImplementingPlugins.put("getActionBar()", implementingPlugins);
+                mIsOverridden_getActionBar = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<android.app.ActionBar> superCall = new CallFun0<android.app.ActionBar>(
                 "getActionBar()") {
@@ -1219,11 +3491,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Context getApplicationContext() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getApplicationContext) {
             return getOriginal().super_getApplicationContext();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getApplicationContext < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getApplicationContext++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getApplicationContext()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getApplicationContext");
+                mMethodImplementingPlugins.put("getApplicationContext()", implementingPlugins);
+                mIsOverridden_getApplicationContext = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Context> superCall = new CallFun0<Context>("getApplicationContext()") {
 
@@ -1240,11 +3526,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ApplicationInfo getApplicationInfo() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getApplicationInfo) {
             return getOriginal().super_getApplicationInfo();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getApplicationInfo < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getApplicationInfo++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getApplicationInfo()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getApplicationInfo");
+                mMethodImplementingPlugins.put("getApplicationInfo()", implementingPlugins);
+                mIsOverridden_getApplicationInfo = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<ApplicationInfo> superCall = new CallFun0<ApplicationInfo>(
                 "getApplicationInfo()") {
@@ -1262,11 +3562,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public AssetManager getAssets() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getAssets) {
             return getOriginal().super_getAssets();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getAssets < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getAssets++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getAssets()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getAssets");
+                mMethodImplementingPlugins.put("getAssets()", implementingPlugins);
+                mIsOverridden_getAssets = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<AssetManager> superCall = new CallFun0<AssetManager>("getAssets()") {
 
@@ -1283,11 +3597,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Context getBaseContext() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getBaseContext) {
             return getOriginal().super_getBaseContext();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getBaseContext < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getBaseContext++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getBaseContext()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getBaseContext");
+                mMethodImplementingPlugins.put("getBaseContext()", implementingPlugins);
+                mIsOverridden_getBaseContext = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Context> superCall = new CallFun0<Context>("getBaseContext()") {
 
@@ -1304,11 +3632,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getCacheDir() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getCacheDir) {
             return getOriginal().super_getCacheDir();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getCacheDir < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getCacheDir++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getCacheDir()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getCacheDir");
+                mMethodImplementingPlugins.put("getCacheDir()", implementingPlugins);
+                mIsOverridden_getCacheDir = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File> superCall = new CallFun0<File>("getCacheDir()") {
 
@@ -1325,11 +3667,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ComponentName getCallingActivity() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getCallingActivity) {
             return getOriginal().super_getCallingActivity();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getCallingActivity < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getCallingActivity++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getCallingActivity()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getCallingActivity");
+                mMethodImplementingPlugins.put("getCallingActivity()", implementingPlugins);
+                mIsOverridden_getCallingActivity = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<ComponentName> superCall = new CallFun0<ComponentName>(
                 "getCallingActivity()") {
@@ -1347,11 +3703,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String getCallingPackage() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getCallingPackage) {
             return getOriginal().super_getCallingPackage();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getCallingPackage < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getCallingPackage++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getCallingPackage()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getCallingPackage");
+                mMethodImplementingPlugins.put("getCallingPackage()", implementingPlugins);
+                mIsOverridden_getCallingPackage = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String> superCall = new CallFun0<String>("getCallingPackage()") {
 
@@ -1368,11 +3738,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int getChangingConfigurations() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getChangingConfigurations) {
             return getOriginal().super_getChangingConfigurations();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getChangingConfigurations < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getChangingConfigurations++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getChangingConfigurations()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getChangingConfigurations");
+                mMethodImplementingPlugins.put("getChangingConfigurations()", implementingPlugins);
+                mIsOverridden_getChangingConfigurations = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Integer> superCall = new CallFun0<Integer>("getChangingConfigurations()") {
 
@@ -1389,11 +3773,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ClassLoader getClassLoader() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getClassLoader) {
             return getOriginal().super_getClassLoader();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getClassLoader < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getClassLoader++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getClassLoader()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getClassLoader");
+                mMethodImplementingPlugins.put("getClassLoader()", implementingPlugins);
+                mIsOverridden_getClassLoader = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<ClassLoader> superCall = new CallFun0<ClassLoader>("getClassLoader()") {
 
@@ -1410,11 +3808,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getCodeCacheDir() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getCodeCacheDir) {
             return getOriginal().super_getCodeCacheDir();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getCodeCacheDir < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getCodeCacheDir++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getCodeCacheDir()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getCodeCacheDir");
+                mMethodImplementingPlugins.put("getCodeCacheDir()", implementingPlugins);
+                mIsOverridden_getCodeCacheDir = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File> superCall = new CallFun0<File>("getCodeCacheDir()") {
 
@@ -1431,11 +3843,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ComponentName getComponentName() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getComponentName) {
             return getOriginal().super_getComponentName();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getComponentName < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getComponentName++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getComponentName()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getComponentName");
+                mMethodImplementingPlugins.put("getComponentName()", implementingPlugins);
+                mIsOverridden_getComponentName = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<ComponentName> superCall = new CallFun0<ComponentName>(
                 "getComponentName()") {
@@ -1453,11 +3879,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ContentResolver getContentResolver() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getContentResolver) {
             return getOriginal().super_getContentResolver();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getContentResolver < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getContentResolver++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getContentResolver()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getContentResolver");
+                mMethodImplementingPlugins.put("getContentResolver()", implementingPlugins);
+                mIsOverridden_getContentResolver = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<ContentResolver> superCall = new CallFun0<ContentResolver>(
                 "getContentResolver()") {
@@ -1475,11 +3915,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Scene getContentScene() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getContentScene) {
             return getOriginal().super_getContentScene();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getContentScene < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getContentScene++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getContentScene()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getContentScene");
+                mMethodImplementingPlugins.put("getContentScene()", implementingPlugins);
+                mIsOverridden_getContentScene = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Scene> superCall = new CallFun0<Scene>("getContentScene()") {
 
@@ -1496,11 +3950,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public TransitionManager getContentTransitionManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getContentTransitionManager) {
             return getOriginal().super_getContentTransitionManager();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getContentTransitionManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getContentTransitionManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getContentTransitionManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getContentTransitionManager");
+                mMethodImplementingPlugins
+                        .put("getContentTransitionManager()", implementingPlugins);
+                mIsOverridden_getContentTransitionManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<TransitionManager> superCall = new CallFun0<TransitionManager>(
                 "getContentTransitionManager()") {
@@ -1518,11 +3987,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public View getCurrentFocus() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getCurrentFocus) {
             return getOriginal().super_getCurrentFocus();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getCurrentFocus < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getCurrentFocus++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getCurrentFocus()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getCurrentFocus");
+                mMethodImplementingPlugins.put("getCurrentFocus()", implementingPlugins);
+                mIsOverridden_getCurrentFocus = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<View> superCall = new CallFun0<View>("getCurrentFocus()") {
 
@@ -1539,11 +4022,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getDatabasePath(final String name) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getDatabasePathSg) {
             return getOriginal().super_getDatabasePath(name);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getDatabasePathSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getDatabasePathSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getDatabasePath(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getDatabasePath", String.class);
+                mMethodImplementingPlugins.put("getDatabasePath(String)", implementingPlugins);
+                mIsOverridden_getDatabasePathSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<File, String> superCall = new CallFun1<File, String>(
                 "getDatabasePath(String)") {
@@ -1561,11 +4058,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public AppCompatDelegate getDelegate() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getDelegate) {
             return getOriginal().super_getDelegate();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getDelegate < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getDelegate++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getDelegate()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getDelegate");
+                mMethodImplementingPlugins.put("getDelegate()", implementingPlugins);
+                mIsOverridden_getDelegate = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<AppCompatDelegate> superCall = new CallFun0<AppCompatDelegate>(
                 "getDelegate()") {
@@ -1583,11 +4094,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getDir(final String name, final int mode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getDirSgIr) {
             return getOriginal().super_getDir(name, mode);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getDirSgIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getDirSgIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getDir(String, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getDir", String.class, Integer.class);
+                mMethodImplementingPlugins.put("getDir(String, Integer)", implementingPlugins);
+                mIsOverridden_getDirSgIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<File, String, Integer> superCall = new CallFun2<File, String, Integer>(
                 "getDir(String, Integer)") {
@@ -1605,11 +4130,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ActionBarDrawerToggle.Delegate getDrawerToggleDelegate() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getDrawerToggleDelegate) {
             return getOriginal().super_getDrawerToggleDelegate();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getDrawerToggleDelegate < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getDrawerToggleDelegate++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getDrawerToggleDelegate()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getDrawerToggleDelegate");
+                mMethodImplementingPlugins.put("getDrawerToggleDelegate()", implementingPlugins);
+                mIsOverridden_getDrawerToggleDelegate = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<ActionBarDrawerToggle.Delegate> superCall
                 = new CallFun0<ActionBarDrawerToggle.Delegate>("getDrawerToggleDelegate()") {
@@ -1627,11 +4166,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getExternalCacheDir() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getExternalCacheDir) {
             return getOriginal().super_getExternalCacheDir();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getExternalCacheDir < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getExternalCacheDir++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getExternalCacheDir()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getExternalCacheDir");
+                mMethodImplementingPlugins.put("getExternalCacheDir()", implementingPlugins);
+                mIsOverridden_getExternalCacheDir = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File> superCall = new CallFun0<File>("getExternalCacheDir()") {
 
@@ -1648,11 +4201,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File[] getExternalCacheDirs() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getExternalCacheDirs) {
             return getOriginal().super_getExternalCacheDirs();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getExternalCacheDirs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getExternalCacheDirs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getExternalCacheDirs()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getExternalCacheDirs");
+                mMethodImplementingPlugins.put("getExternalCacheDirs()", implementingPlugins);
+                mIsOverridden_getExternalCacheDirs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File[]> superCall = new CallFun0<File[]>("getExternalCacheDirs()") {
 
@@ -1669,11 +4236,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getExternalFilesDir(final String type) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getExternalFilesDirSg) {
             return getOriginal().super_getExternalFilesDir(type);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getExternalFilesDirSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getExternalFilesDirSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getExternalFilesDir(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getExternalFilesDir", String.class);
+                mMethodImplementingPlugins.put("getExternalFilesDir(String)", implementingPlugins);
+                mIsOverridden_getExternalFilesDirSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<File, String> superCall = new CallFun1<File, String>(
                 "getExternalFilesDir(String)") {
@@ -1691,11 +4272,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File[] getExternalFilesDirs(final String type) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getExternalFilesDirsSg) {
             return getOriginal().super_getExternalFilesDirs(type);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getExternalFilesDirsSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getExternalFilesDirsSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getExternalFilesDirs(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getExternalFilesDirs", String.class);
+                mMethodImplementingPlugins.put("getExternalFilesDirs(String)", implementingPlugins);
+                mIsOverridden_getExternalFilesDirsSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<File[], String> superCall = new CallFun1<File[], String>(
                 "getExternalFilesDirs(String)") {
@@ -1713,11 +4308,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File[] getExternalMediaDirs() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getExternalMediaDirs) {
             return getOriginal().super_getExternalMediaDirs();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getExternalMediaDirs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getExternalMediaDirs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getExternalMediaDirs()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getExternalMediaDirs");
+                mMethodImplementingPlugins.put("getExternalMediaDirs()", implementingPlugins);
+                mIsOverridden_getExternalMediaDirs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File[]> superCall = new CallFun0<File[]>("getExternalMediaDirs()") {
 
@@ -1734,11 +4343,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getFileStreamPath(final String name) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getFileStreamPathSg) {
             return getOriginal().super_getFileStreamPath(name);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getFileStreamPathSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getFileStreamPathSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getFileStreamPath(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getFileStreamPath", String.class);
+                mMethodImplementingPlugins.put("getFileStreamPath(String)", implementingPlugins);
+                mIsOverridden_getFileStreamPathSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<File, String> superCall = new CallFun1<File, String>(
                 "getFileStreamPath(String)") {
@@ -1756,11 +4379,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getFilesDir() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getFilesDir) {
             return getOriginal().super_getFilesDir();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getFilesDir < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getFilesDir++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getFilesDir()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getFilesDir");
+                mMethodImplementingPlugins.put("getFilesDir()", implementingPlugins);
+                mIsOverridden_getFilesDir = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File> superCall = new CallFun0<File>("getFilesDir()") {
 
@@ -1777,11 +4414,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public android.app.FragmentManager getFragmentManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getFragmentManager) {
             return getOriginal().super_getFragmentManager();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getFragmentManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getFragmentManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getFragmentManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getFragmentManager");
+                mMethodImplementingPlugins.put("getFragmentManager()", implementingPlugins);
+                mIsOverridden_getFragmentManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<android.app.FragmentManager> superCall
                 = new CallFun0<android.app.FragmentManager>("getFragmentManager()") {
@@ -1799,11 +4450,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Intent getIntent() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getIntent) {
             return getOriginal().super_getIntent();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getIntent < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getIntent++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getIntent()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getIntent");
+                mMethodImplementingPlugins.put("getIntent()", implementingPlugins);
+                mIsOverridden_getIntent = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Intent> superCall = new CallFun0<Intent>("getIntent()") {
 
@@ -1838,11 +4503,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public LayoutInflater getLayoutInflater() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getLayoutInflater) {
             return getOriginal().super_getLayoutInflater();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getLayoutInflater < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getLayoutInflater++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getLayoutInflater()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getLayoutInflater");
+                mMethodImplementingPlugins.put("getLayoutInflater()", implementingPlugins);
+                mIsOverridden_getLayoutInflater = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<LayoutInflater> superCall = new CallFun0<LayoutInflater>(
                 "getLayoutInflater()") {
@@ -1860,11 +4539,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public android.app.LoaderManager getLoaderManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getLoaderManager) {
             return getOriginal().super_getLoaderManager();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getLoaderManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getLoaderManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getLoaderManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getLoaderManager");
+                mMethodImplementingPlugins.put("getLoaderManager()", implementingPlugins);
+                mIsOverridden_getLoaderManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<android.app.LoaderManager> superCall
                 = new CallFun0<android.app.LoaderManager>("getLoaderManager()") {
@@ -1882,11 +4575,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String getLocalClassName() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getLocalClassName) {
             return getOriginal().super_getLocalClassName();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getLocalClassName < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getLocalClassName++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getLocalClassName()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getLocalClassName");
+                mMethodImplementingPlugins.put("getLocalClassName()", implementingPlugins);
+                mIsOverridden_getLocalClassName = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String> superCall = new CallFun0<String>("getLocalClassName()") {
 
@@ -1903,11 +4610,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Looper getMainLooper() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getMainLooper) {
             return getOriginal().super_getMainLooper();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getMainLooper < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getMainLooper++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getMainLooper()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getMainLooper");
+                mMethodImplementingPlugins.put("getMainLooper()", implementingPlugins);
+                mIsOverridden_getMainLooper = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Looper> superCall = new CallFun0<Looper>("getMainLooper()") {
 
@@ -1924,11 +4645,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public MenuInflater getMenuInflater() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getMenuInflater) {
             return getOriginal().super_getMenuInflater();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getMenuInflater < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getMenuInflater++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getMenuInflater()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getMenuInflater");
+                mMethodImplementingPlugins.put("getMenuInflater()", implementingPlugins);
+                mIsOverridden_getMenuInflater = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<MenuInflater> superCall = new CallFun0<MenuInflater>("getMenuInflater()") {
 
@@ -1945,11 +4680,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getNoBackupFilesDir() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getNoBackupFilesDir) {
             return getOriginal().super_getNoBackupFilesDir();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getNoBackupFilesDir < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getNoBackupFilesDir++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getNoBackupFilesDir()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getNoBackupFilesDir");
+                mMethodImplementingPlugins.put("getNoBackupFilesDir()", implementingPlugins);
+                mIsOverridden_getNoBackupFilesDir = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File> superCall = new CallFun0<File>("getNoBackupFilesDir()") {
 
@@ -1966,11 +4715,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File getObbDir() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getObbDir) {
             return getOriginal().super_getObbDir();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getObbDir < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getObbDir++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getObbDir()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getObbDir");
+                mMethodImplementingPlugins.put("getObbDir()", implementingPlugins);
+                mIsOverridden_getObbDir = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File> superCall = new CallFun0<File>("getObbDir()") {
 
@@ -1987,11 +4750,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public File[] getObbDirs() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getObbDirs) {
             return getOriginal().super_getObbDirs();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getObbDirs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getObbDirs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getObbDirs()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getObbDirs");
+                mMethodImplementingPlugins.put("getObbDirs()", implementingPlugins);
+                mIsOverridden_getObbDirs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<File[]> superCall = new CallFun0<File[]>("getObbDirs()") {
 
@@ -2008,11 +4785,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String getPackageCodePath() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getPackageCodePath) {
             return getOriginal().super_getPackageCodePath();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getPackageCodePath < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getPackageCodePath++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getPackageCodePath()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getPackageCodePath");
+                mMethodImplementingPlugins.put("getPackageCodePath()", implementingPlugins);
+                mIsOverridden_getPackageCodePath = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String> superCall = new CallFun0<String>("getPackageCodePath()") {
 
@@ -2029,11 +4820,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public PackageManager getPackageManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getPackageManager) {
             return getOriginal().super_getPackageManager();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getPackageManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getPackageManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getPackageManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getPackageManager");
+                mMethodImplementingPlugins.put("getPackageManager()", implementingPlugins);
+                mIsOverridden_getPackageManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<PackageManager> superCall = new CallFun0<PackageManager>(
                 "getPackageManager()") {
@@ -2051,11 +4856,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String getPackageName() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getPackageName) {
             return getOriginal().super_getPackageName();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getPackageName < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getPackageName++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getPackageName()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getPackageName");
+                mMethodImplementingPlugins.put("getPackageName()", implementingPlugins);
+                mIsOverridden_getPackageName = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String> superCall = new CallFun0<String>("getPackageName()") {
 
@@ -2072,11 +4891,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String getPackageResourcePath() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getPackageResourcePath) {
             return getOriginal().super_getPackageResourcePath();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getPackageResourcePath < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getPackageResourcePath++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getPackageResourcePath()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getPackageResourcePath");
+                mMethodImplementingPlugins.put("getPackageResourcePath()", implementingPlugins);
+                mIsOverridden_getPackageResourcePath = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String> superCall = new CallFun0<String>("getPackageResourcePath()") {
 
@@ -2093,11 +4926,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Intent getParentActivityIntent() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getParentActivityIntent) {
             return getOriginal().super_getParentActivityIntent();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getParentActivityIntent < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getParentActivityIntent++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getParentActivityIntent()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getParentActivityIntent");
+                mMethodImplementingPlugins.put("getParentActivityIntent()", implementingPlugins);
+                mIsOverridden_getParentActivityIntent = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Intent> superCall = new CallFun0<Intent>("getParentActivityIntent()") {
 
@@ -2114,11 +4961,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public SharedPreferences getPreferences(final int mode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getPreferencesIr) {
             return getOriginal().super_getPreferences(mode);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getPreferencesIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getPreferencesIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getPreferences(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getPreferences", Integer.class);
+                mMethodImplementingPlugins.put("getPreferences(Integer)", implementingPlugins);
+                mIsOverridden_getPreferencesIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<SharedPreferences, Integer> superCall
                 = new CallFun1<SharedPreferences, Integer>("getPreferences(Integer)") {
@@ -2136,11 +4997,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Uri getReferrer() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getReferrer) {
             return getOriginal().super_getReferrer();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getReferrer < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getReferrer++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getReferrer()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getReferrer");
+                mMethodImplementingPlugins.put("getReferrer()", implementingPlugins);
+                mIsOverridden_getReferrer = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Uri> superCall = new CallFun0<Uri>("getReferrer()") {
 
@@ -2157,11 +5032,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int getRequestedOrientation() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getRequestedOrientation) {
             return getOriginal().super_getRequestedOrientation();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getRequestedOrientation < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getRequestedOrientation++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getRequestedOrientation()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getRequestedOrientation");
+                mMethodImplementingPlugins.put("getRequestedOrientation()", implementingPlugins);
+                mIsOverridden_getRequestedOrientation = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Integer> superCall = new CallFun0<Integer>("getRequestedOrientation()") {
 
@@ -2178,13 +5067,13 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Resources getResources() {
-        if (!mIsGetResourcesOverridden) {
+        if (!mIsOverridden_getResources) {
             return getOriginal().super_getResources();
         }
 
         final ListIterator<ActivityPlugin> iterator;
-        if (mGetResourcesCallCount < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
-            mGetResourcesCallCount++;
+        if (mCallCount_getResources < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getResources++;
             iterator = mPlugins.listIterator(mPlugins.size());
         } else {
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
@@ -2192,7 +5081,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("getResources");
                 mMethodImplementingPlugins.put("getResources()", implementingPlugins);
-                mIsGetResourcesOverridden = implementingPlugins.size() > 0;
+                mIsOverridden_getResources = implementingPlugins.size() > 0;
             }
 
             iterator = implementingPlugins.listIterator(implementingPlugins.size());
@@ -2213,8 +5102,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public SharedPreferences getSharedPreferences(final String name, final int mode) {
+        if (!mIsOverridden_getSharedPreferencesSgIr) {
+            return getOriginal().super_getSharedPreferences(name, mode);
+        }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getSharedPreferencesSgIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSharedPreferencesSgIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSharedPreferences(String, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSharedPreferences", String.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("getSharedPreferences(String, Integer)", implementingPlugins);
+                mIsOverridden_getSharedPreferencesSgIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<SharedPreferences, String, Integer> superCall
                 = new CallFun2<SharedPreferences, String, Integer>(
@@ -2233,11 +5141,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ActionBar getSupportActionBar() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSupportActionBar) {
             return getOriginal().super_getSupportActionBar();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getSupportActionBar < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSupportActionBar++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSupportActionBar()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSupportActionBar");
+                mMethodImplementingPlugins.put("getSupportActionBar()", implementingPlugins);
+                mIsOverridden_getSupportActionBar = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<ActionBar> superCall = new CallFun0<ActionBar>("getSupportActionBar()") {
 
@@ -2254,11 +5176,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public FragmentManager getSupportFragmentManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSupportFragmentManager) {
             return getOriginal().super_getSupportFragmentManager();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getSupportFragmentManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSupportFragmentManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSupportFragmentManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSupportFragmentManager");
+                mMethodImplementingPlugins.put("getSupportFragmentManager()", implementingPlugins);
+                mIsOverridden_getSupportFragmentManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<FragmentManager> superCall = new CallFun0<FragmentManager>(
                 "getSupportFragmentManager()") {
@@ -2276,11 +5212,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public LoaderManager getSupportLoaderManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSupportLoaderManager) {
             return getOriginal().super_getSupportLoaderManager();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getSupportLoaderManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSupportLoaderManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSupportLoaderManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSupportLoaderManager");
+                mMethodImplementingPlugins.put("getSupportLoaderManager()", implementingPlugins);
+                mIsOverridden_getSupportLoaderManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<LoaderManager> superCall = new CallFun0<LoaderManager>(
                 "getSupportLoaderManager()") {
@@ -2298,11 +5248,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Intent getSupportParentActivityIntent() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSupportParentActivityIntent) {
             return getOriginal().super_getSupportParentActivityIntent();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getSupportParentActivityIntent < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSupportParentActivityIntent++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSupportParentActivityIntent()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSupportParentActivityIntent");
+                mMethodImplementingPlugins
+                        .put("getSupportParentActivityIntent()", implementingPlugins);
+                mIsOverridden_getSupportParentActivityIntent = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Intent> superCall = new CallFun0<Intent>(
                 "getSupportParentActivityIntent()") {
@@ -2320,11 +5285,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Object getSystemService(final String name) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSystemServiceSg) {
             return getOriginal().super_getSystemService(name);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getSystemServiceSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSystemServiceSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSystemService(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSystemService", String.class);
+                mMethodImplementingPlugins.put("getSystemService(String)", implementingPlugins);
+                mIsOverridden_getSystemServiceSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Object, String> superCall = new CallFun1<Object, String>(
                 "getSystemService(String)") {
@@ -2342,11 +5321,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public String getSystemServiceName(final Class<?> serviceClass) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSystemServiceNameCs) {
             return getOriginal().super_getSystemServiceName(serviceClass);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getSystemServiceNameCs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSystemServiceNameCs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSystemServiceName(Class<?>)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSystemServiceName", Class.class);
+                mMethodImplementingPlugins
+                        .put("getSystemServiceName(Class<?>)", implementingPlugins);
+                mIsOverridden_getSystemServiceNameCs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<String, Class<?>> superCall = new CallFun1<String, Class<?>>(
                 "getSystemServiceName(Class<?>)") {
@@ -2364,11 +5358,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int getTaskId() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getTaskId) {
             return getOriginal().super_getTaskId();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getTaskId < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getTaskId++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getTaskId()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getTaskId");
+                mMethodImplementingPlugins.put("getTaskId()", implementingPlugins);
+                mIsOverridden_getTaskId = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Integer> superCall = new CallFun0<Integer>("getTaskId()") {
 
@@ -2385,11 +5393,24 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Resources.Theme getTheme() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getTheme) {
             return getOriginal().super_getTheme();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getTheme < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getTheme++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("getTheme()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getTheme");
+                mMethodImplementingPlugins.put("getTheme()", implementingPlugins);
+                mIsOverridden_getTheme = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Resources.Theme> superCall = new CallFun0<Resources.Theme>("getTheme()") {
 
@@ -2406,11 +5427,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public VoiceInteractor getVoiceInteractor() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getVoiceInteractor) {
             return getOriginal().super_getVoiceInteractor();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getVoiceInteractor < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getVoiceInteractor++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getVoiceInteractor()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getVoiceInteractor");
+                mMethodImplementingPlugins.put("getVoiceInteractor()", implementingPlugins);
+                mIsOverridden_getVoiceInteractor = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<VoiceInteractor> superCall = new CallFun0<VoiceInteractor>(
                 "getVoiceInteractor()") {
@@ -2428,11 +5463,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Drawable getWallpaper() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getWallpaper) {
             return getOriginal().super_getWallpaper();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getWallpaper < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getWallpaper++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getWallpaper()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getWallpaper");
+                mMethodImplementingPlugins.put("getWallpaper()", implementingPlugins);
+                mIsOverridden_getWallpaper = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Drawable> superCall = new CallFun0<Drawable>("getWallpaper()") {
 
@@ -2449,11 +5498,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int getWallpaperDesiredMinimumHeight() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getWallpaperDesiredMinimumHeight) {
             return getOriginal().super_getWallpaperDesiredMinimumHeight();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getWallpaperDesiredMinimumHeight < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getWallpaperDesiredMinimumHeight++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getWallpaperDesiredMinimumHeight()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getWallpaperDesiredMinimumHeight");
+                mMethodImplementingPlugins
+                        .put("getWallpaperDesiredMinimumHeight()", implementingPlugins);
+                mIsOverridden_getWallpaperDesiredMinimumHeight = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Integer> superCall = new CallFun0<Integer>(
                 "getWallpaperDesiredMinimumHeight()") {
@@ -2471,11 +5535,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public int getWallpaperDesiredMinimumWidth() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getWallpaperDesiredMinimumWidth) {
             return getOriginal().super_getWallpaperDesiredMinimumWidth();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getWallpaperDesiredMinimumWidth < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getWallpaperDesiredMinimumWidth++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getWallpaperDesiredMinimumWidth()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getWallpaperDesiredMinimumWidth");
+                mMethodImplementingPlugins
+                        .put("getWallpaperDesiredMinimumWidth()", implementingPlugins);
+                mIsOverridden_getWallpaperDesiredMinimumWidth = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Integer> superCall = new CallFun0<Integer>(
                 "getWallpaperDesiredMinimumWidth()") {
@@ -2493,11 +5572,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Window getWindow() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getWindow) {
             return getOriginal().super_getWindow();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getWindow < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getWindow++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getWindow()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getWindow");
+                mMethodImplementingPlugins.put("getWindow()", implementingPlugins);
+                mIsOverridden_getWindow = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Window> superCall = new CallFun0<Window>("getWindow()") {
 
@@ -2514,11 +5607,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public WindowManager getWindowManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getWindowManager) {
             return getOriginal().super_getWindowManager();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_getWindowManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getWindowManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getWindowManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getWindowManager");
+                mMethodImplementingPlugins.put("getWindowManager()", implementingPlugins);
+                mIsOverridden_getWindowManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<WindowManager> superCall = new CallFun0<WindowManager>(
                 "getWindowManager()") {
@@ -2536,12 +5643,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void grantUriPermission(final String toPackage, final Uri uri, final int modeFlags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_grantUriPermissionSgUiIr) {
             getOriginal().super_grantUriPermission(toPackage, uri, modeFlags);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_grantUriPermissionSgUiIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_grantUriPermissionSgUiIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("grantUriPermission(String, Uri, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("grantUriPermission", String.class,
+                        Uri.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("grantUriPermission(String, Uri, Integer)", implementingPlugins);
+                mIsOverridden_grantUriPermissionSgUiIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<String, Uri, Integer> superCall = new CallVoid3<String, Uri, Integer>(
                 "grantUriPermission(String, Uri, Integer)") {
@@ -2559,11 +5682,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean hasWindowFocus() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_hasWindowFocus) {
             return getOriginal().super_hasWindowFocus();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_hasWindowFocus < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_hasWindowFocus++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("hasWindowFocus()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("hasWindowFocus");
+                mMethodImplementingPlugins.put("hasWindowFocus()", implementingPlugins);
+                mIsOverridden_hasWindowFocus = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("hasWindowFocus()") {
 
@@ -2580,12 +5717,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void invalidateOptionsMenu() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_invalidateOptionsMenu) {
             getOriginal().super_invalidateOptionsMenu();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_invalidateOptionsMenu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_invalidateOptionsMenu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("invalidateOptionsMenu()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("invalidateOptionsMenu");
+                mMethodImplementingPlugins.put("invalidateOptionsMenu()", implementingPlugins);
+                mIsOverridden_invalidateOptionsMenu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("invalidateOptionsMenu()") {
 
@@ -2602,11 +5753,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isChangingConfigurations() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isChangingConfigurations) {
             return getOriginal().super_isChangingConfigurations();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isChangingConfigurations < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isChangingConfigurations++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isChangingConfigurations()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isChangingConfigurations");
+                mMethodImplementingPlugins.put("isChangingConfigurations()", implementingPlugins);
+                mIsOverridden_isChangingConfigurations = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isChangingConfigurations()") {
 
@@ -2623,11 +5788,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isDestroyed() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isDestroyed) {
             return getOriginal().super_isDestroyed();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isDestroyed < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isDestroyed++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isDestroyed()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isDestroyed");
+                mMethodImplementingPlugins.put("isDestroyed()", implementingPlugins);
+                mIsOverridden_isDestroyed = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isDestroyed()") {
 
@@ -2644,11 +5823,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isFinishing() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isFinishing) {
             return getOriginal().super_isFinishing();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isFinishing < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isFinishing++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isFinishing()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isFinishing");
+                mMethodImplementingPlugins.put("isFinishing()", implementingPlugins);
+                mIsOverridden_isFinishing = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isFinishing()") {
 
@@ -2665,11 +5858,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isImmersive() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isImmersive) {
             return getOriginal().super_isImmersive();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isImmersive < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isImmersive++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isImmersive()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isImmersive");
+                mMethodImplementingPlugins.put("isImmersive()", implementingPlugins);
+                mIsOverridden_isImmersive = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isImmersive()") {
 
@@ -2686,11 +5893,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isRestricted() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isRestricted) {
             return getOriginal().super_isRestricted();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isRestricted < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isRestricted++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isRestricted()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isRestricted");
+                mMethodImplementingPlugins.put("isRestricted()", implementingPlugins);
+                mIsOverridden_isRestricted = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isRestricted()") {
 
@@ -2707,11 +5928,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isTaskRoot() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isTaskRoot) {
             return getOriginal().super_isTaskRoot();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isTaskRoot < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isTaskRoot++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isTaskRoot()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isTaskRoot");
+                mMethodImplementingPlugins.put("isTaskRoot()", implementingPlugins);
+                mIsOverridden_isTaskRoot = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isTaskRoot()") {
 
@@ -2728,11 +5963,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isVoiceInteraction() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isVoiceInteraction) {
             return getOriginal().super_isVoiceInteraction();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isVoiceInteraction < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isVoiceInteraction++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isVoiceInteraction()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isVoiceInteraction");
+                mMethodImplementingPlugins.put("isVoiceInteraction()", implementingPlugins);
+                mIsOverridden_isVoiceInteraction = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isVoiceInteraction()") {
 
@@ -2749,11 +5998,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean isVoiceInteractionRoot() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isVoiceInteractionRoot) {
             return getOriginal().super_isVoiceInteractionRoot();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_isVoiceInteractionRoot < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isVoiceInteractionRoot++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isVoiceInteractionRoot()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isVoiceInteractionRoot");
+                mMethodImplementingPlugins.put("isVoiceInteractionRoot()", implementingPlugins);
+                mIsOverridden_isVoiceInteractionRoot = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isVoiceInteractionRoot()") {
 
@@ -2770,11 +6033,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean moveTaskToBack(final boolean nonRoot) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_moveTaskToBackBn) {
             return getOriginal().super_moveTaskToBack(nonRoot);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_moveTaskToBackBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_moveTaskToBackBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("moveTaskToBack(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("moveTaskToBack", Boolean.class);
+                mMethodImplementingPlugins.put("moveTaskToBack(Boolean)", implementingPlugins);
+                mIsOverridden_moveTaskToBackBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Boolean> superCall = new CallFun1<Boolean, Boolean>(
                 "moveTaskToBack(Boolean)") {
@@ -2792,11 +6069,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean navigateUpTo(final Intent upIntent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_navigateUpToIt) {
             return getOriginal().super_navigateUpTo(upIntent);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_navigateUpToIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_navigateUpToIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("navigateUpTo(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("navigateUpTo", Intent.class);
+                mMethodImplementingPlugins.put("navigateUpTo(Intent)", implementingPlugins);
+                mIsOverridden_navigateUpToIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "navigateUpTo(Intent)") {
@@ -2814,11 +6105,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean navigateUpToFromChild(final Activity child, final Intent upIntent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_navigateUpToFromChildAyIt) {
             return getOriginal().super_navigateUpToFromChild(child, upIntent);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_navigateUpToFromChildAyIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_navigateUpToFromChildAyIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("navigateUpToFromChild(Activity, Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("navigateUpToFromChild",
+                        Activity.class, Intent.class);
+                mMethodImplementingPlugins
+                        .put("navigateUpToFromChild(Activity, Intent)", implementingPlugins);
+                mIsOverridden_navigateUpToFromChildAyIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Activity, Intent> superCall
                 = new CallFun2<Boolean, Activity, Intent>(
@@ -2837,12 +6144,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onActionModeFinished(final android.view.ActionMode mode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onActionModeFinishedae) {
             getOriginal().super_onActionModeFinished(mode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onActionModeFinishedae < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onActionModeFinishedae++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onActionModeFinished(android.view.ActionMode)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onActionModeFinished",
+                        android.view.ActionMode.class);
+                mMethodImplementingPlugins
+                        .put("onActionModeFinished(android.view.ActionMode)", implementingPlugins);
+                mIsOverridden_onActionModeFinishedae = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.view.ActionMode> superCall = new CallVoid1<android.view.ActionMode>(
                 "onActionModeFinished(android.view.ActionMode)") {
@@ -2860,12 +6183,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onActionModeStarted(final android.view.ActionMode mode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onActionModeStartedae) {
             getOriginal().super_onActionModeStarted(mode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onActionModeStartedae < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onActionModeStartedae++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onActionModeStarted(android.view.ActionMode)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onActionModeStarted",
+                        android.view.ActionMode.class);
+                mMethodImplementingPlugins
+                        .put("onActionModeStarted(android.view.ActionMode)", implementingPlugins);
+                mIsOverridden_onActionModeStartedae = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.view.ActionMode> superCall = new CallVoid1<android.view.ActionMode>(
                 "onActionModeStarted(android.view.ActionMode)") {
@@ -2883,12 +6222,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onActivityReenter(final int resultCode, final Intent data) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onActivityReenterIrIt) {
             getOriginal().super_onActivityReenter(resultCode, data);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onActivityReenterIrIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onActivityReenterIrIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onActivityReenter(Integer, Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onActivityReenter", Integer.class,
+                        Intent.class);
+                mMethodImplementingPlugins
+                        .put("onActivityReenter(Integer, Intent)", implementingPlugins);
+                mIsOverridden_onActivityReenterIrIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Integer, Intent> superCall = new CallVoid2<Integer, Intent>(
                 "onActivityReenter(Integer, Intent)") {
@@ -2906,12 +6261,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onActivityResultIrIrIt) {
             getOriginal().super_onActivityResult(requestCode, resultCode, data);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onActivityResultIrIrIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onActivityResultIrIrIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onActivityResult(Integer, Integer, Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onActivityResult", Integer.class,
+                        Integer.class, Intent.class);
+                mMethodImplementingPlugins
+                        .put("onActivityResult(Integer, Integer, Intent)", implementingPlugins);
+                mIsOverridden_onActivityResultIrIrIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Integer, Integer, Intent> superCall
                 = new CallVoid3<Integer, Integer, Intent>(
@@ -2932,12 +6303,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onApplyThemeResource(final Resources.Theme theme, final int resid,
             final boolean first) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onApplyThemeResourceReIrBn) {
             getOriginal().super_onApplyThemeResource(theme, resid, first);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onApplyThemeResourceReIrBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onApplyThemeResourceReIrBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onApplyThemeResource(Resources.Theme, Integer, Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onApplyThemeResource",
+                        Resources.Theme.class, Integer.class, Boolean.class);
+                mMethodImplementingPlugins
+                        .put("onApplyThemeResource(Resources.Theme, Integer, Boolean)",
+                                implementingPlugins);
+                mIsOverridden_onApplyThemeResourceReIrBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Resources.Theme, Integer, Boolean> superCall
                 = new CallVoid3<Resources.Theme, Integer, Boolean>(
@@ -2957,12 +6345,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onAttachFragment(final Fragment fragment) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onAttachFragmentFt) {
             getOriginal().super_onAttachFragment(fragment);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onAttachFragmentFt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onAttachFragmentFt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onAttachFragment(Fragment)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onAttachFragment", Fragment.class);
+                mMethodImplementingPlugins.put("onAttachFragment(Fragment)", implementingPlugins);
+                mIsOverridden_onAttachFragmentFt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Fragment> superCall = new CallVoid1<Fragment>(
                 "onAttachFragment(Fragment)") {
@@ -2980,12 +6382,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onAttachFragment(final android.app.Fragment fragment) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onAttachFragmentat) {
             getOriginal().super_onAttachFragment(fragment);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onAttachFragmentat < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onAttachFragmentat++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onAttachFragment(android.app.Fragment)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onAttachFragment",
+                        android.app.Fragment.class);
+                mMethodImplementingPlugins
+                        .put("onAttachFragment(android.app.Fragment)", implementingPlugins);
+                mIsOverridden_onAttachFragmentat = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.app.Fragment> superCall = new CallVoid1<android.app.Fragment>(
                 "onAttachFragment(android.app.Fragment)") {
@@ -3003,12 +6421,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onAttachedToWindow() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onAttachedToWindow) {
             getOriginal().super_onAttachedToWindow();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onAttachedToWindow < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onAttachedToWindow++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onAttachedToWindow()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onAttachedToWindow");
+                mMethodImplementingPlugins.put("onAttachedToWindow()", implementingPlugins);
+                mIsOverridden_onAttachedToWindow = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onAttachedToWindow()") {
 
@@ -3025,12 +6457,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onBackPressed() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onBackPressed) {
             getOriginal().super_onBackPressed();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onBackPressed < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onBackPressed++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onBackPressed()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onBackPressed");
+                mMethodImplementingPlugins.put("onBackPressed()", implementingPlugins);
+                mIsOverridden_onBackPressed = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onBackPressed()") {
 
@@ -3047,12 +6493,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onChildTitleChanged(final Activity childActivity, final CharSequence title) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onChildTitleChangedAyCe) {
             getOriginal().super_onChildTitleChanged(childActivity, title);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onChildTitleChangedAyCe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onChildTitleChangedAyCe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onChildTitleChanged(Activity, CharSequence)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onChildTitleChanged", Activity.class,
+                        CharSequence.class);
+                mMethodImplementingPlugins
+                        .put("onChildTitleChanged(Activity, CharSequence)", implementingPlugins);
+                mIsOverridden_onChildTitleChangedAyCe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Activity, CharSequence> superCall = new CallVoid2<Activity, CharSequence>(
                 "onChildTitleChanged(Activity, CharSequence)") {
@@ -3070,12 +6532,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onConfigurationChanged(final Configuration newConfig) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onConfigurationChangedCn) {
             getOriginal().super_onConfigurationChanged(newConfig);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onConfigurationChangedCn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onConfigurationChangedCn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onConfigurationChanged(Configuration)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onConfigurationChanged",
+                        Configuration.class);
+                mMethodImplementingPlugins
+                        .put("onConfigurationChanged(Configuration)", implementingPlugins);
+                mIsOverridden_onConfigurationChangedCn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Configuration> superCall = new CallVoid1<Configuration>(
                 "onConfigurationChanged(Configuration)") {
@@ -3093,12 +6571,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onContentChanged() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onContentChanged) {
             getOriginal().super_onContentChanged();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onContentChanged < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onContentChanged++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onContentChanged()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onContentChanged");
+                mMethodImplementingPlugins.put("onContentChanged()", implementingPlugins);
+                mIsOverridden_onContentChanged = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onContentChanged()") {
 
@@ -3115,11 +6607,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onContextItemSelected(final MenuItem item) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onContextItemSelectedMm) {
             return getOriginal().super_onContextItemSelected(item);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onContextItemSelectedMm < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onContextItemSelectedMm++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onContextItemSelected(MenuItem)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onContextItemSelected",
+                        MenuItem.class);
+                mMethodImplementingPlugins
+                        .put("onContextItemSelected(MenuItem)", implementingPlugins);
+                mIsOverridden_onContextItemSelectedMm = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onContextItemSelected(MenuItem)") {
@@ -3137,12 +6645,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onContextMenuClosed(final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onContextMenuClosedMu) {
             getOriginal().super_onContextMenuClosed(menu);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onContextMenuClosedMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onContextMenuClosedMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onContextMenuClosed(Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onContextMenuClosed", Menu.class);
+                mMethodImplementingPlugins.put("onContextMenuClosed(Menu)", implementingPlugins);
+                mIsOverridden_onContextMenuClosedMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onContextMenuClosed(Menu)") {
 
@@ -3159,12 +6681,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onCreate(final Bundle savedInstanceState, final PersistableBundle persistentState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateBePe) {
             getOriginal().super_onCreate(savedInstanceState, persistentState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateBePe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateBePe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreate(Bundle, PersistableBundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreate", Bundle.class,
+                        PersistableBundle.class);
+                mMethodImplementingPlugins
+                        .put("onCreate(Bundle, PersistableBundle)", implementingPlugins);
+                mIsOverridden_onCreateBePe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Bundle, PersistableBundle> superCall
                 = new CallVoid2<Bundle, PersistableBundle>("onCreate(Bundle, PersistableBundle)") {
@@ -3183,12 +6721,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateBe) {
             getOriginal().super_onCreate(savedInstanceState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreate(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreate", Bundle.class);
+                mMethodImplementingPlugins.put("onCreate(Bundle)", implementingPlugins);
+                mIsOverridden_onCreateBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onCreate(Bundle)") {
 
@@ -3206,12 +6758,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateContextMenuCuVwCo) {
             getOriginal().super_onCreateContextMenu(menu, v, menuInfo);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateContextMenuCuVwCo < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateContextMenuCuVwCo++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateContextMenu",
+                        ContextMenu.class, View.class, ContextMenu.ContextMenuInfo.class);
+                mMethodImplementingPlugins
+                        .put("onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)",
+                                implementingPlugins);
+                mIsOverridden_onCreateContextMenuCuVwCo = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo> superCall
                 = new CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo>(
@@ -3231,11 +6800,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public CharSequence onCreateDescription() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateDescription) {
             return getOriginal().super_onCreateDescription();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateDescription < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateDescription++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateDescription()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateDescription");
+                mMethodImplementingPlugins.put("onCreateDescription()", implementingPlugins);
+                mIsOverridden_onCreateDescription = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<CharSequence> superCall = new CallFun0<CharSequence>(
                 "onCreateDescription()") {
@@ -3253,11 +6836,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Dialog onCreateDialog(final int id) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateDialogIr) {
             return getOriginal().super_onCreateDialog(id);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateDialogIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateDialogIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateDialog(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateDialog", Integer.class);
+                mMethodImplementingPlugins.put("onCreateDialog(Integer)", implementingPlugins);
+                mIsOverridden_onCreateDialogIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Dialog, Integer> superCall = new CallFun1<Dialog, Integer>(
                 "onCreateDialog(Integer)") {
@@ -3275,11 +6872,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Dialog onCreateDialog(final int id, final Bundle args) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateDialogIrBe) {
             return getOriginal().super_onCreateDialog(id, args);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateDialogIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateDialogIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateDialog(Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateDialog", Integer.class,
+                        Bundle.class);
+                mMethodImplementingPlugins
+                        .put("onCreateDialog(Integer, Bundle)", implementingPlugins);
+                mIsOverridden_onCreateDialogIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Dialog, Integer, Bundle> superCall = new CallFun2<Dialog, Integer, Bundle>(
                 "onCreateDialog(Integer, Bundle)") {
@@ -3297,12 +6910,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onCreateNavigateUpTaskStack(final TaskStackBuilder builder) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateNavigateUpTaskStackTr) {
             getOriginal().super_onCreateNavigateUpTaskStack(builder);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateNavigateUpTaskStackTr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateNavigateUpTaskStackTr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateNavigateUpTaskStack(TaskStackBuilder)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateNavigateUpTaskStack",
+                        TaskStackBuilder.class);
+                mMethodImplementingPlugins
+                        .put("onCreateNavigateUpTaskStack(TaskStackBuilder)", implementingPlugins);
+                mIsOverridden_onCreateNavigateUpTaskStackTr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<TaskStackBuilder> superCall = new CallVoid1<TaskStackBuilder>(
                 "onCreateNavigateUpTaskStack(TaskStackBuilder)") {
@@ -3320,11 +6949,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onCreateOptionsMenu(final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateOptionsMenuMu) {
             return getOriginal().super_onCreateOptionsMenu(menu);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateOptionsMenuMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateOptionsMenuMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateOptionsMenu(Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateOptionsMenu", Menu.class);
+                mMethodImplementingPlugins.put("onCreateOptionsMenu(Menu)", implementingPlugins);
+                mIsOverridden_onCreateOptionsMenuMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Menu> superCall = new CallFun1<Boolean, Menu>(
                 "onCreateOptionsMenu(Menu)") {
@@ -3342,11 +6985,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onCreatePanelMenu(final int featureId, final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreatePanelMenuIrMu) {
             return getOriginal().super_onCreatePanelMenu(featureId, menu);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreatePanelMenuIrMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreatePanelMenuIrMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreatePanelMenu(Integer, Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreatePanelMenu", Integer.class,
+                        Menu.class);
+                mMethodImplementingPlugins
+                        .put("onCreatePanelMenu(Integer, Menu)", implementingPlugins);
+                mIsOverridden_onCreatePanelMenuIrMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Integer, Menu> superCall = new CallFun2<Boolean, Integer, Menu>(
                 "onCreatePanelMenu(Integer, Menu)") {
@@ -3364,11 +7023,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public View onCreatePanelView(final int featureId) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreatePanelViewIr) {
             return getOriginal().super_onCreatePanelView(featureId);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreatePanelViewIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreatePanelViewIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreatePanelView(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreatePanelView", Integer.class);
+                mMethodImplementingPlugins.put("onCreatePanelView(Integer)", implementingPlugins);
+                mIsOverridden_onCreatePanelViewIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<View, Integer> superCall = new CallFun1<View, Integer>(
                 "onCreatePanelView(Integer)") {
@@ -3387,12 +7060,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onCreateSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateSupportNavigateUpTaskStackar) {
             getOriginal().super_onCreateSupportNavigateUpTaskStack(builder);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateSupportNavigateUpTaskStackar < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateSupportNavigateUpTaskStackar++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateSupportNavigateUpTaskStack",
+                        android.support.v4.app.TaskStackBuilder.class);
+                mMethodImplementingPlugins
+                        .put("onCreateSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)",
+                                implementingPlugins);
+                mIsOverridden_onCreateSupportNavigateUpTaskStackar = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.support.v4.app.TaskStackBuilder> superCall
                 = new CallVoid1<android.support.v4.app.TaskStackBuilder>(
@@ -3411,11 +7101,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onCreateThumbnail(final Bitmap outBitmap, final Canvas canvas) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateThumbnailBpCs) {
             return getOriginal().super_onCreateThumbnail(outBitmap, canvas);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateThumbnailBpCs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateThumbnailBpCs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateThumbnail(Bitmap, Canvas)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateThumbnail", Bitmap.class,
+                        Canvas.class);
+                mMethodImplementingPlugins
+                        .put("onCreateThumbnail(Bitmap, Canvas)", implementingPlugins);
+                mIsOverridden_onCreateThumbnailBpCs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Bitmap, Canvas> superCall = new CallFun2<Boolean, Bitmap, Canvas>(
                 "onCreateThumbnail(Bitmap, Canvas)") {
@@ -3434,11 +7140,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public View onCreateView(final View parent, final String name, final Context context,
             final AttributeSet attrs) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateViewVwSgCtAt) {
             return getOriginal().super_onCreateView(parent, name, context, attrs);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateViewVwSgCtAt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateViewVwSgCtAt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateView(View, String, Context, AttributeSet)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateView", View.class,
+                        String.class, Context.class, AttributeSet.class);
+                mMethodImplementingPlugins.put("onCreateView(View, String, Context, AttributeSet)",
+                        implementingPlugins);
+                mIsOverridden_onCreateViewVwSgCtAt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun4<View, View, String, Context, AttributeSet> superCall
                 = new CallFun4<View, View, String, Context, AttributeSet>(
@@ -3458,11 +7180,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public View onCreateView(final String name, final Context context, final AttributeSet attrs) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateViewSgCtAt) {
             return getOriginal().super_onCreateView(name, context, attrs);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onCreateViewSgCtAt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateViewSgCtAt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateView(String, Context, AttributeSet)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateView", String.class,
+                        Context.class, AttributeSet.class);
+                mMethodImplementingPlugins
+                        .put("onCreateView(String, Context, AttributeSet)", implementingPlugins);
+                mIsOverridden_onCreateViewSgCtAt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<View, String, Context, AttributeSet> superCall
                 = new CallFun3<View, String, Context, AttributeSet>(
@@ -3481,12 +7219,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onDestroy() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onDestroy) {
             getOriginal().super_onDestroy();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onDestroy < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onDestroy++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onDestroy()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onDestroy");
+                mMethodImplementingPlugins.put("onDestroy()", implementingPlugins);
+                mIsOverridden_onDestroy = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onDestroy()") {
 
@@ -3503,12 +7255,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onDetachedFromWindow() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onDetachedFromWindow) {
             getOriginal().super_onDetachedFromWindow();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onDetachedFromWindow < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onDetachedFromWindow++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onDetachedFromWindow()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onDetachedFromWindow");
+                mMethodImplementingPlugins.put("onDetachedFromWindow()", implementingPlugins);
+                mIsOverridden_onDetachedFromWindow = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onDetachedFromWindow()") {
 
@@ -3525,12 +7291,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onEnterAnimationComplete() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onEnterAnimationComplete) {
             getOriginal().super_onEnterAnimationComplete();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onEnterAnimationComplete < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onEnterAnimationComplete++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onEnterAnimationComplete()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onEnterAnimationComplete");
+                mMethodImplementingPlugins.put("onEnterAnimationComplete()", implementingPlugins);
+                mIsOverridden_onEnterAnimationComplete = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onEnterAnimationComplete()") {
 
@@ -3547,11 +7327,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onGenericMotionEvent(final MotionEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onGenericMotionEventMt) {
             return getOriginal().super_onGenericMotionEvent(event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onGenericMotionEventMt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onGenericMotionEventMt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onGenericMotionEvent(MotionEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onGenericMotionEvent",
+                        MotionEvent.class);
+                mMethodImplementingPlugins
+                        .put("onGenericMotionEvent(MotionEvent)", implementingPlugins);
+                mIsOverridden_onGenericMotionEventMt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "onGenericMotionEvent(MotionEvent)") {
@@ -3569,11 +7365,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onKeyDown(final int keyCode, final KeyEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onKeyDownIrKt) {
             return getOriginal().super_onKeyDown(keyCode, event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onKeyDownIrKt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onKeyDownIrKt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onKeyDown(Integer, KeyEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onKeyDown", Integer.class,
+                        KeyEvent.class);
+                mMethodImplementingPlugins.put("onKeyDown(Integer, KeyEvent)", implementingPlugins);
+                mIsOverridden_onKeyDownIrKt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Integer, KeyEvent> superCall
                 = new CallFun2<Boolean, Integer, KeyEvent>("onKeyDown(Integer, KeyEvent)") {
@@ -3591,11 +7402,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onKeyLongPress(final int keyCode, final KeyEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onKeyLongPressIrKt) {
             return getOriginal().super_onKeyLongPress(keyCode, event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onKeyLongPressIrKt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onKeyLongPressIrKt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onKeyLongPress(Integer, KeyEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onKeyLongPress", Integer.class,
+                        KeyEvent.class);
+                mMethodImplementingPlugins
+                        .put("onKeyLongPress(Integer, KeyEvent)", implementingPlugins);
+                mIsOverridden_onKeyLongPressIrKt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Integer, KeyEvent> superCall
                 = new CallFun2<Boolean, Integer, KeyEvent>("onKeyLongPress(Integer, KeyEvent)") {
@@ -3613,11 +7440,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onKeyMultiple(final int keyCode, final int repeatCount, final KeyEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onKeyMultipleIrIrKt) {
             return getOriginal().super_onKeyMultiple(keyCode, repeatCount, event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onKeyMultipleIrIrKt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onKeyMultipleIrIrKt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onKeyMultiple(Integer, Integer, KeyEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onKeyMultiple", Integer.class,
+                        Integer.class, KeyEvent.class);
+                mMethodImplementingPlugins
+                        .put("onKeyMultiple(Integer, Integer, KeyEvent)", implementingPlugins);
+                mIsOverridden_onKeyMultipleIrIrKt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<Boolean, Integer, Integer, KeyEvent> superCall
                 = new CallFun3<Boolean, Integer, Integer, KeyEvent>(
@@ -3637,11 +7480,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onKeyShortcut(final int keyCode, final KeyEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onKeyShortcutIrKt) {
             return getOriginal().super_onKeyShortcut(keyCode, event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onKeyShortcutIrKt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onKeyShortcutIrKt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onKeyShortcut(Integer, KeyEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onKeyShortcut", Integer.class,
+                        KeyEvent.class);
+                mMethodImplementingPlugins
+                        .put("onKeyShortcut(Integer, KeyEvent)", implementingPlugins);
+                mIsOverridden_onKeyShortcutIrKt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Integer, KeyEvent> superCall
                 = new CallFun2<Boolean, Integer, KeyEvent>("onKeyShortcut(Integer, KeyEvent)") {
@@ -3659,11 +7518,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onKeyUp(final int keyCode, final KeyEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onKeyUpIrKt) {
             return getOriginal().super_onKeyUp(keyCode, event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onKeyUpIrKt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onKeyUpIrKt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onKeyUp(Integer, KeyEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onKeyUp", Integer.class,
+                        KeyEvent.class);
+                mMethodImplementingPlugins.put("onKeyUp(Integer, KeyEvent)", implementingPlugins);
+                mIsOverridden_onKeyUpIrKt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Integer, KeyEvent> superCall
                 = new CallFun2<Boolean, Integer, KeyEvent>("onKeyUp(Integer, KeyEvent)") {
@@ -3681,12 +7555,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onLowMemory() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onLowMemory) {
             getOriginal().super_onLowMemory();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onLowMemory < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onLowMemory++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onLowMemory()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onLowMemory");
+                mMethodImplementingPlugins.put("onLowMemory()", implementingPlugins);
+                mIsOverridden_onLowMemory = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onLowMemory()") {
 
@@ -3703,11 +7591,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onMenuOpened(final int featureId, final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onMenuOpenedIrMu) {
             return getOriginal().super_onMenuOpened(featureId, menu);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onMenuOpenedIrMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onMenuOpenedIrMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onMenuOpened(Integer, Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onMenuOpened", Integer.class,
+                        Menu.class);
+                mMethodImplementingPlugins.put("onMenuOpened(Integer, Menu)", implementingPlugins);
+                mIsOverridden_onMenuOpenedIrMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Integer, Menu> superCall = new CallFun2<Boolean, Integer, Menu>(
                 "onMenuOpened(Integer, Menu)") {
@@ -3725,11 +7628,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onNavigateUp() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onNavigateUp) {
             return getOriginal().super_onNavigateUp();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onNavigateUp < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onNavigateUp++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onNavigateUp()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onNavigateUp");
+                mMethodImplementingPlugins.put("onNavigateUp()", implementingPlugins);
+                mIsOverridden_onNavigateUp = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("onNavigateUp()") {
 
@@ -3746,11 +7663,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onNavigateUpFromChild(final Activity child) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onNavigateUpFromChildAy) {
             return getOriginal().super_onNavigateUpFromChild(child);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onNavigateUpFromChildAy < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onNavigateUpFromChildAy++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onNavigateUpFromChild(Activity)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onNavigateUpFromChild",
+                        Activity.class);
+                mMethodImplementingPlugins
+                        .put("onNavigateUpFromChild(Activity)", implementingPlugins);
+                mIsOverridden_onNavigateUpFromChildAy = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Activity> superCall = new CallFun1<Boolean, Activity>(
                 "onNavigateUpFromChild(Activity)") {
@@ -3768,12 +7701,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onNewIntent(final Intent intent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onNewIntentIt) {
             getOriginal().super_onNewIntent(intent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onNewIntentIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onNewIntentIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onNewIntent(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onNewIntent", Intent.class);
+                mMethodImplementingPlugins.put("onNewIntent(Intent)", implementingPlugins);
+                mIsOverridden_onNewIntentIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("onNewIntent(Intent)") {
 
@@ -3790,11 +7737,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onOptionsItemSelected(final MenuItem item) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onOptionsItemSelectedMm) {
             return getOriginal().super_onOptionsItemSelected(item);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onOptionsItemSelectedMm < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onOptionsItemSelectedMm++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onOptionsItemSelected(MenuItem)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onOptionsItemSelected",
+                        MenuItem.class);
+                mMethodImplementingPlugins
+                        .put("onOptionsItemSelected(MenuItem)", implementingPlugins);
+                mIsOverridden_onOptionsItemSelectedMm = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onOptionsItemSelected(MenuItem)") {
@@ -3812,12 +7775,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onOptionsMenuClosed(final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onOptionsMenuClosedMu) {
             getOriginal().super_onOptionsMenuClosed(menu);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onOptionsMenuClosedMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onOptionsMenuClosedMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onOptionsMenuClosed(Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onOptionsMenuClosed", Menu.class);
+                mMethodImplementingPlugins.put("onOptionsMenuClosed(Menu)", implementingPlugins);
+                mIsOverridden_onOptionsMenuClosedMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onOptionsMenuClosed(Menu)") {
 
@@ -3834,12 +7811,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onPanelClosed(final int featureId, final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPanelClosedIrMu) {
             getOriginal().super_onPanelClosed(featureId, menu);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPanelClosedIrMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPanelClosedIrMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPanelClosed(Integer, Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPanelClosed", Integer.class,
+                        Menu.class);
+                mMethodImplementingPlugins.put("onPanelClosed(Integer, Menu)", implementingPlugins);
+                mIsOverridden_onPanelClosedIrMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Integer, Menu> superCall = new CallVoid2<Integer, Menu>(
                 "onPanelClosed(Integer, Menu)") {
@@ -3857,12 +7849,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onPause() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPause) {
             getOriginal().super_onPause();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPause < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPause++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("onPause()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPause");
+                mMethodImplementingPlugins.put("onPause()", implementingPlugins);
+                mIsOverridden_onPause = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onPause()") {
 
@@ -3880,12 +7885,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onPostCreate(final Bundle savedInstanceState,
             final PersistableBundle persistentState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPostCreateBePe) {
             getOriginal().super_onPostCreate(savedInstanceState, persistentState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPostCreateBePe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPostCreateBePe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPostCreate(Bundle, PersistableBundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPostCreate", Bundle.class,
+                        PersistableBundle.class);
+                mMethodImplementingPlugins
+                        .put("onPostCreate(Bundle, PersistableBundle)", implementingPlugins);
+                mIsOverridden_onPostCreateBePe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Bundle, PersistableBundle> superCall
                 = new CallVoid2<Bundle, PersistableBundle>(
@@ -3905,12 +7926,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onPostCreate(@Nullable final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPostCreateBe) {
             getOriginal().super_onPostCreate(savedInstanceState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPostCreateBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPostCreateBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPostCreate(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPostCreate", Bundle.class);
+                mMethodImplementingPlugins.put("onPostCreate(Bundle)", implementingPlugins);
+                mIsOverridden_onPostCreateBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onPostCreate(Bundle)") {
 
@@ -3927,12 +7962,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onPostResume() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPostResume) {
             getOriginal().super_onPostResume();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPostResume < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPostResume++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPostResume()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPostResume");
+                mMethodImplementingPlugins.put("onPostResume()", implementingPlugins);
+                mIsOverridden_onPostResume = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onPostResume()") {
 
@@ -3949,12 +7998,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onPrepareDialog(final int id, final Dialog dialog) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPrepareDialogIrDg) {
             getOriginal().super_onPrepareDialog(id, dialog);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPrepareDialogIrDg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPrepareDialogIrDg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPrepareDialog(Integer, Dialog)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPrepareDialog", Integer.class,
+                        Dialog.class);
+                mMethodImplementingPlugins
+                        .put("onPrepareDialog(Integer, Dialog)", implementingPlugins);
+                mIsOverridden_onPrepareDialogIrDg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Integer, Dialog> superCall = new CallVoid2<Integer, Dialog>(
                 "onPrepareDialog(Integer, Dialog)") {
@@ -3972,12 +8037,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onPrepareDialog(final int id, final Dialog dialog, final Bundle args) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPrepareDialogIrDgBe) {
             getOriginal().super_onPrepareDialog(id, dialog, args);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPrepareDialogIrDgBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPrepareDialogIrDgBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPrepareDialog(Integer, Dialog, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPrepareDialog", Integer.class,
+                        Dialog.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("onPrepareDialog(Integer, Dialog, Bundle)", implementingPlugins);
+                mIsOverridden_onPrepareDialogIrDgBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Integer, Dialog, Bundle> superCall = new CallVoid3<Integer, Dialog, Bundle>(
                 "onPrepareDialog(Integer, Dialog, Bundle)") {
@@ -3995,12 +8076,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onPrepareNavigateUpTaskStack(final TaskStackBuilder builder) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPrepareNavigateUpTaskStackTr) {
             getOriginal().super_onPrepareNavigateUpTaskStack(builder);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPrepareNavigateUpTaskStackTr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPrepareNavigateUpTaskStackTr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPrepareNavigateUpTaskStack(TaskStackBuilder)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPrepareNavigateUpTaskStack",
+                        TaskStackBuilder.class);
+                mMethodImplementingPlugins
+                        .put("onPrepareNavigateUpTaskStack(TaskStackBuilder)", implementingPlugins);
+                mIsOverridden_onPrepareNavigateUpTaskStackTr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<TaskStackBuilder> superCall = new CallVoid1<TaskStackBuilder>(
                 "onPrepareNavigateUpTaskStack(TaskStackBuilder)") {
@@ -4018,11 +8115,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onPrepareOptionsMenu(final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPrepareOptionsMenuMu) {
             return getOriginal().super_onPrepareOptionsMenu(menu);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPrepareOptionsMenuMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPrepareOptionsMenuMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPrepareOptionsMenu(Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPrepareOptionsMenu", Menu.class);
+                mMethodImplementingPlugins.put("onPrepareOptionsMenu(Menu)", implementingPlugins);
+                mIsOverridden_onPrepareOptionsMenuMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Menu> superCall = new CallFun1<Boolean, Menu>(
                 "onPrepareOptionsMenu(Menu)") {
@@ -4040,11 +8151,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onPrepareOptionsPanel(final View view, final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPrepareOptionsPanelVwMu) {
             return getOriginal().super_onPrepareOptionsPanel(view, menu);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPrepareOptionsPanelVwMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPrepareOptionsPanelVwMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPrepareOptionsPanel(View, Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPrepareOptionsPanel", View.class,
+                        Menu.class);
+                mMethodImplementingPlugins
+                        .put("onPrepareOptionsPanel(View, Menu)", implementingPlugins);
+                mIsOverridden_onPrepareOptionsPanelVwMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, View, Menu> superCall = new CallFun2<Boolean, View, Menu>(
                 "onPrepareOptionsPanel(View, Menu)") {
@@ -4062,11 +8189,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onPreparePanel(final int featureId, final View view, final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPreparePanelIrVwMu) {
             return getOriginal().super_onPreparePanel(featureId, view, menu);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPreparePanelIrVwMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPreparePanelIrVwMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPreparePanel(Integer, View, Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPreparePanel", Integer.class,
+                        View.class, Menu.class);
+                mMethodImplementingPlugins
+                        .put("onPreparePanel(Integer, View, Menu)", implementingPlugins);
+                mIsOverridden_onPreparePanelIrVwMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<Boolean, Integer, View, Menu> superCall
                 = new CallFun3<Boolean, Integer, View, Menu>(
@@ -4086,12 +8229,30 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onPrepareSupportNavigateUpTaskStack(
             @NonNull final android.support.v4.app.TaskStackBuilder builder) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPrepareSupportNavigateUpTaskStackar) {
             getOriginal().super_onPrepareSupportNavigateUpTaskStack(builder);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onPrepareSupportNavigateUpTaskStackar < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPrepareSupportNavigateUpTaskStackar++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPrepareSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPrepareSupportNavigateUpTaskStack",
+                        android.support.v4.app.TaskStackBuilder.class);
+                mMethodImplementingPlugins
+                        .put("onPrepareSupportNavigateUpTaskStack(android.support.v4.app.TaskStackBuilder)",
+                                implementingPlugins);
+                mIsOverridden_onPrepareSupportNavigateUpTaskStackar = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.support.v4.app.TaskStackBuilder> superCall
                 = new CallVoid1<android.support.v4.app.TaskStackBuilder>(
@@ -4110,12 +8271,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onProvideAssistContent(final AssistContent outContent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onProvideAssistContentAt) {
             getOriginal().super_onProvideAssistContent(outContent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onProvideAssistContentAt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onProvideAssistContentAt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onProvideAssistContent(AssistContent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onProvideAssistContent",
+                        AssistContent.class);
+                mMethodImplementingPlugins
+                        .put("onProvideAssistContent(AssistContent)", implementingPlugins);
+                mIsOverridden_onProvideAssistContentAt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<AssistContent> superCall = new CallVoid1<AssistContent>(
                 "onProvideAssistContent(AssistContent)") {
@@ -4133,12 +8310,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onProvideAssistData(final Bundle data) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onProvideAssistDataBe) {
             getOriginal().super_onProvideAssistData(data);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onProvideAssistDataBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onProvideAssistDataBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onProvideAssistData(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onProvideAssistData", Bundle.class);
+                mMethodImplementingPlugins.put("onProvideAssistData(Bundle)", implementingPlugins);
+                mIsOverridden_onProvideAssistDataBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onProvideAssistData(Bundle)") {
 
@@ -4155,11 +8346,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Uri onProvideReferrer() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onProvideReferrer) {
             return getOriginal().super_onProvideReferrer();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onProvideReferrer < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onProvideReferrer++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onProvideReferrer()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onProvideReferrer");
+                mMethodImplementingPlugins.put("onProvideReferrer()", implementingPlugins);
+                mIsOverridden_onProvideReferrer = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Uri> superCall = new CallFun0<Uri>("onProvideReferrer()") {
 
@@ -4177,12 +8382,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onRequestPermissionsResultIrSgit) {
             getOriginal().super_onRequestPermissionsResult(requestCode, permissions, grantResults);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onRequestPermissionsResultIrSgit < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onRequestPermissionsResultIrSgit++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onRequestPermissionsResult(Integer, String[], int[])");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onRequestPermissionsResult",
+                        Integer.class, String[].class, int[].class);
+                mMethodImplementingPlugins
+                        .put("onRequestPermissionsResult(Integer, String[], int[])",
+                                implementingPlugins);
+                mIsOverridden_onRequestPermissionsResultIrSgit = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Integer, String[], int[]> superCall
                 = new CallVoid3<Integer, String[], int[]>(
@@ -4204,12 +8426,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onRestart() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onRestart) {
             getOriginal().super_onRestart();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onRestart < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onRestart++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onRestart()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onRestart");
+                mMethodImplementingPlugins.put("onRestart()", implementingPlugins);
+                mIsOverridden_onRestart = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onRestart()") {
 
@@ -4227,12 +8463,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onRestoreInstanceState(final Bundle savedInstanceState,
             final PersistableBundle persistentState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onRestoreInstanceStateBePe) {
             getOriginal().super_onRestoreInstanceState(savedInstanceState, persistentState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onRestoreInstanceStateBePe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onRestoreInstanceStateBePe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onRestoreInstanceState(Bundle, PersistableBundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onRestoreInstanceState", Bundle.class,
+                        PersistableBundle.class);
+                mMethodImplementingPlugins.put("onRestoreInstanceState(Bundle, PersistableBundle)",
+                        implementingPlugins);
+                mIsOverridden_onRestoreInstanceStateBePe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Bundle, PersistableBundle> superCall
                 = new CallVoid2<Bundle, PersistableBundle>(
@@ -4253,12 +8505,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onRestoreInstanceState(final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onRestoreInstanceStateBe) {
             getOriginal().super_onRestoreInstanceState(savedInstanceState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onRestoreInstanceStateBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onRestoreInstanceStateBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onRestoreInstanceState(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onRestoreInstanceState",
+                        Bundle.class);
+                mMethodImplementingPlugins
+                        .put("onRestoreInstanceState(Bundle)", implementingPlugins);
+                mIsOverridden_onRestoreInstanceStateBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>(
                 "onRestoreInstanceState(Bundle)") {
@@ -4276,12 +8544,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onResume() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onResume) {
             getOriginal().super_onResume();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onResume < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onResume++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("onResume()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onResume");
+                mMethodImplementingPlugins.put("onResume()", implementingPlugins);
+                mIsOverridden_onResume = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onResume()") {
 
@@ -4298,12 +8579,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onResumeFragments() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onResumeFragments) {
             getOriginal().super_onResumeFragments();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onResumeFragments < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onResumeFragments++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onResumeFragments()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onResumeFragments");
+                mMethodImplementingPlugins.put("onResumeFragments()", implementingPlugins);
+                mIsOverridden_onResumeFragments = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onResumeFragments()") {
 
@@ -4334,12 +8629,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void onSaveInstanceState(final Bundle outState,
             final PersistableBundle outPersistentState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSaveInstanceStateBePe) {
             getOriginal().super_onSaveInstanceState(outState, outPersistentState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSaveInstanceStateBePe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSaveInstanceStateBePe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSaveInstanceState(Bundle, PersistableBundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSaveInstanceState", Bundle.class,
+                        PersistableBundle.class);
+                mMethodImplementingPlugins
+                        .put("onSaveInstanceState(Bundle, PersistableBundle)", implementingPlugins);
+                mIsOverridden_onSaveInstanceStateBePe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Bundle, PersistableBundle> superCall
                 = new CallVoid2<Bundle, PersistableBundle>(
@@ -4358,12 +8669,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onSaveInstanceState(final Bundle outState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSaveInstanceStateBe) {
             getOriginal().super_onSaveInstanceState(outState);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSaveInstanceStateBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSaveInstanceStateBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSaveInstanceState(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSaveInstanceState", Bundle.class);
+                mMethodImplementingPlugins.put("onSaveInstanceState(Bundle)", implementingPlugins);
+                mIsOverridden_onSaveInstanceStateBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onSaveInstanceState(Bundle)") {
 
@@ -4380,11 +8705,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onSearchRequested(final SearchEvent searchEvent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSearchRequestedSt) {
             return getOriginal().super_onSearchRequested(searchEvent);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSearchRequestedSt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSearchRequestedSt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSearchRequested(SearchEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSearchRequested",
+                        SearchEvent.class);
+                mMethodImplementingPlugins
+                        .put("onSearchRequested(SearchEvent)", implementingPlugins);
+                mIsOverridden_onSearchRequestedSt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, SearchEvent> superCall = new CallFun1<Boolean, SearchEvent>(
                 "onSearchRequested(SearchEvent)") {
@@ -4402,11 +8743,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onSearchRequested() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSearchRequested) {
             return getOriginal().super_onSearchRequested();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSearchRequested < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSearchRequested++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSearchRequested()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSearchRequested");
+                mMethodImplementingPlugins.put("onSearchRequested()", implementingPlugins);
+                mIsOverridden_onSearchRequested = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("onSearchRequested()") {
 
@@ -4423,12 +8778,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onStart() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onStart) {
             getOriginal().super_onStart();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onStart < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onStart++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("onStart()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onStart");
+                mMethodImplementingPlugins.put("onStart()", implementingPlugins);
+                mIsOverridden_onStart = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onStart()") {
 
@@ -4445,12 +8813,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onStateNotSaved() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onStateNotSaved) {
             getOriginal().super_onStateNotSaved();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onStateNotSaved < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onStateNotSaved++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onStateNotSaved()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onStateNotSaved");
+                mMethodImplementingPlugins.put("onStateNotSaved()", implementingPlugins);
+                mIsOverridden_onStateNotSaved = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onStateNotSaved()") {
 
@@ -4467,12 +8849,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onStop() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onStop) {
             getOriginal().super_onStop();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onStop < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onStop++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("onStop()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onStop");
+                mMethodImplementingPlugins.put("onStop()", implementingPlugins);
+                mIsOverridden_onStop = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onStop()") {
 
@@ -4489,12 +8884,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onSupportActionModeFinished(@NonNull final ActionMode mode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSupportActionModeFinishedAe) {
             getOriginal().super_onSupportActionModeFinished(mode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSupportActionModeFinishedAe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSupportActionModeFinishedAe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSupportActionModeFinished(ActionMode)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSupportActionModeFinished",
+                        ActionMode.class);
+                mMethodImplementingPlugins
+                        .put("onSupportActionModeFinished(ActionMode)", implementingPlugins);
+                mIsOverridden_onSupportActionModeFinishedAe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<ActionMode> superCall = new CallVoid1<ActionMode>(
                 "onSupportActionModeFinished(ActionMode)") {
@@ -4512,12 +8923,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onSupportActionModeStarted(@NonNull final ActionMode mode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSupportActionModeStartedAe) {
             getOriginal().super_onSupportActionModeStarted(mode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSupportActionModeStartedAe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSupportActionModeStartedAe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSupportActionModeStarted(ActionMode)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSupportActionModeStarted",
+                        ActionMode.class);
+                mMethodImplementingPlugins
+                        .put("onSupportActionModeStarted(ActionMode)", implementingPlugins);
+                mIsOverridden_onSupportActionModeStartedAe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<ActionMode> superCall = new CallVoid1<ActionMode>(
                 "onSupportActionModeStarted(ActionMode)") {
@@ -4535,12 +8962,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onSupportContentChanged() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSupportContentChanged) {
             getOriginal().super_onSupportContentChanged();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSupportContentChanged < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSupportContentChanged++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSupportContentChanged()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSupportContentChanged");
+                mMethodImplementingPlugins.put("onSupportContentChanged()", implementingPlugins);
+                mIsOverridden_onSupportContentChanged = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onSupportContentChanged()") {
 
@@ -4557,11 +8998,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onSupportNavigateUp() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSupportNavigateUp) {
             return getOriginal().super_onSupportNavigateUp();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onSupportNavigateUp < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSupportNavigateUp++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSupportNavigateUp()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSupportNavigateUp");
+                mMethodImplementingPlugins.put("onSupportNavigateUp()", implementingPlugins);
+                mIsOverridden_onSupportNavigateUp = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("onSupportNavigateUp()") {
 
@@ -4578,12 +9033,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onTitleChanged(final CharSequence title, final int color) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onTitleChangedCeIr) {
             getOriginal().super_onTitleChanged(title, color);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onTitleChangedCeIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onTitleChangedCeIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onTitleChanged(CharSequence, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onTitleChanged", CharSequence.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("onTitleChanged(CharSequence, Integer)", implementingPlugins);
+                mIsOverridden_onTitleChangedCeIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<CharSequence, Integer> superCall = new CallVoid2<CharSequence, Integer>(
                 "onTitleChanged(CharSequence, Integer)") {
@@ -4601,11 +9072,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onTouchEvent(final MotionEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onTouchEventMt) {
             return getOriginal().super_onTouchEvent(event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onTouchEventMt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onTouchEventMt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onTouchEvent(MotionEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onTouchEvent", MotionEvent.class);
+                mMethodImplementingPlugins.put("onTouchEvent(MotionEvent)", implementingPlugins);
+                mIsOverridden_onTouchEventMt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "onTouchEvent(MotionEvent)") {
@@ -4623,11 +9108,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean onTrackballEvent(final MotionEvent event) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onTrackballEventMt) {
             return getOriginal().super_onTrackballEvent(event);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onTrackballEventMt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onTrackballEventMt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onTrackballEvent(MotionEvent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onTrackballEvent", MotionEvent.class);
+                mMethodImplementingPlugins
+                        .put("onTrackballEvent(MotionEvent)", implementingPlugins);
+                mIsOverridden_onTrackballEventMt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MotionEvent> superCall = new CallFun1<Boolean, MotionEvent>(
                 "onTrackballEvent(MotionEvent)") {
@@ -4645,12 +9145,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onTrimMemory(final int level) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onTrimMemoryIr) {
             getOriginal().super_onTrimMemory(level);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onTrimMemoryIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onTrimMemoryIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onTrimMemory(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onTrimMemory", Integer.class);
+                mMethodImplementingPlugins.put("onTrimMemory(Integer)", implementingPlugins);
+                mIsOverridden_onTrimMemoryIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>("onTrimMemory(Integer)") {
 
@@ -4667,12 +9181,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onUserInteraction() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onUserInteraction) {
             getOriginal().super_onUserInteraction();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onUserInteraction < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onUserInteraction++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onUserInteraction()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onUserInteraction");
+                mMethodImplementingPlugins.put("onUserInteraction()", implementingPlugins);
+                mIsOverridden_onUserInteraction = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onUserInteraction()") {
 
@@ -4689,12 +9217,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onUserLeaveHint() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onUserLeaveHint) {
             getOriginal().super_onUserLeaveHint();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onUserLeaveHint < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onUserLeaveHint++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onUserLeaveHint()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onUserLeaveHint");
+                mMethodImplementingPlugins.put("onUserLeaveHint()", implementingPlugins);
+                mIsOverridden_onUserLeaveHint = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onUserLeaveHint()") {
 
@@ -4711,12 +9253,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onVisibleBehindCanceled() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onVisibleBehindCanceled) {
             getOriginal().super_onVisibleBehindCanceled();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onVisibleBehindCanceled < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onVisibleBehindCanceled++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onVisibleBehindCanceled()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onVisibleBehindCanceled");
+                mMethodImplementingPlugins.put("onVisibleBehindCanceled()", implementingPlugins);
+                mIsOverridden_onVisibleBehindCanceled = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onVisibleBehindCanceled()") {
 
@@ -4733,12 +9289,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onWindowAttributesChanged(final WindowManager.LayoutParams params) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onWindowAttributesChangedWs) {
             getOriginal().super_onWindowAttributesChanged(params);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onWindowAttributesChangedWs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onWindowAttributesChangedWs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onWindowAttributesChanged(WindowManager.LayoutParams)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onWindowAttributesChanged",
+                        WindowManager.LayoutParams.class);
+                mMethodImplementingPlugins
+                        .put("onWindowAttributesChanged(WindowManager.LayoutParams)",
+                                implementingPlugins);
+                mIsOverridden_onWindowAttributesChangedWs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<WindowManager.LayoutParams> superCall
                 = new CallVoid1<WindowManager.LayoutParams>(
@@ -4757,12 +9330,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void onWindowFocusChanged(final boolean hasFocus) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onWindowFocusChangedBn) {
             getOriginal().super_onWindowFocusChanged(hasFocus);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onWindowFocusChangedBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onWindowFocusChangedBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onWindowFocusChanged(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onWindowFocusChanged", Boolean.class);
+                mMethodImplementingPlugins
+                        .put("onWindowFocusChanged(Boolean)", implementingPlugins);
+                mIsOverridden_onWindowFocusChangedBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
                 "onWindowFocusChanged(Boolean)") {
@@ -4781,11 +9369,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public android.view.ActionMode onWindowStartingActionMode(
             final android.view.ActionMode.Callback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onWindowStartingActionModeak) {
             return getOriginal().super_onWindowStartingActionMode(callback);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onWindowStartingActionModeak < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onWindowStartingActionModeak++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onWindowStartingActionMode(android.view.ActionMode.Callback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onWindowStartingActionMode",
+                        android.view.ActionMode.Callback.class);
+                mMethodImplementingPlugins
+                        .put("onWindowStartingActionMode(android.view.ActionMode.Callback)",
+                                implementingPlugins);
+                mIsOverridden_onWindowStartingActionModeak = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<android.view.ActionMode, android.view.ActionMode.Callback> superCall
                 = new CallFun1<android.view.ActionMode, android.view.ActionMode.Callback>(
@@ -4805,11 +9410,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public android.view.ActionMode onWindowStartingActionMode(
             final android.view.ActionMode.Callback callback, final int type) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onWindowStartingActionModeakIr) {
             return getOriginal().super_onWindowStartingActionMode(callback, type);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onWindowStartingActionModeakIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onWindowStartingActionModeakIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onWindowStartingActionMode(android.view.ActionMode.Callback, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onWindowStartingActionMode",
+                        android.view.ActionMode.Callback.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("onWindowStartingActionMode(android.view.ActionMode.Callback, Integer)",
+                                implementingPlugins);
+                mIsOverridden_onWindowStartingActionModeakIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer> superCall
                 = new CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer>(
@@ -4830,11 +9452,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public ActionMode onWindowStartingSupportActionMode(
             @NonNull final ActionMode.Callback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onWindowStartingSupportActionModeAk) {
             return getOriginal().super_onWindowStartingSupportActionMode(callback);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_onWindowStartingSupportActionModeAk < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onWindowStartingSupportActionModeAk++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onWindowStartingSupportActionMode(ActionMode.Callback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onWindowStartingSupportActionMode",
+                        ActionMode.Callback.class);
+                mMethodImplementingPlugins
+                        .put("onWindowStartingSupportActionMode(ActionMode.Callback)",
+                                implementingPlugins);
+                mIsOverridden_onWindowStartingSupportActionModeAk = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<ActionMode, ActionMode.Callback> superCall
                 = new CallFun1<ActionMode, ActionMode.Callback>(
@@ -4853,12 +9492,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void openContextMenu(final View view) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_openContextMenuVw) {
             getOriginal().super_openContextMenu(view);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_openContextMenuVw < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_openContextMenuVw++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("openContextMenu(View)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("openContextMenu", View.class);
+                mMethodImplementingPlugins.put("openContextMenu(View)", implementingPlugins);
+                mIsOverridden_openContextMenuVw = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<View> superCall = new CallVoid1<View>("openContextMenu(View)") {
 
@@ -4875,15 +9528,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public FileInputStream openFileInput(final String name) throws FileNotFoundException {
-        if (mPlugins.isEmpty()) {
-            try {
-                return getOriginal().super_openFileInput(name);
-            } catch (FileNotFoundException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_openFileInputSg) {
+            return getOriginal().super_openFileInput(name);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_openFileInputSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_openFileInputSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("openFileInput(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("openFileInput", String.class);
+                mMethodImplementingPlugins.put("openFileInput(String)", implementingPlugins);
+                mIsOverridden_openFileInputSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<FileInputStream, String> superCall = new CallFun1<FileInputStream, String>(
                 "openFileInput(String)") {
@@ -4910,15 +9573,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public FileOutputStream openFileOutput(final String name, final int mode)
             throws FileNotFoundException {
-        if (mPlugins.isEmpty()) {
-            try {
-                return getOriginal().super_openFileOutput(name, mode);
-            } catch (FileNotFoundException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_openFileOutputSgIr) {
+            return getOriginal().super_openFileOutput(name, mode);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_openFileOutputSgIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_openFileOutputSgIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("openFileOutput(String, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("openFileOutput", String.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("openFileOutput(String, Integer)", implementingPlugins);
+                mIsOverridden_openFileOutputSgIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<FileOutputStream, String, Integer> superCall
                 = new CallFun2<FileOutputStream, String, Integer>(
@@ -4945,12 +9620,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void openOptionsMenu() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_openOptionsMenu) {
             getOriginal().super_openOptionsMenu();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_openOptionsMenu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_openOptionsMenu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("openOptionsMenu()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("openOptionsMenu");
+                mMethodImplementingPlugins.put("openOptionsMenu()", implementingPlugins);
+                mIsOverridden_openOptionsMenu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("openOptionsMenu()") {
 
@@ -4968,11 +9657,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_openOrCreateDatabaseSgIrSy) {
             return getOriginal().super_openOrCreateDatabase(name, mode, factory);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_openOrCreateDatabaseSgIrSy < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_openOrCreateDatabaseSgIrSy++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("openOrCreateDatabase", String.class,
+                        Integer.class, SQLiteDatabase.CursorFactory.class);
+                mMethodImplementingPlugins
+                        .put("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory)",
+                                implementingPlugins);
+                mIsOverridden_openOrCreateDatabaseSgIrSy = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory> superCall
                 = new CallFun3<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory>(
@@ -4993,11 +9699,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public SQLiteDatabase openOrCreateDatabase(final String name, final int mode,
             final SQLiteDatabase.CursorFactory factory, final DatabaseErrorHandler errorHandler) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_openOrCreateDatabaseSgIrSyDr) {
             return getOriginal().super_openOrCreateDatabase(name, mode, factory, errorHandler);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_openOrCreateDatabaseSgIrSyDr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_openOrCreateDatabaseSgIrSyDr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("openOrCreateDatabase", String.class,
+                        Integer.class, SQLiteDatabase.CursorFactory.class,
+                        DatabaseErrorHandler.class);
+                mMethodImplementingPlugins
+                        .put("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)",
+                                implementingPlugins);
+                mIsOverridden_openOrCreateDatabaseSgIrSyDr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun4<SQLiteDatabase, String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler>
                 superCall
@@ -5021,12 +9745,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void overridePendingTransition(final int enterAnim, final int exitAnim) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_overridePendingTransitionIrIr) {
             getOriginal().super_overridePendingTransition(enterAnim, exitAnim);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_overridePendingTransitionIrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_overridePendingTransitionIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("overridePendingTransition(Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("overridePendingTransition",
+                        Integer.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("overridePendingTransition(Integer, Integer)", implementingPlugins);
+                mIsOverridden_overridePendingTransitionIrIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Integer, Integer> superCall = new CallVoid2<Integer, Integer>(
                 "overridePendingTransition(Integer, Integer)") {
@@ -5044,11 +9784,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Drawable peekWallpaper() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_peekWallpaper) {
             return getOriginal().super_peekWallpaper();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_peekWallpaper < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_peekWallpaper++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("peekWallpaper()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("peekWallpaper");
+                mMethodImplementingPlugins.put("peekWallpaper()", implementingPlugins);
+                mIsOverridden_peekWallpaper = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Drawable> superCall = new CallFun0<Drawable>("peekWallpaper()") {
 
@@ -5065,12 +9819,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void postponeEnterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_postponeEnterTransition) {
             getOriginal().super_postponeEnterTransition();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_postponeEnterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_postponeEnterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("postponeEnterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("postponeEnterTransition");
+                mMethodImplementingPlugins.put("postponeEnterTransition()", implementingPlugins);
+                mIsOverridden_postponeEnterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("postponeEnterTransition()") {
 
@@ -5087,12 +9855,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void recreate() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_recreate) {
             getOriginal().super_recreate();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_recreate < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_recreate++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins.get("recreate()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("recreate");
+                mMethodImplementingPlugins.put("recreate()", implementingPlugins);
+                mIsOverridden_recreate = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("recreate()") {
 
@@ -5109,12 +9890,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void registerComponentCallbacks(final ComponentCallbacks callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_registerComponentCallbacksCs) {
             getOriginal().super_registerComponentCallbacks(callback);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_registerComponentCallbacksCs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_registerComponentCallbacksCs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("registerComponentCallbacks(ComponentCallbacks)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("registerComponentCallbacks",
+                        ComponentCallbacks.class);
+                mMethodImplementingPlugins
+                        .put("registerComponentCallbacks(ComponentCallbacks)", implementingPlugins);
+                mIsOverridden_registerComponentCallbacksCs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<ComponentCallbacks> superCall = new CallVoid1<ComponentCallbacks>(
                 "registerComponentCallbacks(ComponentCallbacks)") {
@@ -5132,12 +9929,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void registerForContextMenu(final View view) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_registerForContextMenuVw) {
             getOriginal().super_registerForContextMenu(view);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_registerForContextMenuVw < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_registerForContextMenuVw++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("registerForContextMenu(View)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("registerForContextMenu", View.class);
+                mMethodImplementingPlugins.put("registerForContextMenu(View)", implementingPlugins);
+                mIsOverridden_registerForContextMenuVw = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<View> superCall = new CallVoid1<View>("registerForContextMenu(View)") {
 
@@ -5154,11 +9965,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_registerReceiverBrIr) {
             return getOriginal().super_registerReceiver(receiver, filter);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_registerReceiverBrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_registerReceiverBrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("registerReceiver(BroadcastReceiver, IntentFilter)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("registerReceiver",
+                        BroadcastReceiver.class, IntentFilter.class);
+                mMethodImplementingPlugins.put("registerReceiver(BroadcastReceiver, IntentFilter)",
+                        implementingPlugins);
+                mIsOverridden_registerReceiverBrIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Intent, BroadcastReceiver, IntentFilter> superCall
                 = new CallFun2<Intent, BroadcastReceiver, IntentFilter>(
@@ -5178,12 +10005,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public Intent registerReceiver(final BroadcastReceiver receiver, final IntentFilter filter,
             final String broadcastPermission, final Handler scheduler) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_registerReceiverBrIrSgHr) {
             return getOriginal()
                     .super_registerReceiver(receiver, filter, broadcastPermission, scheduler);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_registerReceiverBrIrSgHr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_registerReceiverBrIrSgHr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("registerReceiver(BroadcastReceiver, IntentFilter, String, Handler)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("registerReceiver",
+                        BroadcastReceiver.class, IntentFilter.class, String.class, Handler.class);
+                mMethodImplementingPlugins
+                        .put("registerReceiver(BroadcastReceiver, IntentFilter, String, Handler)",
+                                implementingPlugins);
+                mIsOverridden_registerReceiverBrIrSgHr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun4<Intent, BroadcastReceiver, IntentFilter, String, Handler> superCall
                 = new CallFun4<Intent, BroadcastReceiver, IntentFilter, String, Handler>(
@@ -5207,11 +10051,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean releaseInstance() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_releaseInstance) {
             return getOriginal().super_releaseInstance();
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_releaseInstance < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_releaseInstance++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("releaseInstance()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("releaseInstance");
+                mMethodImplementingPlugins.put("releaseInstance()", implementingPlugins);
+                mIsOverridden_releaseInstance = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("releaseInstance()") {
 
@@ -5228,12 +10086,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void removeStickyBroadcast(final Intent intent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_removeStickyBroadcastIt) {
             getOriginal().super_removeStickyBroadcast(intent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_removeStickyBroadcastIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_removeStickyBroadcastIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("removeStickyBroadcast(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("removeStickyBroadcast", Intent.class);
+                mMethodImplementingPlugins
+                        .put("removeStickyBroadcast(Intent)", implementingPlugins);
+                mIsOverridden_removeStickyBroadcastIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("removeStickyBroadcast(Intent)") {
 
@@ -5250,12 +10123,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void removeStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_removeStickyBroadcastAsUserItUe) {
             getOriginal().super_removeStickyBroadcastAsUser(intent, user);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_removeStickyBroadcastAsUserItUe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_removeStickyBroadcastAsUserItUe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("removeStickyBroadcastAsUser(Intent, UserHandle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("removeStickyBroadcastAsUser",
+                        Intent.class, UserHandle.class);
+                mMethodImplementingPlugins.put("removeStickyBroadcastAsUser(Intent, UserHandle)",
+                        implementingPlugins);
+                mIsOverridden_removeStickyBroadcastAsUserItUe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, UserHandle> superCall = new CallVoid2<Intent, UserHandle>(
                 "removeStickyBroadcastAsUser(Intent, UserHandle)") {
@@ -5273,12 +10162,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void reportFullyDrawn() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_reportFullyDrawn) {
             getOriginal().super_reportFullyDrawn();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_reportFullyDrawn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_reportFullyDrawn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("reportFullyDrawn()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("reportFullyDrawn");
+                mMethodImplementingPlugins.put("reportFullyDrawn()", implementingPlugins);
+                mIsOverridden_reportFullyDrawn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("reportFullyDrawn()") {
 
@@ -5295,11 +10198,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean requestVisibleBehind(final boolean visible) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_requestVisibleBehindBn) {
             return getOriginal().super_requestVisibleBehind(visible);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_requestVisibleBehindBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_requestVisibleBehindBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("requestVisibleBehind(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("requestVisibleBehind", Boolean.class);
+                mMethodImplementingPlugins
+                        .put("requestVisibleBehind(Boolean)", implementingPlugins);
+                mIsOverridden_requestVisibleBehindBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Boolean> superCall = new CallFun1<Boolean, Boolean>(
                 "requestVisibleBehind(Boolean)") {
@@ -5317,12 +10235,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void revokeUriPermission(final Uri uri, final int modeFlags) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_revokeUriPermissionUiIr) {
             getOriginal().super_revokeUriPermission(uri, modeFlags);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_revokeUriPermissionUiIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_revokeUriPermissionUiIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("revokeUriPermission(Uri, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("revokeUriPermission", Uri.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("revokeUriPermission(Uri, Integer)", implementingPlugins);
+                mIsOverridden_revokeUriPermissionUiIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Uri, Integer> superCall = new CallVoid2<Uri, Integer>(
                 "revokeUriPermission(Uri, Integer)") {
@@ -5340,12 +10274,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void sendBroadcast(final Intent intent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendBroadcastIt) {
             getOriginal().super_sendBroadcast(intent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendBroadcastIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendBroadcastIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendBroadcast(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendBroadcast", Intent.class);
+                mMethodImplementingPlugins.put("sendBroadcast(Intent)", implementingPlugins);
+                mIsOverridden_sendBroadcastIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("sendBroadcast(Intent)") {
 
@@ -5362,12 +10310,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void sendBroadcast(final Intent intent, final String receiverPermission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendBroadcastItSg) {
             getOriginal().super_sendBroadcast(intent, receiverPermission);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendBroadcastItSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendBroadcastItSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendBroadcast(Intent, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendBroadcast", Intent.class,
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("sendBroadcast(Intent, String)", implementingPlugins);
+                mIsOverridden_sendBroadcastItSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, String> superCall = new CallVoid2<Intent, String>(
                 "sendBroadcast(Intent, String)") {
@@ -5385,12 +10349,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void sendBroadcastAsUser(final Intent intent, final UserHandle user) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendBroadcastAsUserItUe) {
             getOriginal().super_sendBroadcastAsUser(intent, user);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendBroadcastAsUserItUe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendBroadcastAsUserItUe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendBroadcastAsUser(Intent, UserHandle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendBroadcastAsUser", Intent.class,
+                        UserHandle.class);
+                mMethodImplementingPlugins
+                        .put("sendBroadcastAsUser(Intent, UserHandle)", implementingPlugins);
+                mIsOverridden_sendBroadcastAsUserItUe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, UserHandle> superCall = new CallVoid2<Intent, UserHandle>(
                 "sendBroadcastAsUser(Intent, UserHandle)") {
@@ -5409,12 +10389,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void sendBroadcastAsUser(final Intent intent, final UserHandle user,
             final String receiverPermission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendBroadcastAsUserItUeSg) {
             getOriginal().super_sendBroadcastAsUser(intent, user, receiverPermission);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendBroadcastAsUserItUeSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendBroadcastAsUserItUeSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendBroadcastAsUser(Intent, UserHandle, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendBroadcastAsUser", Intent.class,
+                        UserHandle.class, String.class);
+                mMethodImplementingPlugins.put("sendBroadcastAsUser(Intent, UserHandle, String)",
+                        implementingPlugins);
+                mIsOverridden_sendBroadcastAsUserItUeSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Intent, UserHandle, String> superCall
                 = new CallVoid3<Intent, UserHandle, String>(
@@ -5434,12 +10430,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void sendOrderedBroadcast(final Intent intent, final String receiverPermission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendOrderedBroadcastItSg) {
             getOriginal().super_sendOrderedBroadcast(intent, receiverPermission);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendOrderedBroadcastItSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendOrderedBroadcastItSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendOrderedBroadcast(Intent, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendOrderedBroadcast", Intent.class,
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("sendOrderedBroadcast(Intent, String)", implementingPlugins);
+                mIsOverridden_sendOrderedBroadcastItSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, String> superCall = new CallVoid2<Intent, String>(
                 "sendOrderedBroadcast(Intent, String)") {
@@ -5459,13 +10471,31 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void sendOrderedBroadcast(final Intent intent, final String receiverPermission,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendOrderedBroadcastItSgBrHrIrSgBe) {
             getOriginal().super_sendOrderedBroadcast(intent, receiverPermission, resultReceiver,
                     scheduler, initialCode, initialData, initialExtras);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendOrderedBroadcastItSgBrHrIrSgBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendOrderedBroadcastItSgBrHrIrSgBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendOrderedBroadcast", Intent.class,
+                        String.class, BroadcastReceiver.class, Handler.class, Integer.class,
+                        String.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("sendOrderedBroadcast(Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_sendOrderedBroadcastItSgBrHrIrSgBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid7<Intent, String, BroadcastReceiver, Handler, Integer, String, Bundle>
                 superCall
@@ -5496,13 +10526,33 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             final String receiverPermission, final BroadcastReceiver resultReceiver,
             final Handler scheduler, final int initialCode, final String initialData,
             final Bundle initialExtras) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendOrderedBroadcastAsUserItUeSgBrHrIrSgBe) {
             getOriginal().super_sendOrderedBroadcastAsUser(intent, user, receiverPermission,
                     resultReceiver, scheduler, initialCode, initialData, initialExtras);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendOrderedBroadcastAsUserItUeSgBrHrIrSgBe
+                < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendOrderedBroadcastAsUserItUeSgBrHrIrSgBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendOrderedBroadcastAsUser",
+                        Intent.class, UserHandle.class, String.class, BroadcastReceiver.class,
+                        Handler.class, Integer.class, String.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("sendOrderedBroadcastAsUser(Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_sendOrderedBroadcastAsUserItUeSgBrHrIrSgBe =
+                        implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid8<Intent, UserHandle, String, BroadcastReceiver, Handler, Integer, String, Bundle>
                 superCall
@@ -5530,12 +10580,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void sendStickyBroadcast(final Intent intent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendStickyBroadcastIt) {
             getOriginal().super_sendStickyBroadcast(intent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendStickyBroadcastIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendStickyBroadcastIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendStickyBroadcast(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendStickyBroadcast", Intent.class);
+                mMethodImplementingPlugins.put("sendStickyBroadcast(Intent)", implementingPlugins);
+                mIsOverridden_sendStickyBroadcastIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("sendStickyBroadcast(Intent)") {
 
@@ -5552,12 +10616,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void sendStickyBroadcastAsUser(final Intent intent, final UserHandle user) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendStickyBroadcastAsUserItUe) {
             getOriginal().super_sendStickyBroadcastAsUser(intent, user);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendStickyBroadcastAsUserItUe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendStickyBroadcastAsUserItUe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendStickyBroadcastAsUser(Intent, UserHandle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendStickyBroadcastAsUser",
+                        Intent.class, UserHandle.class);
+                mMethodImplementingPlugins
+                        .put("sendStickyBroadcastAsUser(Intent, UserHandle)", implementingPlugins);
+                mIsOverridden_sendStickyBroadcastAsUserItUe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, UserHandle> superCall = new CallVoid2<Intent, UserHandle>(
                 "sendStickyBroadcastAsUser(Intent, UserHandle)") {
@@ -5577,13 +10657,32 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void sendStickyOrderedBroadcast(final Intent intent,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendStickyOrderedBroadcastItBrHrIrSgBe) {
             getOriginal().super_sendStickyOrderedBroadcast(intent, resultReceiver, scheduler,
                     initialCode, initialData, initialExtras);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendStickyOrderedBroadcastItBrHrIrSgBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendStickyOrderedBroadcastItBrHrIrSgBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, Integer, String, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendStickyOrderedBroadcast",
+                        Intent.class, BroadcastReceiver.class, Handler.class, Integer.class,
+                        String.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("sendStickyOrderedBroadcast(Intent, BroadcastReceiver, Handler, Integer, String, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_sendStickyOrderedBroadcastItBrHrIrSgBe = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid6<Intent, BroadcastReceiver, Handler, Integer, String, Bundle> superCall
                 = new CallVoid6<Intent, BroadcastReceiver, Handler, Integer, String, Bundle>(
@@ -5610,14 +10709,34 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void sendStickyOrderedBroadcastAsUser(final Intent intent, final UserHandle user,
             final BroadcastReceiver resultReceiver, final Handler scheduler, final int initialCode,
             final String initialData, final Bundle initialExtras) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_sendStickyOrderedBroadcastAsUserItUeBrHrIrSgBe) {
             getOriginal()
                     .super_sendStickyOrderedBroadcastAsUser(intent, user, resultReceiver, scheduler,
                             initialCode, initialData, initialExtras);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_sendStickyOrderedBroadcastAsUserItUeBrHrIrSgBe
+                < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_sendStickyOrderedBroadcastAsUserItUeBrHrIrSgBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("sendStickyOrderedBroadcastAsUser",
+                        Intent.class, UserHandle.class, BroadcastReceiver.class, Handler.class,
+                        Integer.class, String.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("sendStickyOrderedBroadcastAsUser(Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_sendStickyOrderedBroadcastAsUserItUeBrHrIrSgBe =
+                        implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid7<Intent, UserHandle, BroadcastReceiver, Handler, Integer, String, Bundle>
                 superCall
@@ -5645,12 +10764,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setActionBar(final Toolbar toolbar) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setActionBarTr) {
             getOriginal().super_setActionBar(toolbar);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setActionBarTr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setActionBarTr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setActionBar(Toolbar)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setActionBar", Toolbar.class);
+                mMethodImplementingPlugins.put("setActionBar(Toolbar)", implementingPlugins);
+                mIsOverridden_setActionBarTr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Toolbar> superCall = new CallVoid1<Toolbar>("setActionBar(Toolbar)") {
 
@@ -5667,12 +10800,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setContentTransitionManager(final TransitionManager tm) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setContentTransitionManagerTr) {
             getOriginal().super_setContentTransitionManager(tm);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setContentTransitionManagerTr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setContentTransitionManagerTr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setContentTransitionManager(TransitionManager)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setContentTransitionManager",
+                        TransitionManager.class);
+                mMethodImplementingPlugins
+                        .put("setContentTransitionManager(TransitionManager)", implementingPlugins);
+                mIsOverridden_setContentTransitionManagerTr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<TransitionManager> superCall = new CallVoid1<TransitionManager>(
                 "setContentTransitionManager(TransitionManager)") {
@@ -5690,12 +10839,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setContentView(@LayoutRes final int layoutResID) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setContentViewIr) {
             getOriginal().super_setContentView(layoutResID);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setContentViewIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setContentViewIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setContentView(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setContentView", Integer.class);
+                mMethodImplementingPlugins.put("setContentView(Integer)", implementingPlugins);
+                mIsOverridden_setContentViewIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setContentView(Integer)") {
 
@@ -5712,12 +10875,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setContentView(final View view) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setContentViewVw) {
             getOriginal().super_setContentView(view);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setContentViewVw < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setContentViewVw++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setContentView(View)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setContentView", View.class);
+                mMethodImplementingPlugins.put("setContentView(View)", implementingPlugins);
+                mIsOverridden_setContentViewVw = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<View> superCall = new CallVoid1<View>("setContentView(View)") {
 
@@ -5734,12 +10911,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setContentView(final View view, final ViewGroup.LayoutParams params) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setContentViewVwVs) {
             getOriginal().super_setContentView(view, params);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setContentViewVwVs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setContentViewVwVs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setContentView(View, ViewGroup.LayoutParams)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setContentView", View.class,
+                        ViewGroup.LayoutParams.class);
+                mMethodImplementingPlugins
+                        .put("setContentView(View, ViewGroup.LayoutParams)", implementingPlugins);
+                mIsOverridden_setContentViewVwVs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<View, ViewGroup.LayoutParams> superCall
                 = new CallVoid2<View, ViewGroup.LayoutParams>(
@@ -5758,12 +10951,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setEnterSharedElementCallbackSk) {
             getOriginal().super_setEnterSharedElementCallback(callback);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setEnterSharedElementCallbackSk < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setEnterSharedElementCallbackSk++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setEnterSharedElementCallback(SharedElementCallback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setEnterSharedElementCallback",
+                        SharedElementCallback.class);
+                mMethodImplementingPlugins
+                        .put("setEnterSharedElementCallback(SharedElementCallback)",
+                                implementingPlugins);
+                mIsOverridden_setEnterSharedElementCallbackSk = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setEnterSharedElementCallback(SharedElementCallback)") {
@@ -5781,12 +10991,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setEnterSharedElementCallback(final android.app.SharedElementCallback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setEnterSharedElementCallbackak) {
             getOriginal().super_setEnterSharedElementCallback(callback);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setEnterSharedElementCallbackak < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setEnterSharedElementCallbackak++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setEnterSharedElementCallback(android.app.SharedElementCallback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setEnterSharedElementCallback",
+                        android.app.SharedElementCallback.class);
+                mMethodImplementingPlugins
+                        .put("setEnterSharedElementCallback(android.app.SharedElementCallback)",
+                                implementingPlugins);
+                mIsOverridden_setEnterSharedElementCallbackak = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.app.SharedElementCallback> superCall
                 = new CallVoid1<android.app.SharedElementCallback>(
@@ -5805,12 +11032,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setExitSharedElementCallback(final SharedElementCallback listener) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setExitSharedElementCallbackSk) {
             getOriginal().super_setExitSharedElementCallback(listener);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setExitSharedElementCallbackSk < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setExitSharedElementCallbackSk++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setExitSharedElementCallback(SharedElementCallback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setExitSharedElementCallback",
+                        SharedElementCallback.class);
+                mMethodImplementingPlugins
+                        .put("setExitSharedElementCallback(SharedElementCallback)",
+                                implementingPlugins);
+                mIsOverridden_setExitSharedElementCallbackSk = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setExitSharedElementCallback(SharedElementCallback)") {
@@ -5828,12 +11072,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setExitSharedElementCallback(final android.app.SharedElementCallback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setExitSharedElementCallbackak) {
             getOriginal().super_setExitSharedElementCallback(callback);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setExitSharedElementCallbackak < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setExitSharedElementCallbackak++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setExitSharedElementCallback(android.app.SharedElementCallback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setExitSharedElementCallback",
+                        android.app.SharedElementCallback.class);
+                mMethodImplementingPlugins
+                        .put("setExitSharedElementCallback(android.app.SharedElementCallback)",
+                                implementingPlugins);
+                mIsOverridden_setExitSharedElementCallbackak = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.app.SharedElementCallback> superCall
                 = new CallVoid1<android.app.SharedElementCallback>(
@@ -5852,12 +11113,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setFinishOnTouchOutside(final boolean finish) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setFinishOnTouchOutsideBn) {
             getOriginal().super_setFinishOnTouchOutside(finish);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setFinishOnTouchOutsideBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setFinishOnTouchOutsideBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setFinishOnTouchOutside(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setFinishOnTouchOutside",
+                        Boolean.class);
+                mMethodImplementingPlugins
+                        .put("setFinishOnTouchOutside(Boolean)", implementingPlugins);
+                mIsOverridden_setFinishOnTouchOutsideBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
                 "setFinishOnTouchOutside(Boolean)") {
@@ -5875,12 +11152,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setImmersive(final boolean i) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setImmersiveBn) {
             getOriginal().super_setImmersive(i);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setImmersiveBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setImmersiveBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setImmersive(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setImmersive", Boolean.class);
+                mMethodImplementingPlugins.put("setImmersive(Boolean)", implementingPlugins);
+                mIsOverridden_setImmersiveBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setImmersive(Boolean)") {
 
@@ -5897,12 +11188,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setIntent(final Intent newIntent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setIntentIt) {
             getOriginal().super_setIntent(newIntent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setIntentIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setIntentIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setIntent(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setIntent", Intent.class);
+                mMethodImplementingPlugins.put("setIntent(Intent)", implementingPlugins);
+                mIsOverridden_setIntentIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("setIntent(Intent)") {
 
@@ -5919,12 +11224,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setRequestedOrientation(final int requestedOrientation) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setRequestedOrientationIr) {
             getOriginal().super_setRequestedOrientation(requestedOrientation);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setRequestedOrientationIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setRequestedOrientationIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setRequestedOrientation(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setRequestedOrientation",
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("setRequestedOrientation(Integer)", implementingPlugins);
+                mIsOverridden_setRequestedOrientationIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>(
                 "setRequestedOrientation(Integer)") {
@@ -5942,12 +11263,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setSupportActionBar(@Nullable final android.support.v7.widget.Toolbar toolbar) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setSupportActionBarar) {
             getOriginal().super_setSupportActionBar(toolbar);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setSupportActionBarar < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setSupportActionBarar++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setSupportActionBar(android.support.v7.widget.Toolbar)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setSupportActionBar",
+                        android.support.v7.widget.Toolbar.class);
+                mMethodImplementingPlugins
+                        .put("setSupportActionBar(android.support.v7.widget.Toolbar)",
+                                implementingPlugins);
+                mIsOverridden_setSupportActionBarar = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<android.support.v7.widget.Toolbar> superCall
                 = new CallVoid1<android.support.v7.widget.Toolbar>(
@@ -5966,12 +11304,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setSupportProgress(final int progress) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setSupportProgressIr) {
             getOriginal().super_setSupportProgress(progress);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setSupportProgressIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setSupportProgressIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setSupportProgress(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setSupportProgress", Integer.class);
+                mMethodImplementingPlugins.put("setSupportProgress(Integer)", implementingPlugins);
+                mIsOverridden_setSupportProgressIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setSupportProgress(Integer)") {
 
@@ -5988,12 +11340,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setSupportProgressBarIndeterminate(final boolean indeterminate) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setSupportProgressBarIndeterminateBn) {
             getOriginal().super_setSupportProgressBarIndeterminate(indeterminate);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setSupportProgressBarIndeterminateBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setSupportProgressBarIndeterminateBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setSupportProgressBarIndeterminate(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setSupportProgressBarIndeterminate",
+                        Boolean.class);
+                mMethodImplementingPlugins
+                        .put("setSupportProgressBarIndeterminate(Boolean)", implementingPlugins);
+                mIsOverridden_setSupportProgressBarIndeterminateBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
                 "setSupportProgressBarIndeterminate(Boolean)") {
@@ -6011,12 +11379,31 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setSupportProgressBarIndeterminateVisibility(final boolean visible) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setSupportProgressBarIndeterminateVisibilityBn) {
             getOriginal().super_setSupportProgressBarIndeterminateVisibility(visible);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setSupportProgressBarIndeterminateVisibilityBn
+                < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setSupportProgressBarIndeterminateVisibilityBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setSupportProgressBarIndeterminateVisibility(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins(
+                        "setSupportProgressBarIndeterminateVisibility", Boolean.class);
+                mMethodImplementingPlugins
+                        .put("setSupportProgressBarIndeterminateVisibility(Boolean)",
+                                implementingPlugins);
+                mIsOverridden_setSupportProgressBarIndeterminateVisibilityBn =
+                        implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
                 "setSupportProgressBarIndeterminateVisibility(Boolean)") {
@@ -6034,12 +11421,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setSupportProgressBarVisibility(final boolean visible) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setSupportProgressBarVisibilityBn) {
             getOriginal().super_setSupportProgressBarVisibility(visible);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setSupportProgressBarVisibilityBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setSupportProgressBarVisibilityBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setSupportProgressBarVisibility(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setSupportProgressBarVisibility",
+                        Boolean.class);
+                mMethodImplementingPlugins
+                        .put("setSupportProgressBarVisibility(Boolean)", implementingPlugins);
+                mIsOverridden_setSupportProgressBarVisibilityBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
                 "setSupportProgressBarVisibility(Boolean)") {
@@ -6057,12 +11460,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setTaskDescription(final ActivityManager.TaskDescription taskDescription) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setTaskDescriptionAn) {
             getOriginal().super_setTaskDescription(taskDescription);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setTaskDescriptionAn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setTaskDescriptionAn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setTaskDescription(ActivityManager.TaskDescription)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setTaskDescription",
+                        ActivityManager.TaskDescription.class);
+                mMethodImplementingPlugins
+                        .put("setTaskDescription(ActivityManager.TaskDescription)",
+                                implementingPlugins);
+                mIsOverridden_setTaskDescriptionAn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<ActivityManager.TaskDescription> superCall
                 = new CallVoid1<ActivityManager.TaskDescription>(
@@ -6081,12 +11501,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setTheme(@StyleRes final int resid) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setThemeIr) {
             getOriginal().super_setTheme(resid);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setThemeIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setThemeIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setTheme(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setTheme", Integer.class);
+                mMethodImplementingPlugins.put("setTheme(Integer)", implementingPlugins);
+                mIsOverridden_setThemeIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setTheme(Integer)") {
 
@@ -6103,12 +11537,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setTitle(final CharSequence title) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setTitleCe) {
             getOriginal().super_setTitle(title);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setTitleCe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setTitleCe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setTitle(CharSequence)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setTitle", CharSequence.class);
+                mMethodImplementingPlugins.put("setTitle(CharSequence)", implementingPlugins);
+                mIsOverridden_setTitleCe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<CharSequence> superCall = new CallVoid1<CharSequence>(
                 "setTitle(CharSequence)") {
@@ -6126,12 +11574,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setTitle(final int titleId) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setTitleIr) {
             getOriginal().super_setTitle(titleId);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setTitleIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setTitleIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setTitle(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setTitle", Integer.class);
+                mMethodImplementingPlugins.put("setTitle(Integer)", implementingPlugins);
+                mIsOverridden_setTitleIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setTitle(Integer)") {
 
@@ -6148,12 +11610,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setTitleColor(final int textColor) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setTitleColorIr) {
             getOriginal().super_setTitleColor(textColor);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setTitleColorIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setTitleColorIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setTitleColor(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setTitleColor", Integer.class);
+                mMethodImplementingPlugins.put("setTitleColor(Integer)", implementingPlugins);
+                mIsOverridden_setTitleColorIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Integer> superCall = new CallVoid1<Integer>("setTitleColor(Integer)") {
 
@@ -6170,12 +11646,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setVisible(final boolean visible) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setVisibleBn) {
             getOriginal().super_setVisible(visible);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setVisibleBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setVisibleBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setVisible(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setVisible", Boolean.class);
+                mMethodImplementingPlugins.put("setVisible(Boolean)", implementingPlugins);
+                mIsOverridden_setVisibleBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setVisible(Boolean)") {
 
@@ -6192,16 +11682,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setWallpaper(final Bitmap bitmap) throws IOException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal().super_setWallpaper(bitmap);
-            } catch (IOException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_setWallpaperBp) {
+            getOriginal().super_setWallpaper(bitmap);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setWallpaperBp < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setWallpaperBp++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setWallpaper(Bitmap)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setWallpaper", Bitmap.class);
+                mMethodImplementingPlugins.put("setWallpaper(Bitmap)", implementingPlugins);
+                mIsOverridden_setWallpaperBp = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bitmap> superCall = new CallVoid1<Bitmap>("setWallpaper(Bitmap)") {
 
@@ -6226,16 +11726,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void setWallpaper(final InputStream data) throws IOException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal().super_setWallpaper(data);
-            } catch (IOException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_setWallpaperIm) {
+            getOriginal().super_setWallpaper(data);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_setWallpaperIm < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setWallpaperIm++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setWallpaper(InputStream)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setWallpaper", InputStream.class);
+                mMethodImplementingPlugins.put("setWallpaper(InputStream)", implementingPlugins);
+                mIsOverridden_setWallpaperIm = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<InputStream> superCall = new CallVoid1<InputStream>(
                 "setWallpaper(InputStream)") {
@@ -6261,11 +11771,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean shouldShowRequestPermissionRationale(final String permission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_shouldShowRequestPermissionRationaleSg) {
             return getOriginal().super_shouldShowRequestPermissionRationale(permission);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_shouldShowRequestPermissionRationaleSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_shouldShowRequestPermissionRationaleSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("shouldShowRequestPermissionRationale(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("shouldShowRequestPermissionRationale",
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("shouldShowRequestPermissionRationale(String)", implementingPlugins);
+                mIsOverridden_shouldShowRequestPermissionRationaleSg = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "shouldShowRequestPermissionRationale(String)") {
@@ -6284,11 +11811,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean shouldUpRecreateTask(final Intent targetIntent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_shouldUpRecreateTaskIt) {
             return getOriginal().super_shouldUpRecreateTask(targetIntent);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_shouldUpRecreateTaskIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_shouldUpRecreateTaskIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("shouldUpRecreateTask(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("shouldUpRecreateTask", Intent.class);
+                mMethodImplementingPlugins.put("shouldUpRecreateTask(Intent)", implementingPlugins);
+                mIsOverridden_shouldUpRecreateTaskIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "shouldUpRecreateTask(Intent)") {
@@ -6306,11 +11847,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean showAssist(final Bundle args) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_showAssistBe) {
             return getOriginal().super_showAssist(args);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_showAssistBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_showAssistBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("showAssist(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("showAssist", Bundle.class);
+                mMethodImplementingPlugins.put("showAssist(Bundle)", implementingPlugins);
+                mIsOverridden_showAssistBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Bundle> superCall = new CallFun1<Boolean, Bundle>(
                 "showAssist(Bundle)") {
@@ -6328,12 +11883,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void showLockTaskEscapeMessage() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_showLockTaskEscapeMessage) {
             getOriginal().super_showLockTaskEscapeMessage();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_showLockTaskEscapeMessage < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_showLockTaskEscapeMessage++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("showLockTaskEscapeMessage()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("showLockTaskEscapeMessage");
+                mMethodImplementingPlugins.put("showLockTaskEscapeMessage()", implementingPlugins);
+                mIsOverridden_showLockTaskEscapeMessage = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("showLockTaskEscapeMessage()") {
 
@@ -6351,11 +11920,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public android.view.ActionMode startActionMode(
             final android.view.ActionMode.Callback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActionModeak) {
             return getOriginal().super_startActionMode(callback);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActionModeak < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActionModeak++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActionMode(android.view.ActionMode.Callback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActionMode",
+                        android.view.ActionMode.Callback.class);
+                mMethodImplementingPlugins.put("startActionMode(android.view.ActionMode.Callback)",
+                        implementingPlugins);
+                mIsOverridden_startActionModeak = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<android.view.ActionMode, android.view.ActionMode.Callback> superCall
                 = new CallFun1<android.view.ActionMode, android.view.ActionMode.Callback>(
@@ -6375,11 +11960,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public android.view.ActionMode startActionMode(final android.view.ActionMode.Callback callback,
             final int type) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActionModeakIr) {
             return getOriginal().super_startActionMode(callback, type);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActionModeakIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActionModeakIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActionMode(android.view.ActionMode.Callback, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActionMode",
+                        android.view.ActionMode.Callback.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("startActionMode(android.view.ActionMode.Callback, Integer)",
+                                implementingPlugins);
+                mIsOverridden_startActionModeakIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer> superCall
                 = new CallFun2<android.view.ActionMode, android.view.ActionMode.Callback, Integer>(
@@ -6399,12 +12001,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startActivities(final Intent[] intents) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivitiesIt) {
             getOriginal().super_startActivities(intents);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivitiesIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivitiesIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivities(Intent[])");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivities", Intent[].class);
+                mMethodImplementingPlugins.put("startActivities(Intent[])", implementingPlugins);
+                mIsOverridden_startActivitiesIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent[]> superCall = new CallVoid1<Intent[]>("startActivities(Intent[])") {
 
@@ -6421,12 +12037,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startActivities(final Intent[] intents, final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivitiesItBe) {
             getOriginal().super_startActivities(intents, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivitiesItBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivitiesItBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivities(Intent[], Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivities", Intent[].class,
+                        Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startActivities(Intent[], Bundle)", implementingPlugins);
+                mIsOverridden_startActivitiesItBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent[], Bundle> superCall = new CallVoid2<Intent[], Bundle>(
                 "startActivities(Intent[], Bundle)") {
@@ -6444,12 +12076,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startActivity(final Intent intent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityIt) {
             getOriginal().super_startActivity(intent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivity(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivity", Intent.class);
+                mMethodImplementingPlugins.put("startActivity(Intent)", implementingPlugins);
+                mIsOverridden_startActivityIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("startActivity(Intent)") {
 
@@ -6466,12 +12112,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startActivity(final Intent intent, final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityItBe) {
             getOriginal().super_startActivity(intent, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityItBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityItBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivity(Intent, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivity", Intent.class,
+                        Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startActivity(Intent, Bundle)", implementingPlugins);
+                mIsOverridden_startActivityItBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, Bundle> superCall = new CallVoid2<Intent, Bundle>(
                 "startActivity(Intent, Bundle)") {
@@ -6489,12 +12151,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityForResultItIr) {
             getOriginal().super_startActivityForResult(intent, requestCode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityForResultItIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityForResultItIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityForResult(Intent, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityForResult", Intent.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("startActivityForResult(Intent, Integer)", implementingPlugins);
+                mIsOverridden_startActivityForResultItIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, Integer> superCall = new CallVoid2<Intent, Integer>(
                 "startActivityForResult(Intent, Integer)") {
@@ -6513,12 +12191,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startActivityForResult(final Intent intent, final int requestCode,
             final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityForResultItIrBe) {
             getOriginal().super_startActivityForResult(intent, requestCode, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityForResultItIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityForResultItIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityForResult(Intent, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityForResult", Intent.class,
+                        Integer.class, Bundle.class);
+                mMethodImplementingPlugins.put("startActivityForResult(Intent, Integer, Bundle)",
+                        implementingPlugins);
+                mIsOverridden_startActivityForResultItIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Intent, Integer, Bundle> superCall = new CallVoid3<Intent, Integer, Bundle>(
                 "startActivityForResult(Intent, Integer, Bundle)") {
@@ -6537,12 +12231,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startActivityFromChild(final Activity child, final Intent intent,
             final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityFromChildAyItIr) {
             getOriginal().super_startActivityFromChild(child, intent, requestCode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityFromChildAyItIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityFromChildAyItIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityFromChild(Activity, Intent, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityFromChild",
+                        Activity.class, Intent.class, Integer.class);
+                mMethodImplementingPlugins.put("startActivityFromChild(Activity, Intent, Integer)",
+                        implementingPlugins);
+                mIsOverridden_startActivityFromChildAyItIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Activity, Intent, Integer> superCall
                 = new CallVoid3<Activity, Intent, Integer>(
@@ -6562,12 +12272,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startActivityFromChild(final Activity child, final Intent intent,
             final int requestCode, final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityFromChildAyItIrBe) {
             getOriginal().super_startActivityFromChild(child, intent, requestCode, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityFromChildAyItIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityFromChildAyItIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityFromChild(Activity, Intent, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityFromChild",
+                        Activity.class, Intent.class, Integer.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startActivityFromChild(Activity, Intent, Integer, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_startActivityFromChildAyItIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid4<Activity, Intent, Integer, Bundle> superCall
                 = new CallVoid4<Activity, Intent, Integer, Bundle>(
@@ -6589,12 +12316,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startActivityFromFragment(final Fragment fragment, final Intent intent,
             final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityFromFragmentFtItIr) {
             getOriginal().super_startActivityFromFragment(fragment, intent, requestCode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityFromFragmentFtItIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityFromFragmentFtItIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityFromFragment(Fragment, Intent, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityFromFragment",
+                        Fragment.class, Intent.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("startActivityFromFragment(Fragment, Intent, Integer)",
+                                implementingPlugins);
+                mIsOverridden_startActivityFromFragmentFtItIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Fragment, Intent, Integer> superCall
                 = new CallVoid3<Fragment, Intent, Integer>(
@@ -6616,12 +12360,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startActivityFromFragment(final Fragment fragment, final Intent intent,
             final int requestCode, @Nullable final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityFromFragmentFtItIrBe) {
             getOriginal().super_startActivityFromFragment(fragment, intent, requestCode, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityFromFragmentFtItIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityFromFragmentFtItIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityFromFragment(Fragment, Intent, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityFromFragment",
+                        Fragment.class, Intent.class, Integer.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startActivityFromFragment(Fragment, Intent, Integer, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_startActivityFromFragmentFtItIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid4<Fragment, Intent, Integer, Bundle> superCall
                 = new CallVoid4<Fragment, Intent, Integer, Bundle>(
@@ -6645,12 +12406,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
             final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityFromFragmentatItIr) {
             getOriginal().super_startActivityFromFragment(fragment, intent, requestCode);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityFromFragmentatItIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityFromFragmentatItIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityFromFragment(android.app.Fragment, Intent, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityFromFragment",
+                        android.app.Fragment.class, Intent.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("startActivityFromFragment(android.app.Fragment, Intent, Integer)",
+                                implementingPlugins);
+                mIsOverridden_startActivityFromFragmentatItIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<android.app.Fragment, Intent, Integer> superCall
                 = new CallVoid3<android.app.Fragment, Intent, Integer>(
@@ -6672,12 +12450,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startActivityFromFragment(final android.app.Fragment fragment, final Intent intent,
             final int requestCode, final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityFromFragmentatItIrBe) {
             getOriginal().super_startActivityFromFragment(fragment, intent, requestCode, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityFromFragmentatItIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityFromFragmentatItIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityFromFragment(android.app.Fragment, Intent, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityFromFragment",
+                        android.app.Fragment.class, Intent.class, Integer.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startActivityFromFragment(android.app.Fragment, Intent, Integer, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_startActivityFromFragmentatItIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid4<android.app.Fragment, Intent, Integer, Bundle> superCall
                 = new CallVoid4<android.app.Fragment, Intent, Integer, Bundle>(
@@ -6700,11 +12495,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean startActivityIfNeeded(final Intent intent, final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityIfNeededItIr) {
             return getOriginal().super_startActivityIfNeeded(intent, requestCode);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityIfNeededItIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityIfNeededItIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityIfNeeded(Intent, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityIfNeeded", Intent.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("startActivityIfNeeded(Intent, Integer)", implementingPlugins);
+                mIsOverridden_startActivityIfNeededItIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Intent, Integer> superCall = new CallFun2<Boolean, Intent, Integer>(
                 "startActivityIfNeeded(Intent, Integer)") {
@@ -6723,11 +12534,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public boolean startActivityIfNeeded(final Intent intent, final int requestCode,
             final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityIfNeededItIrBe) {
             return getOriginal().super_startActivityIfNeeded(intent, requestCode, options);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startActivityIfNeededItIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityIfNeededItIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityIfNeeded(Intent, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityIfNeeded", Intent.class,
+                        Integer.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startActivityIfNeeded(Intent, Integer, Bundle)", implementingPlugins);
+                mIsOverridden_startActivityIfNeededItIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<Boolean, Intent, Integer, Bundle> superCall
                 = new CallFun3<Boolean, Intent, Integer, Bundle>(
@@ -6749,11 +12576,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public boolean startInstrumentation(final ComponentName className, final String profileFile,
             final Bundle arguments) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startInstrumentationCeSgBe) {
             return getOriginal().super_startInstrumentation(className, profileFile, arguments);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startInstrumentationCeSgBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startInstrumentationCeSgBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startInstrumentation(ComponentName, String, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startInstrumentation",
+                        ComponentName.class, String.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startInstrumentation(ComponentName, String, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_startInstrumentationCeSgBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<Boolean, ComponentName, String, Bundle> superCall
                 = new CallFun3<Boolean, ComponentName, String, Bundle>(
@@ -6777,17 +12621,31 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void startIntentSender(final IntentSender intent, final Intent fillInIntent,
             final int flagsMask, final int flagsValues, final int extraFlags)
             throws IntentSender.SendIntentException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask, flagsValues,
-                        extraFlags);
-            } catch (IntentSender.SendIntentException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_startIntentSenderIrItIrIrIr) {
+            getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask, flagsValues,
+                    extraFlags);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startIntentSenderIrItIrIrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startIntentSenderIrItIrIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startIntentSender(IntentSender, Intent, Integer, Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startIntentSender",
+                        IntentSender.class, Intent.class, Integer.class, Integer.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("startIntentSender(IntentSender, Intent, Integer, Integer, Integer)",
+                                implementingPlugins);
+                mIsOverridden_startIntentSenderIrItIrIrIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid5<IntentSender, Intent, Integer, Integer, Integer> superCall
                 = new CallVoid5<IntentSender, Intent, Integer, Integer, Integer>(
@@ -6819,17 +12677,31 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void startIntentSender(final IntentSender intent, final Intent fillInIntent,
             final int flagsMask, final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask, flagsValues,
-                        extraFlags, options);
-            } catch (IntentSender.SendIntentException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_startIntentSenderIrItIrIrIrBe) {
+            getOriginal().super_startIntentSender(intent, fillInIntent, flagsMask, flagsValues,
+                    extraFlags, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startIntentSenderIrItIrIrIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startIntentSenderIrItIrIrIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startIntentSender(IntentSender, Intent, Integer, Integer, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startIntentSender",
+                        IntentSender.class, Intent.class, Integer.class, Integer.class,
+                        Integer.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startIntentSender(IntentSender, Intent, Integer, Integer, Integer, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_startIntentSenderIrItIrIrIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid6<IntentSender, Intent, Integer, Integer, Integer, Bundle> superCall
                 = new CallVoid6<IntentSender, Intent, Integer, Integer, Integer, Bundle>(
@@ -6862,17 +12734,33 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void startIntentSenderForResult(final IntentSender intent, final int requestCode,
             final Intent fillInIntent, final int flagsMask, final int flagsValues,
             final int extraFlags) throws IntentSender.SendIntentException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal().super_startIntentSenderForResult(intent, requestCode, fillInIntent,
-                        flagsMask, flagsValues, extraFlags);
-            } catch (IntentSender.SendIntentException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_startIntentSenderForResultIrIrItIrIrIr) {
+            getOriginal()
+                    .super_startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask,
+                            flagsValues, extraFlags);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startIntentSenderForResultIrIrItIrIrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startIntentSenderForResultIrIrItIrIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startIntentSenderForResult",
+                        IntentSender.class, Integer.class, Intent.class, Integer.class,
+                        Integer.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer)",
+                                implementingPlugins);
+                mIsOverridden_startIntentSenderForResultIrIrItIrIrIr = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid6<IntentSender, Integer, Intent, Integer, Integer, Integer> superCall
                 = new CallVoid6<IntentSender, Integer, Intent, Integer, Integer, Integer>(
@@ -6907,17 +12795,34 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void startIntentSenderForResult(final IntentSender intent, final int requestCode,
             final Intent fillInIntent, final int flagsMask, final int flagsValues,
             final int extraFlags, final Bundle options) throws IntentSender.SendIntentException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal().super_startIntentSenderForResult(intent, requestCode, fillInIntent,
-                        flagsMask, flagsValues, extraFlags, options);
-            } catch (IntentSender.SendIntentException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_startIntentSenderForResultIrIrItIrIrIrBe) {
+            getOriginal()
+                    .super_startIntentSenderForResult(intent, requestCode, fillInIntent, flagsMask,
+                            flagsValues, extraFlags, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startIntentSenderForResultIrIrItIrIrIrBe
+                < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startIntentSenderForResultIrIrItIrIrIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startIntentSenderForResult",
+                        IntentSender.class, Integer.class, Intent.class, Integer.class,
+                        Integer.class, Integer.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startIntentSenderForResult(IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_startIntentSenderForResultIrIrItIrIrIrBe = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid7<IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle> superCall
                 = new CallVoid7<IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle>(
@@ -6953,18 +12858,33 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     public void startIntentSenderFromChild(final Activity child, final IntentSender intent,
             final int requestCode, final Intent fillInIntent, final int flagsMask,
             final int flagsValues, final int extraFlags) throws IntentSender.SendIntentException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal()
-                        .super_startIntentSenderFromChild(child, intent, requestCode, fillInIntent,
-                                flagsMask, flagsValues, extraFlags);
-            } catch (IntentSender.SendIntentException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIr) {
+            getOriginal().super_startIntentSenderFromChild(child, intent, requestCode, fillInIntent,
+                    flagsMask, flagsValues, extraFlags);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startIntentSenderFromChildAyIrIrItIrIrIr
+                < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startIntentSenderFromChildAyIrIrItIrIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startIntentSenderFromChild",
+                        Activity.class, IntentSender.class, Integer.class, Intent.class,
+                        Integer.class, Integer.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer)",
+                                implementingPlugins);
+                mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIr = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid7<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer>
                 superCall
@@ -7001,18 +12921,33 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             final int requestCode, final Intent fillInIntent, final int flagsMask,
             final int flagsValues, final int extraFlags, final Bundle options)
             throws IntentSender.SendIntentException {
-        if (mPlugins.isEmpty()) {
-            try {
-                getOriginal()
-                        .super_startIntentSenderFromChild(child, intent, requestCode, fillInIntent,
-                                flagsMask, flagsValues, extraFlags, options);
-            } catch (IntentSender.SendIntentException e) {
-                throw new SuppressedException(e);
-            }
+        if (!mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIrBe) {
+            getOriginal().super_startIntentSenderFromChild(child, intent, requestCode, fillInIntent,
+                    flagsMask, flagsValues, extraFlags, options);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startIntentSenderFromChildAyIrIrItIrIrIrBe
+                < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startIntentSenderFromChildAyIrIrItIrIrIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startIntentSenderFromChild",
+                        Activity.class, IntentSender.class, Integer.class, Intent.class,
+                        Integer.class, Integer.class, Integer.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startIntentSenderFromChild(Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle)",
+                                implementingPlugins);
+                mIsOverridden_startIntentSenderFromChildAyIrIrItIrIrIrBe =
+                        implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid8<Activity, IntentSender, Integer, Intent, Integer, Integer, Integer, Bundle>
                 superCall
@@ -7046,12 +12981,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startLockTask() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startLockTask) {
             getOriginal().super_startLockTask();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startLockTask < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startLockTask++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startLockTask()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startLockTask");
+                mMethodImplementingPlugins.put("startLockTask()", implementingPlugins);
+                mIsOverridden_startLockTask = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("startLockTask()") {
 
@@ -7068,12 +13017,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startManagingCursor(final Cursor c) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startManagingCursorCr) {
             getOriginal().super_startManagingCursor(c);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startManagingCursorCr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startManagingCursorCr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startManagingCursor(Cursor)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startManagingCursor", Cursor.class);
+                mMethodImplementingPlugins.put("startManagingCursor(Cursor)", implementingPlugins);
+                mIsOverridden_startManagingCursorCr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Cursor> superCall = new CallVoid1<Cursor>("startManagingCursor(Cursor)") {
 
@@ -7090,11 +13053,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean startNextMatchingActivity(final Intent intent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startNextMatchingActivityIt) {
             return getOriginal().super_startNextMatchingActivity(intent);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startNextMatchingActivityIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startNextMatchingActivityIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startNextMatchingActivity(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startNextMatchingActivity",
+                        Intent.class);
+                mMethodImplementingPlugins
+                        .put("startNextMatchingActivity(Intent)", implementingPlugins);
+                mIsOverridden_startNextMatchingActivityIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "startNextMatchingActivity(Intent)") {
@@ -7112,11 +13091,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean startNextMatchingActivity(final Intent intent, final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startNextMatchingActivityItBe) {
             return getOriginal().super_startNextMatchingActivity(intent, options);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startNextMatchingActivityItBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startNextMatchingActivityItBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startNextMatchingActivity(Intent, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startNextMatchingActivity",
+                        Intent.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startNextMatchingActivity(Intent, Bundle)", implementingPlugins);
+                mIsOverridden_startNextMatchingActivityItBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Boolean, Intent, Bundle> superCall = new CallFun2<Boolean, Intent, Bundle>(
                 "startNextMatchingActivity(Intent, Bundle)") {
@@ -7134,12 +13129,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void startPostponedEnterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startPostponedEnterTransition) {
             getOriginal().super_startPostponedEnterTransition();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startPostponedEnterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startPostponedEnterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startPostponedEnterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startPostponedEnterTransition");
+                mMethodImplementingPlugins
+                        .put("startPostponedEnterTransition()", implementingPlugins);
+                mIsOverridden_startPostponedEnterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("startPostponedEnterTransition()") {
 
@@ -7157,13 +13167,29 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     public void startSearch(final String initialQuery, final boolean selectInitialQuery,
             final Bundle appSearchData, final boolean globalSearch) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startSearchSgBnBeBn) {
             getOriginal().super_startSearch(initialQuery, selectInitialQuery, appSearchData,
                     globalSearch);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startSearchSgBnBeBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startSearchSgBnBeBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startSearch(String, Boolean, Bundle, Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startSearch", String.class,
+                        Boolean.class, Bundle.class, Boolean.class);
+                mMethodImplementingPlugins
+                        .put("startSearch(String, Boolean, Bundle, Boolean)", implementingPlugins);
+                mIsOverridden_startSearchSgBnBeBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid4<String, Boolean, Bundle, Boolean> superCall
                 = new CallVoid4<String, Boolean, Bundle, Boolean>(
@@ -7186,11 +13212,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ComponentName startService(final Intent service) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startServiceIt) {
             return getOriginal().super_startService(service);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startServiceIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startServiceIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startService(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startService", Intent.class);
+                mMethodImplementingPlugins.put("startService(Intent)", implementingPlugins);
+                mIsOverridden_startServiceIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<ComponentName, Intent> superCall = new CallFun1<ComponentName, Intent>(
                 "startService(Intent)") {
@@ -7208,11 +13248,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public ActionMode startSupportActionMode(@NonNull final ActionMode.Callback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startSupportActionModeAk) {
             return getOriginal().super_startSupportActionMode(callback);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_startSupportActionModeAk < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startSupportActionModeAk++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startSupportActionMode(ActionMode.Callback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startSupportActionMode",
+                        ActionMode.Callback.class);
+                mMethodImplementingPlugins
+                        .put("startSupportActionMode(ActionMode.Callback)", implementingPlugins);
+                mIsOverridden_startSupportActionModeAk = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<ActionMode, ActionMode.Callback> superCall
                 = new CallFun1<ActionMode, ActionMode.Callback>(
@@ -7231,12 +13287,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void stopLockTask() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_stopLockTask) {
             getOriginal().super_stopLockTask();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_stopLockTask < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_stopLockTask++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("stopLockTask()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("stopLockTask");
+                mMethodImplementingPlugins.put("stopLockTask()", implementingPlugins);
+                mIsOverridden_stopLockTask = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("stopLockTask()") {
 
@@ -7253,12 +13323,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void stopManagingCursor(final Cursor c) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_stopManagingCursorCr) {
             getOriginal().super_stopManagingCursor(c);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_stopManagingCursorCr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_stopManagingCursorCr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("stopManagingCursor(Cursor)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("stopManagingCursor", Cursor.class);
+                mMethodImplementingPlugins.put("stopManagingCursor(Cursor)", implementingPlugins);
+                mIsOverridden_stopManagingCursorCr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Cursor> superCall = new CallVoid1<Cursor>("stopManagingCursor(Cursor)") {
 
@@ -7275,11 +13359,25 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean stopService(final Intent name) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_stopServiceIt) {
             return getOriginal().super_stopService(name);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_stopServiceIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_stopServiceIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("stopService(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("stopService", Intent.class);
+                mMethodImplementingPlugins.put("stopService(Intent)", implementingPlugins);
+                mIsOverridden_stopServiceIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "stopService(Intent)") {
@@ -7297,12 +13395,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void supportFinishAfterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_supportFinishAfterTransition) {
             getOriginal().super_supportFinishAfterTransition();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_supportFinishAfterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_supportFinishAfterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("supportFinishAfterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("supportFinishAfterTransition");
+                mMethodImplementingPlugins
+                        .put("supportFinishAfterTransition()", implementingPlugins);
+                mIsOverridden_supportFinishAfterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("supportFinishAfterTransition()") {
 
@@ -7319,12 +13432,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void supportInvalidateOptionsMenu() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_supportInvalidateOptionsMenu) {
             getOriginal().super_supportInvalidateOptionsMenu();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_supportInvalidateOptionsMenu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_supportInvalidateOptionsMenu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("supportInvalidateOptionsMenu()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("supportInvalidateOptionsMenu");
+                mMethodImplementingPlugins
+                        .put("supportInvalidateOptionsMenu()", implementingPlugins);
+                mIsOverridden_supportInvalidateOptionsMenu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("supportInvalidateOptionsMenu()") {
 
@@ -7341,12 +13469,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void supportNavigateUpTo(@NonNull final Intent upIntent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_supportNavigateUpToIt) {
             getOriginal().super_supportNavigateUpTo(upIntent);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_supportNavigateUpToIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_supportNavigateUpToIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("supportNavigateUpTo(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("supportNavigateUpTo", Intent.class);
+                mMethodImplementingPlugins.put("supportNavigateUpTo(Intent)", implementingPlugins);
+                mIsOverridden_supportNavigateUpToIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("supportNavigateUpTo(Intent)") {
 
@@ -7363,12 +13505,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void supportPostponeEnterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_supportPostponeEnterTransition) {
             getOriginal().super_supportPostponeEnterTransition();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_supportPostponeEnterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_supportPostponeEnterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("supportPostponeEnterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("supportPostponeEnterTransition");
+                mMethodImplementingPlugins
+                        .put("supportPostponeEnterTransition()", implementingPlugins);
+                mIsOverridden_supportPostponeEnterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("supportPostponeEnterTransition()") {
 
@@ -7385,11 +13542,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean supportRequestWindowFeature(final int featureId) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_supportRequestWindowFeatureIr) {
             return getOriginal().super_supportRequestWindowFeature(featureId);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_supportRequestWindowFeatureIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_supportRequestWindowFeatureIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("supportRequestWindowFeature(Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("supportRequestWindowFeature",
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("supportRequestWindowFeature(Integer)", implementingPlugins);
+                mIsOverridden_supportRequestWindowFeatureIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Integer> superCall = new CallFun1<Boolean, Integer>(
                 "supportRequestWindowFeature(Integer)") {
@@ -7407,11 +13580,27 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public boolean supportShouldUpRecreateTask(@NonNull final Intent targetIntent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_supportShouldUpRecreateTaskIt) {
             return getOriginal().super_supportShouldUpRecreateTask(targetIntent);
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_supportShouldUpRecreateTaskIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_supportShouldUpRecreateTaskIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("supportShouldUpRecreateTask(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("supportShouldUpRecreateTask",
+                        Intent.class);
+                mMethodImplementingPlugins
+                        .put("supportShouldUpRecreateTask(Intent)", implementingPlugins);
+                mIsOverridden_supportShouldUpRecreateTaskIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, Intent> superCall = new CallFun1<Boolean, Intent>(
                 "supportShouldUpRecreateTask(Intent)") {
@@ -7429,12 +13618,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void supportStartPostponedEnterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_supportStartPostponedEnterTransition) {
             getOriginal().super_supportStartPostponedEnterTransition();
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_supportStartPostponedEnterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_supportStartPostponedEnterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("supportStartPostponedEnterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins(
+                        "supportStartPostponedEnterTransition");
+                mMethodImplementingPlugins
+                        .put("supportStartPostponedEnterTransition()", implementingPlugins);
+                mIsOverridden_supportStartPostponedEnterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("supportStartPostponedEnterTransition()") {
 
@@ -7451,12 +13656,26 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void takeKeyEvents(final boolean get) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_takeKeyEventsBn) {
             getOriginal().super_takeKeyEvents(get);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_takeKeyEventsBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_takeKeyEventsBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("takeKeyEvents(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("takeKeyEvents", Boolean.class);
+                mMethodImplementingPlugins.put("takeKeyEvents(Boolean)", implementingPlugins);
+                mIsOverridden_takeKeyEventsBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("takeKeyEvents(Boolean)") {
 
@@ -7473,12 +13692,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void triggerSearch(final String query, final Bundle appSearchData) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_triggerSearchSgBe) {
             getOriginal().super_triggerSearch(query, appSearchData);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_triggerSearchSgBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_triggerSearchSgBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("triggerSearch(String, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("triggerSearch", String.class,
+                        Bundle.class);
+                mMethodImplementingPlugins
+                        .put("triggerSearch(String, Bundle)", implementingPlugins);
+                mIsOverridden_triggerSearchSgBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<String, Bundle> superCall = new CallVoid2<String, Bundle>(
                 "triggerSearch(String, Bundle)") {
@@ -7496,12 +13731,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void unbindService(final ServiceConnection conn) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_unbindServiceSn) {
             getOriginal().super_unbindService(conn);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_unbindServiceSn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_unbindServiceSn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("unbindService(ServiceConnection)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("unbindService",
+                        ServiceConnection.class);
+                mMethodImplementingPlugins
+                        .put("unbindService(ServiceConnection)", implementingPlugins);
+                mIsOverridden_unbindServiceSn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<ServiceConnection> superCall = new CallVoid1<ServiceConnection>(
                 "unbindService(ServiceConnection)") {
@@ -7519,12 +13770,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void unregisterComponentCallbacks(final ComponentCallbacks callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_unregisterComponentCallbacksCs) {
             getOriginal().super_unregisterComponentCallbacks(callback);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_unregisterComponentCallbacksCs < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_unregisterComponentCallbacksCs++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("unregisterComponentCallbacks(ComponentCallbacks)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("unregisterComponentCallbacks",
+                        ComponentCallbacks.class);
+                mMethodImplementingPlugins.put("unregisterComponentCallbacks(ComponentCallbacks)",
+                        implementingPlugins);
+                mIsOverridden_unregisterComponentCallbacksCs = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<ComponentCallbacks> superCall = new CallVoid1<ComponentCallbacks>(
                 "unregisterComponentCallbacks(ComponentCallbacks)") {
@@ -7542,12 +13809,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void unregisterForContextMenu(final View view) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_unregisterForContextMenuVw) {
             getOriginal().super_unregisterForContextMenu(view);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_unregisterForContextMenuVw < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_unregisterForContextMenuVw++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("unregisterForContextMenu(View)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("unregisterForContextMenu",
+                        View.class);
+                mMethodImplementingPlugins
+                        .put("unregisterForContextMenu(View)", implementingPlugins);
+                mIsOverridden_unregisterForContextMenuVw = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<View> superCall = new CallVoid1<View>("unregisterForContextMenu(View)") {
 
@@ -7564,12 +13847,28 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
     }
 
     public void unregisterReceiver(final BroadcastReceiver receiver) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_unregisterReceiverBr) {
             getOriginal().super_unregisterReceiver(receiver);
             return;
         }
 
-        final ListIterator<ActivityPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<ActivityPlugin> iterator;
+        if (mCallCount_unregisterReceiverBr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_unregisterReceiverBr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("unregisterReceiver(BroadcastReceiver)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("unregisterReceiver",
+                        BroadcastReceiver.class);
+                mMethodImplementingPlugins
+                        .put("unregisterReceiver(BroadcastReceiver)", implementingPlugins);
+                mIsOverridden_unregisterReceiverBr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<BroadcastReceiver> superCall = new CallVoid1<BroadcastReceiver>(
                 "unregisterReceiver(BroadcastReceiver)") {

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -101,7 +101,7 @@ import java.util.ListIterator;
 public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, ActivityPlugin> {
 
     @VisibleForTesting
-    static final int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
+    int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
 
     private int mCallCount_addContentViewVwVs = 0;
 
@@ -1843,7 +1843,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("bindService(Intent, ServiceConnection, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("bindService", Intent.class,
-                        ServiceConnection.class, Integer.class);
+                        ServiceConnection.class, Integer.TYPE);
                 mMethodImplementingPlugins.put("bindService(Intent, ServiceConnection, Integer)",
                         implementingPlugins);
                 mIsOverridden_bindServiceItSnIr = implementingPlugins.size() > 0;
@@ -1921,7 +1921,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("checkCallingOrSelfUriPermission(Uri, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("checkCallingOrSelfUriPermission",
-                        Uri.class, Integer.class);
+                        Uri.class, Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("checkCallingOrSelfUriPermission(Uri, Integer)", implementingPlugins);
                 mIsOverridden_checkCallingOrSelfUriPermissionUiIr = implementingPlugins.size() > 0;
@@ -1998,7 +1998,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("checkCallingUriPermission(Uri, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("checkCallingUriPermission", Uri.class,
-                        Integer.class);
+                        Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("checkCallingUriPermission(Uri, Integer)", implementingPlugins);
                 mIsOverridden_checkCallingUriPermissionUiIr = implementingPlugins.size() > 0;
@@ -2036,7 +2036,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("checkPermission(String, Integer, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("checkPermission", String.class,
-                        Integer.class, Integer.class);
+                        Integer.TYPE, Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("checkPermission(String, Integer, Integer)", implementingPlugins);
                 mIsOverridden_checkPermissionSgIrIr = implementingPlugins.size() > 0;
@@ -2112,7 +2112,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("checkUriPermission(Uri, Integer, Integer, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("checkUriPermission", Uri.class,
-                        Integer.class, Integer.class, Integer.class);
+                        Integer.TYPE, Integer.TYPE, Integer.TYPE);
                 mMethodImplementingPlugins.put("checkUriPermission(Uri, Integer, Integer, Integer)",
                         implementingPlugins);
                 mIsOverridden_checkUriPermissionUiIrIrIr = implementingPlugins.size() > 0;
@@ -2155,7 +2155,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("checkUriPermission(Uri, String, String, Integer, Integer, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("checkUriPermission", Uri.class,
-                        String.class, String.class, Integer.class, Integer.class, Integer.class);
+                        String.class, String.class, Integer.TYPE, Integer.TYPE, Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("checkUriPermission(Uri, String, String, Integer, Integer, Integer)",
                                 implementingPlugins);
@@ -2394,7 +2394,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("createPackageContext(String, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("createPackageContext", String.class,
-                        Integer.class);
+                        Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("createPackageContext(String, Integer)", implementingPlugins);
                 mIsOverridden_createPackageContextSgIr = implementingPlugins.size() > 0;
@@ -2440,8 +2440,8 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("createPendingResult(Integer, Intent, Integer)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("createPendingResult", Integer.class,
-                        Intent.class, Integer.class);
+                implementingPlugins = getImplementingPlugins("createPendingResult", Integer.TYPE,
+                        Intent.class, Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("createPendingResult(Integer, Intent, Integer)", implementingPlugins);
                 mIsOverridden_createPendingResultIrItIr = implementingPlugins.size() > 0;
@@ -3192,7 +3192,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("findViewById(Integer)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("findViewById", Integer.class);
+                implementingPlugins = getImplementingPlugins("findViewById", Integer.TYPE);
                 mMethodImplementingPlugins.put("findViewById(Integer)", implementingPlugins);
                 mIsOverridden_findViewByIdIr = implementingPlugins.size() > 0;
             }
@@ -4121,7 +4121,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("getDir(String, Integer)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("getDir", String.class, Integer.class);
+                implementingPlugins = getImplementingPlugins("getDir", String.class, Integer.TYPE);
                 mMethodImplementingPlugins.put("getDir(String, Integer)", implementingPlugins);
                 mIsOverridden_getDirSgIr = implementingPlugins.size() > 0;
             }
@@ -4988,7 +4988,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("getPreferences(Integer)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("getPreferences", Integer.class);
+                implementingPlugins = getImplementingPlugins("getPreferences", Integer.TYPE);
                 mMethodImplementingPlugins.put("getPreferences(Integer)", implementingPlugins);
                 mIsOverridden_getPreferencesIr = implementingPlugins.size() > 0;
             }
@@ -5130,7 +5130,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("getSharedPreferences(String, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("getSharedPreferences", String.class,
-                        Integer.class);
+                        Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("getSharedPreferences(String, Integer)", implementingPlugins);
                 mIsOverridden_getSharedPreferencesSgIr = implementingPlugins.size() > 0;
@@ -6060,7 +6060,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("moveTaskToBack(Boolean)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("moveTaskToBack", Boolean.class);
+                implementingPlugins = getImplementingPlugins("moveTaskToBack", Boolean.TYPE);
                 mMethodImplementingPlugins.put("moveTaskToBack(Boolean)", implementingPlugins);
                 mIsOverridden_moveTaskToBackBn = implementingPlugins.size() > 0;
             }
@@ -6863,7 +6863,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onCreateDialog(Integer)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onCreateDialog", Integer.class);
+                implementingPlugins = getImplementingPlugins("onCreateDialog", Integer.TYPE);
                 mMethodImplementingPlugins.put("onCreateDialog(Integer)", implementingPlugins);
                 mIsOverridden_onCreateDialogIr = implementingPlugins.size() > 0;
             }
@@ -6899,7 +6899,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onCreateDialog(Integer, Bundle)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onCreateDialog", Integer.class,
+                implementingPlugins = getImplementingPlugins("onCreateDialog", Integer.TYPE,
                         Bundle.class);
                 mMethodImplementingPlugins
                         .put("onCreateDialog(Integer, Bundle)", implementingPlugins);
@@ -7012,7 +7012,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onCreatePanelMenu(Integer, Menu)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onCreatePanelMenu", Integer.class,
+                implementingPlugins = getImplementingPlugins("onCreatePanelMenu", Integer.TYPE,
                         Menu.class);
                 mMethodImplementingPlugins
                         .put("onCreatePanelMenu(Integer, Menu)", implementingPlugins);
@@ -7050,7 +7050,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onCreatePanelView(Integer)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onCreatePanelView", Integer.class);
+                implementingPlugins = getImplementingPlugins("onCreatePanelView", Integer.TYPE);
                 mMethodImplementingPlugins.put("onCreatePanelView(Integer)", implementingPlugins);
                 mIsOverridden_onCreatePanelViewIr = implementingPlugins.size() > 0;
             }
@@ -7392,7 +7392,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onKeyDown(Integer, KeyEvent)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onKeyDown", Integer.class,
+                implementingPlugins = getImplementingPlugins("onKeyDown", Integer.TYPE,
                         KeyEvent.class);
                 mMethodImplementingPlugins.put("onKeyDown(Integer, KeyEvent)", implementingPlugins);
                 mIsOverridden_onKeyDownIrKt = implementingPlugins.size() > 0;
@@ -7429,7 +7429,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onKeyLongPress(Integer, KeyEvent)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onKeyLongPress", Integer.class,
+                implementingPlugins = getImplementingPlugins("onKeyLongPress", Integer.TYPE,
                         KeyEvent.class);
                 mMethodImplementingPlugins
                         .put("onKeyLongPress(Integer, KeyEvent)", implementingPlugins);
@@ -7467,8 +7467,8 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onKeyMultiple(Integer, Integer, KeyEvent)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onKeyMultiple", Integer.class,
-                        Integer.class, KeyEvent.class);
+                implementingPlugins = getImplementingPlugins("onKeyMultiple", Integer.TYPE,
+                        Integer.TYPE, KeyEvent.class);
                 mMethodImplementingPlugins
                         .put("onKeyMultiple(Integer, Integer, KeyEvent)", implementingPlugins);
                 mIsOverridden_onKeyMultipleIrIrKt = implementingPlugins.size() > 0;
@@ -7507,7 +7507,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onKeyShortcut(Integer, KeyEvent)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onKeyShortcut", Integer.class,
+                implementingPlugins = getImplementingPlugins("onKeyShortcut", Integer.TYPE,
                         KeyEvent.class);
                 mMethodImplementingPlugins
                         .put("onKeyShortcut(Integer, KeyEvent)", implementingPlugins);
@@ -7545,7 +7545,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onKeyUp(Integer, KeyEvent)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onKeyUp", Integer.class,
+                implementingPlugins = getImplementingPlugins("onKeyUp", Integer.TYPE,
                         KeyEvent.class);
                 mMethodImplementingPlugins.put("onKeyUp(Integer, KeyEvent)", implementingPlugins);
                 mIsOverridden_onKeyUpIrKt = implementingPlugins.size() > 0;
@@ -7618,7 +7618,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onMenuOpened(Integer, Menu)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onMenuOpened", Integer.class,
+                implementingPlugins = getImplementingPlugins("onMenuOpened", Integer.TYPE,
                         Menu.class);
                 mMethodImplementingPlugins.put("onMenuOpened(Integer, Menu)", implementingPlugins);
                 mIsOverridden_onMenuOpenedIrMu = implementingPlugins.size() > 0;
@@ -8295,7 +8295,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onPreparePanel(Integer, View, Menu)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onPreparePanel", Integer.class,
+                implementingPlugins = getImplementingPlugins("onPreparePanel", Integer.TYPE,
                         View.class, Menu.class);
                 mMethodImplementingPlugins
                         .put("onPreparePanel(Integer, View, Menu)", implementingPlugins);
@@ -9517,7 +9517,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("onWindowStartingActionMode(android.view.ActionMode.Callback, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("onWindowStartingActionMode",
-                        android.view.ActionMode.Callback.class, Integer.class);
+                        android.view.ActionMode.Callback.class, Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("onWindowStartingActionMode(android.view.ActionMode.Callback, Integer)",
                                 implementingPlugins);
@@ -9680,7 +9680,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("openFileOutput(String, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("openFileOutput", String.class,
-                        Integer.class);
+                        Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("openFileOutput(String, Integer)", implementingPlugins);
                 mIsOverridden_openFileOutputSgIr = implementingPlugins.size() > 0;
@@ -9764,7 +9764,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("openOrCreateDatabase", String.class,
-                        Integer.class, SQLiteDatabase.CursorFactory.class);
+                        Integer.TYPE, SQLiteDatabase.CursorFactory.class);
                 mMethodImplementingPlugins
                         .put("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory)",
                                 implementingPlugins);
@@ -9806,7 +9806,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("openOrCreateDatabase", String.class,
-                        Integer.class, SQLiteDatabase.CursorFactory.class,
+                        Integer.TYPE, SQLiteDatabase.CursorFactory.class,
                         DatabaseErrorHandler.class);
                 mMethodImplementingPlugins
                         .put("openOrCreateDatabase(String, Integer, SQLiteDatabase.CursorFactory, DatabaseErrorHandler)",
@@ -10304,7 +10304,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
             List<ActivityPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("requestVisibleBehind(Boolean)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("requestVisibleBehind", Boolean.class);
+                implementingPlugins = getImplementingPlugins("requestVisibleBehind", Boolean.TYPE);
                 mMethodImplementingPlugins
                         .put("requestVisibleBehind(Boolean)", implementingPlugins);
                 mIsOverridden_requestVisibleBehindBn = implementingPlugins.size() > 0;
@@ -12067,7 +12067,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("startActionMode(android.view.ActionMode.Callback, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("startActionMode",
-                        android.view.ActionMode.Callback.class, Integer.class);
+                        android.view.ActionMode.Callback.class, Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("startActionMode(android.view.ActionMode.Callback, Integer)",
                                 implementingPlugins);
@@ -12602,7 +12602,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("startActivityIfNeeded(Intent, Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("startActivityIfNeeded", Intent.class,
-                        Integer.class);
+                        Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("startActivityIfNeeded(Intent, Integer)", implementingPlugins);
                 mIsOverridden_startActivityIfNeededItIr = implementingPlugins.size() > 0;
@@ -12641,7 +12641,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("startActivityIfNeeded(Intent, Integer, Bundle)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("startActivityIfNeeded", Intent.class,
-                        Integer.class, Bundle.class);
+                        Integer.TYPE, Bundle.class);
                 mMethodImplementingPlugins
                         .put("startActivityIfNeeded(Intent, Integer, Bundle)", implementingPlugins);
                 mIsOverridden_startActivityIfNeededItIrBe = implementingPlugins.size() > 0;
@@ -13713,7 +13713,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
                     .get("supportRequestWindowFeature(Integer)");
             if (implementingPlugins == null) {
                 implementingPlugins = getImplementingPlugins("supportRequestWindowFeature",
-                        Integer.class);
+                        Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("supportRequestWindowFeature(Integer)", implementingPlugins);
                 mIsOverridden_supportRequestWindowFeatureIr = implementingPlugins.size() > 0;

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegate.java
@@ -106,7 +106,7 @@ public class ActivityDelegate extends AbstractDelegate<ICompositeActivity, Activ
 
     private int mGetResourcesCallCount = 0;
 
-    private transient boolean mIsGetResourcesOverridden = true;
+    private transient boolean mIsGetResourcesOverridden = false;
 
     private final HashMap<String, List<ActivityPlugin>> mMethodImplementingPlugins
             = new HashMap<>();

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
@@ -97,7 +97,6 @@ import java.lang.reflect.Method;
 @SuppressWarnings("unused")
 public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDelegate> {
 
-
     public void addContentView(final View view, final ViewGroup.LayoutParams params) {
         verifyMethodCalledFromDelegate("addContentView(View, ViewGroup.LayoutParams)");
         ((CallVoid2<View, ViewGroup.LayoutParams>) mSuperListeners.pop()).call(view, params);
@@ -2686,7 +2685,7 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
             if (method.getDeclaringClass() == ActivityPlugin.class) {
                 return false;
             }
-        } catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException ignore) {
         }
         return true;
     }

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
@@ -91,10 +91,12 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.lang.reflect.Method;
 
 
 @SuppressWarnings("unused")
 public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDelegate> {
+
 
     public void addContentView(final View view, final ViewGroup.LayoutParams params) {
         verifyMethodCalledFromDelegate("addContentView(View, ViewGroup.LayoutParams)");
@@ -2675,6 +2677,18 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
             mSuperListeners.push(superCall);
             return isImmersive();
         }
+    }
+
+    boolean isMethodOverridden(final String methodName, final Class<?>... parameterTypes) {
+        try {
+            final Class<? extends ActivityPlugin> myClass = this.getClass();
+            final Method method = myClass.getMethod(methodName, parameterTypes);
+            if (method.getDeclaringClass() == ActivityPlugin.class) {
+                return false;
+            }
+        } catch (NoSuchMethodException e) {
+        }
+        return true;
     }
 
     boolean isRestricted(final CallFun0<Boolean> superCall) {

--- a/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
+++ b/activity/src/main/java/com/pascalwelsch/compositeandroid/activity/ActivityPlugin.java
@@ -2703,12 +2703,10 @@ public class ActivityPlugin extends AbstractPlugin<CompositeActivity, ActivityDe
         try {
             final Class<? extends ActivityPlugin> myClass = this.getClass();
             final Method method = myClass.getMethod(methodName, parameterTypes);
-            if (method.getDeclaringClass() == ActivityPlugin.class) {
-                return false;
-            }
+            return method.getDeclaringClass() != ActivityPlugin.class;
         } catch (NoSuchMethodException ignore) {
+            return false;
         }
-        return true;
     }
 
     boolean isRestricted(final CallFun0<Boolean> superCall) {

--- a/activity/src/test/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegateTest.java
+++ b/activity/src/test/java/com/pascalwelsch/compositeandroid/activity/ActivityDelegateTest.java
@@ -7,14 +7,17 @@ import android.support.annotation.LayoutRes;
 import android.view.KeyEvent;
 import android.view.MenuItem;
 
+import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.fail;
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ActivityDelegateTest {
 
@@ -240,55 +243,41 @@ public class ActivityDelegateTest {
         verify(a).onKeyDown(1, event);
         verify(activity).super_onKeyDown(1, event);
     }
-/*
+
     @Test
     public void testNonConfigurationInstance() throws Exception {
 
         final ActivityPlugin a = spy(new ActivityPlugin());
         final ActivityPlugin b = spy(new ActivityPlugin() {
+
             @Override
-            public Object onRetainCustomNonConfigurationInstance() {
-                final Object superNic = super.onRetainCustomNonConfigurationInstance();
-                assertEquals("c", superNic.toString());
-                return new NonConfigurationInstanceWrapper(superNic) {
-                    @Override
-                    public String toString() {
-                        return "b";
-                    }
-                };
+            public CompositeNonConfigurationInstance onRetainNonConfigurationInstance() {
+                return new CompositeNonConfigurationInstance("testB", "b");
             }
         });
         final ActivityPlugin c = spy(new ActivityPlugin() {
             @Override
-            public Object onRetainCustomNonConfigurationInstance() {
-                return new NonConfigurationInstanceWrapper(
-                        super.onRetainCustomNonConfigurationInstance()) {
-                    @Override
-                    public String toString() {
-                        return "c";
-                    }
-                };
+            public CompositeNonConfigurationInstance onRetainNonConfigurationInstance() {
+                return new CompositeNonConfigurationInstance("testC", "c");
             }
         });
 
-        final CompositeActivity activity = mock(CompositeActivity.class);
-        doReturn("SuperObject").when(activity).onRetainCustomNonConfigurationInstance_super();
+        final ICompositeActivity activity = mock(ICompositeActivity.class);
+        doReturn("super").when(activity).onRetainCompositeCustomNonConfigurationInstance();
         final ActivityDelegate delegate = new ActivityDelegate(activity);
 
         delegate.addPlugin(a);
         delegate.addPlugin(b);
         delegate.addPlugin(c);
 
-        Object o = delegate.onRetainCustomNonConfigurationInstance();
-        assertEquals("b", o.toString());
+        NonConfigurationInstanceWrapper nci = (NonConfigurationInstanceWrapper) delegate.onRetainNonConfigurationInstance();
+        assertEquals("super", nci.getSuperNonConfigurationInstance());
 
+        when(activity.getLastCustomNonConfigurationInstance()).thenReturn(nci);
 
-        doReturn(o).when(activity).getLastCustomNonConfigurationInstance_super();
-
-        assertEquals("SuperObject", a.getLastCustomNonConfigurationInstance().toString());
-        assertEquals("b", b.getLastCustomNonConfigurationInstance().toString());
-        assertEquals("c", c.getLastCustomNonConfigurationInstance().toString());
-    }*/
+        assertEquals("b", b.getLastNonConfigurationInstance("testB"));
+        assertEquals("c", c.getLastNonConfigurationInstance("testC"));
+    }
 
     @Test
     public void testStopPropagatingEvent() throws Exception {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
 
 ext {
     supportLibraryVersion = '23.4.0'
-    VERSION_NAME = "0.2.1"
+    VERSION_NAME = "0.3.0-SNAPSHOT"
     VERSION_CODE = 6
     MIN_SDK_VERSION = 14
     TARGET_SDK_VERSION = 23

--- a/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractDelegate.java
+++ b/core/src/main/java/com/pascalwelsch/compositeandroid/core/AbstractDelegate.java
@@ -11,7 +11,7 @@ public class AbstractDelegate<T, P extends AbstractPlugin> {
 
     protected final T mOriginal;
 
-    protected List<P> mPlugins = new CopyOnWriteArrayList<>();
+    protected final List<P> mPlugins = new CopyOnWriteArrayList<>();
 
     public AbstractDelegate(final T original) {
         mOriginal = original;
@@ -19,14 +19,18 @@ public class AbstractDelegate<T, P extends AbstractPlugin> {
 
     @SuppressWarnings("unchecked")
     public Removable addPlugin(final P plugin) {
-        plugin.addToDelegate(this, mOriginal);
-        mPlugins.add(plugin);
+        synchronized (mPlugins) {
+            plugin.addToDelegate(this, mOriginal);
+            mPlugins.add(plugin);
+        }
 
         return new Removable() {
             @Override
             public void remove() {
-                mPlugins.remove(plugin);
-                plugin.removeFromDelegate();
+                synchronized (mPlugins) {
+                    mPlugins.remove(plugin);
+                    plugin.removeFromDelegate();
+                }
             }
         };
     }

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.StyleRes;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
@@ -36,12 +37,81 @@ import android.view.animation.Animation;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.ListIterator;
 
 public class DialogFragmentDelegate
         extends AbstractDelegate<ICompositeDialogFragment, DialogFragmentPlugin> {
 
+    @VisibleForTesting
+    static final int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
+
+    private int mCallCount_dismiss = 0;
+
+    private int mCallCount_dismissAllowingStateLoss = 0;
+
+    private int mCallCount_getDialog = 0;
+
+    private int mCallCount_getShowsDialog = 0;
+
+    private int mCallCount_getTheme = 0;
+
+    private int mCallCount_isCancelable = 0;
+
+    private int mCallCount_onCancelDe = 0;
+
+    private int mCallCount_onCreateDialogBe = 0;
+
+    private int mCallCount_onDismissDe = 0;
+
+    private int mCallCount_setCancelableBn = 0;
+
+    private int mCallCount_setShowsDialogBn = 0;
+
+    private int mCallCount_setStyleIrIr = 0;
+
+    private int mCallCount_setupDialogDgIr = 0;
+
+    private int mCallCount_showFnSg = 0;
+
+    private int mCallCount_showFrSg = 0;
+
     private final FragmentDelegate mFragmentDelegate;
+
+    private boolean mIsOverridden_dismiss = false;
+
+    private boolean mIsOverridden_dismissAllowingStateLoss = false;
+
+    private boolean mIsOverridden_getDialog = false;
+
+    private boolean mIsOverridden_getShowsDialog = false;
+
+    private boolean mIsOverridden_getTheme = false;
+
+    private boolean mIsOverridden_isCancelable = false;
+
+    private boolean mIsOverridden_onCancelDe = false;
+
+    private boolean mIsOverridden_onCreateDialogBe = false;
+
+    private boolean mIsOverridden_onDismissDe = false;
+
+    private boolean mIsOverridden_setCancelableBn = false;
+
+    private boolean mIsOverridden_setShowsDialogBn = false;
+
+    private boolean mIsOverridden_setStyleIrIr = false;
+
+    private boolean mIsOverridden_setupDialogDgIr = false;
+
+    private boolean mIsOverridden_showFnSg = false;
+
+    private boolean mIsOverridden_showFrSg = false;
+
+    private final HashMap<String, List<DialogFragmentPlugin>> mMethodImplementingPlugins
+            = new HashMap<>();
 
     public DialogFragmentDelegate(final ICompositeDialogFragment icompositedialogfragment) {
         super(icompositedialogfragment);
@@ -54,6 +124,23 @@ public class DialogFragmentDelegate
 
     @Override
     public Removable addPlugin(final DialogFragmentPlugin plugin) {
+        mMethodImplementingPlugins.clear();
+        mIsOverridden_dismiss = true;
+        mIsOverridden_dismissAllowingStateLoss = true;
+        mIsOverridden_getDialog = true;
+        mIsOverridden_getShowsDialog = true;
+        mIsOverridden_getTheme = true;
+        mIsOverridden_isCancelable = true;
+        mIsOverridden_onCancelDe = true;
+        mIsOverridden_onCreateDialogBe = true;
+        mIsOverridden_onDismissDe = true;
+        mIsOverridden_setCancelableBn = true;
+        mIsOverridden_setShowsDialogBn = true;
+        mIsOverridden_setStyleIrIr = true;
+        mIsOverridden_setupDialogDgIr = true;
+        mIsOverridden_showFrSg = true;
+        mIsOverridden_showFnSg = true;
+
         final Removable removable = super.addPlugin(plugin);
         final Removable superRemovable = mFragmentDelegate.addPlugin(plugin);
         return new Removable() {
@@ -66,12 +153,26 @@ public class DialogFragmentDelegate
     }
 
     public void dismiss() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dismiss) {
             getOriginal().super_dismiss();
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_dismiss < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dismiss++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dismiss()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dismiss");
+                mMethodImplementingPlugins.put("dismiss()", implementingPlugins);
+                mIsOverridden_dismiss = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("dismiss()") {
 
@@ -88,12 +189,26 @@ public class DialogFragmentDelegate
     }
 
     public void dismissAllowingStateLoss() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dismissAllowingStateLoss) {
             getOriginal().super_dismissAllowingStateLoss();
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_dismissAllowingStateLoss < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dismissAllowingStateLoss++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dismissAllowingStateLoss()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dismissAllowingStateLoss");
+                mMethodImplementingPlugins.put("dismissAllowingStateLoss()", implementingPlugins);
+                mIsOverridden_dismissAllowingStateLoss = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("dismissAllowingStateLoss()") {
 
@@ -127,11 +242,25 @@ public class DialogFragmentDelegate
     }
 
     public Dialog getDialog() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getDialog) {
             return getOriginal().super_getDialog();
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_getDialog < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getDialog++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getDialog()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getDialog");
+                mMethodImplementingPlugins.put("getDialog()", implementingPlugins);
+                mIsOverridden_getDialog = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Dialog> superCall = new CallFun0<Dialog>("getDialog()") {
 
@@ -180,11 +309,25 @@ public class DialogFragmentDelegate
     }
 
     public boolean getShowsDialog() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getShowsDialog) {
             return getOriginal().super_getShowsDialog();
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_getShowsDialog < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getShowsDialog++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getShowsDialog()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getShowsDialog");
+                mMethodImplementingPlugins.put("getShowsDialog()", implementingPlugins);
+                mIsOverridden_getShowsDialog = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("getShowsDialog()") {
 
@@ -201,11 +344,25 @@ public class DialogFragmentDelegate
     }
 
     public int getTheme() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getTheme) {
             return getOriginal().super_getTheme();
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_getTheme < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getTheme++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getTheme()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getTheme");
+                mMethodImplementingPlugins.put("getTheme()", implementingPlugins);
+                mIsOverridden_getTheme = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Integer> superCall = new CallFun0<Integer>("getTheme()") {
 
@@ -230,11 +387,25 @@ public class DialogFragmentDelegate
     }
 
     public boolean isCancelable() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_isCancelable) {
             return getOriginal().super_isCancelable();
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_isCancelable < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_isCancelable++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("isCancelable()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("isCancelable");
+                mMethodImplementingPlugins.put("isCancelable()", implementingPlugins);
+                mIsOverridden_isCancelable = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("isCancelable()") {
 
@@ -267,12 +438,26 @@ public class DialogFragmentDelegate
     }
 
     public void onCancel(final DialogInterface dialog) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCancelDe) {
             getOriginal().super_onCancel(dialog);
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_onCancelDe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCancelDe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCancel(DialogInterface)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCancel", DialogInterface.class);
+                mMethodImplementingPlugins.put("onCancel(DialogInterface)", implementingPlugins);
+                mIsOverridden_onCancelDe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<DialogInterface> superCall = new CallVoid1<DialogInterface>(
                 "onCancel(DialogInterface)") {
@@ -311,11 +496,25 @@ public class DialogFragmentDelegate
     }
 
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateDialogBe) {
             return getOriginal().super_onCreateDialog(savedInstanceState);
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_onCreateDialogBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateDialogBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateDialog(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateDialog", Bundle.class);
+                mMethodImplementingPlugins.put("onCreateDialog(Bundle)", implementingPlugins);
+                mIsOverridden_onCreateDialogBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Dialog, Bundle> superCall = new CallFun1<Dialog, Bundle>(
                 "onCreateDialog(Bundle)") {
@@ -358,12 +557,26 @@ public class DialogFragmentDelegate
     }
 
     public void onDismiss(final DialogInterface dialog) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onDismissDe) {
             getOriginal().super_onDismiss(dialog);
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_onDismissDe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onDismissDe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onDismiss(DialogInterface)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onDismiss", DialogInterface.class);
+                mMethodImplementingPlugins.put("onDismiss(DialogInterface)", implementingPlugins);
+                mIsOverridden_onDismissDe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<DialogInterface> superCall = new CallVoid1<DialogInterface>(
                 "onDismiss(DialogInterface)") {
@@ -460,12 +673,26 @@ public class DialogFragmentDelegate
     }
 
     public void setCancelable(final boolean cancelable) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setCancelableBn) {
             getOriginal().super_setCancelable(cancelable);
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_setCancelableBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setCancelableBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setCancelable(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setCancelable", Boolean.class);
+                mMethodImplementingPlugins.put("setCancelable(Boolean)", implementingPlugins);
+                mIsOverridden_setCancelableBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setCancelable(Boolean)") {
 
@@ -530,12 +757,26 @@ public class DialogFragmentDelegate
     }
 
     public void setShowsDialog(final boolean showsDialog) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setShowsDialogBn) {
             getOriginal().super_setShowsDialog(showsDialog);
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_setShowsDialogBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setShowsDialogBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setShowsDialog(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setShowsDialog", Boolean.class);
+                mMethodImplementingPlugins.put("setShowsDialog(Boolean)", implementingPlugins);
+                mIsOverridden_setShowsDialogBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setShowsDialog(Boolean)") {
 
@@ -552,12 +793,27 @@ public class DialogFragmentDelegate
     }
 
     public void setStyle(final int style, @StyleRes final int theme) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setStyleIrIr) {
             getOriginal().super_setStyle(style, theme);
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_setStyleIrIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setStyleIrIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setStyle(Integer, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setStyle", Integer.class,
+                        Integer.class);
+                mMethodImplementingPlugins.put("setStyle(Integer, Integer)", implementingPlugins);
+                mIsOverridden_setStyleIrIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Integer, Integer> superCall = new CallVoid2<Integer, Integer>(
                 "setStyle(Integer, Integer)") {
@@ -583,12 +839,27 @@ public class DialogFragmentDelegate
     }
 
     public void setupDialog(final Dialog dialog, final int style) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setupDialogDgIr) {
             getOriginal().super_setupDialog(dialog, style);
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_setupDialogDgIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setupDialogDgIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setupDialog(Dialog, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setupDialog", Dialog.class,
+                        Integer.class);
+                mMethodImplementingPlugins.put("setupDialog(Dialog, Integer)", implementingPlugins);
+                mIsOverridden_setupDialogDgIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Dialog, Integer> superCall = new CallVoid2<Dialog, Integer>(
                 "setupDialog(Dialog, Integer)") {
@@ -610,12 +881,28 @@ public class DialogFragmentDelegate
     }
 
     public void show(final FragmentManager manager, final String tag) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_showFrSg) {
             getOriginal().super_show(manager, tag);
             return;
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_showFrSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_showFrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("show(FragmentManager, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("show", FragmentManager.class,
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("show(FragmentManager, String)", implementingPlugins);
+                mIsOverridden_showFrSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<FragmentManager, String> superCall = new CallVoid2<FragmentManager, String>(
                 "show(FragmentManager, String)") {
@@ -633,11 +920,27 @@ public class DialogFragmentDelegate
     }
 
     public int show(final FragmentTransaction transaction, final String tag) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_showFnSg) {
             return getOriginal().super_show(transaction, tag);
         }
 
-        final ListIterator<DialogFragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<DialogFragmentPlugin> iterator;
+        if (mCallCount_showFnSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_showFnSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<DialogFragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("show(FragmentTransaction, String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("show", FragmentTransaction.class,
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("show(FragmentTransaction, String)", implementingPlugins);
+                mIsOverridden_showFnSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun2<Integer, FragmentTransaction, String> superCall
                 = new CallFun2<Integer, FragmentTransaction, String>(
@@ -678,6 +981,20 @@ public class DialogFragmentDelegate
 
     public void unregisterForContextMenu(final View view) {
         mFragmentDelegate.unregisterForContextMenu(view);
+    }
+
+    private List<DialogFragmentPlugin> getImplementingPlugins(final String methodName,
+            final Class<?>... parameterTypes) {
+        synchronized (mPlugins) {
+            final ArrayList<DialogFragmentPlugin> implementingPlugins = new ArrayList<>();
+            for (int i = 0; i < mPlugins.size(); i++) {
+                final DialogFragmentPlugin plugin = mPlugins.get(i);
+                if (plugin.isMethodOverridden(methodName, parameterTypes)) {
+                    implementingPlugins.add(plugin);
+                }
+            }
+            return implementingPlugins;
+        }
     }
 
 

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentDelegate.java
@@ -47,7 +47,7 @@ public class DialogFragmentDelegate
         extends AbstractDelegate<ICompositeDialogFragment, DialogFragmentPlugin> {
 
     @VisibleForTesting
-    static final int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
+    int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
 
     private int mCallCount_dismiss = 0;
 

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentPlugin.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentPlugin.java
@@ -203,12 +203,10 @@ public class DialogFragmentPlugin extends FragmentPlugin {
         try {
             final Class<? extends DialogFragmentPlugin> myClass = this.getClass();
             final Method method = myClass.getMethod(methodName, parameterTypes);
-            if (method.getDeclaringClass() == DialogFragmentPlugin.class) {
-                return false;
-            }
+            return method.getDeclaringClass() != DialogFragmentPlugin.class;
         } catch (NoSuchMethodException ignore) {
+            return false;
         }
-        return true;
     }
 
     void onActivityCreated(final CallVoid1<Bundle> superCall, final Bundle savedInstanceState) {

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentPlugin.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/DialogFragmentPlugin.java
@@ -18,6 +18,8 @@ import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.view.LayoutInflater;
 
+import java.lang.reflect.Method;
+
 
 @SuppressWarnings("unused")
 public class DialogFragmentPlugin extends FragmentPlugin {
@@ -195,6 +197,18 @@ public class DialogFragmentPlugin extends FragmentPlugin {
             mSuperListeners.push(superCall);
             return isCancelable();
         }
+    }
+
+    boolean isMethodOverridden(final String methodName, final Class<?>... parameterTypes) {
+        try {
+            final Class<? extends DialogFragmentPlugin> myClass = this.getClass();
+            final Method method = myClass.getMethod(methodName, parameterTypes);
+            if (method.getDeclaringClass() == DialogFragmentPlugin.class) {
+                return false;
+            }
+        } catch (NoSuchMethodException ignore) {
+        }
+        return true;
     }
 
     void onActivityCreated(final CallVoid1<Bundle> superCall, final Bundle savedInstanceState) {

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
@@ -9,6 +9,7 @@ import com.pascalwelsch.compositeandroid.core.CallVoid1;
 import com.pascalwelsch.compositeandroid.core.CallVoid2;
 import com.pascalwelsch.compositeandroid.core.CallVoid3;
 import com.pascalwelsch.compositeandroid.core.CallVoid4;
+import com.pascalwelsch.compositeandroid.core.Removable;
 
 import android.app.Activity;
 import android.content.Context;
@@ -17,6 +18,7 @@ import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.LoaderManager;
 import android.support.v4.app.SharedElementCallback;
@@ -32,25 +34,401 @@ import android.view.animation.Animation;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.ListIterator;
 
 public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, FragmentPlugin> {
 
+    @VisibleForTesting
+    static final int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
+
+    private int mCallCount_dumpSgFrPrSg = 0;
+
+    private int mCallCount_getAllowEnterTransitionOverlap = 0;
+
+    private int mCallCount_getAllowReturnTransitionOverlap = 0;
+
+    private int mCallCount_getContext = 0;
+
+    private int mCallCount_getEnterTransition = 0;
+
+    private int mCallCount_getExitTransition = 0;
+
+    private int mCallCount_getLayoutInflaterBe = 0;
+
+    private int mCallCount_getLoaderManager = 0;
+
+    private int mCallCount_getReenterTransition = 0;
+
+    private int mCallCount_getReturnTransition = 0;
+
+    private int mCallCount_getSharedElementEnterTransition = 0;
+
+    private int mCallCount_getSharedElementReturnTransition = 0;
+
+    private int mCallCount_getUserVisibleHint = 0;
+
+    private int mCallCount_getView = 0;
+
+    private int mCallCount_onActivityCreatedBe = 0;
+
+    private int mCallCount_onActivityResultIrIrIt = 0;
+
+    private int mCallCount_onAttachAy = 0;
+
+    private int mCallCount_onAttachCt = 0;
+
+    private int mCallCount_onConfigurationChangedCn = 0;
+
+    private int mCallCount_onContextItemSelectedMm = 0;
+
+    private int mCallCount_onCreateAnimationIrBnIr = 0;
+
+    private int mCallCount_onCreateBe = 0;
+
+    private int mCallCount_onCreateContextMenuCuVwCo = 0;
+
+    private int mCallCount_onCreateOptionsMenuMuMr = 0;
+
+    private int mCallCount_onCreateViewLrVpBe = 0;
+
+    private int mCallCount_onDestroy = 0;
+
+    private int mCallCount_onDestroyOptionsMenu = 0;
+
+    private int mCallCount_onDestroyView = 0;
+
+    private int mCallCount_onDetach = 0;
+
+    private int mCallCount_onHiddenChangedBn = 0;
+
+    private int mCallCount_onInflateAyAtBe = 0;
+
+    private int mCallCount_onInflateCtAtBe = 0;
+
+    private int mCallCount_onLowMemory = 0;
+
+    private int mCallCount_onOptionsItemSelectedMm = 0;
+
+    private int mCallCount_onOptionsMenuClosedMu = 0;
+
+    private int mCallCount_onPause = 0;
+
+    private int mCallCount_onPrepareOptionsMenuMu = 0;
+
+    private int mCallCount_onRequestPermissionsResultIrSgit = 0;
+
+    private int mCallCount_onResume = 0;
+
+    private int mCallCount_onSaveInstanceStateBe = 0;
+
+    private int mCallCount_onStart = 0;
+
+    private int mCallCount_onStop = 0;
+
+    private int mCallCount_onViewCreatedVwBe = 0;
+
+    private int mCallCount_onViewStateRestoredBe = 0;
+
+    private int mCallCount_registerForContextMenuVw = 0;
+
+    private int mCallCount_setAllowEnterTransitionOverlapBn = 0;
+
+    private int mCallCount_setAllowReturnTransitionOverlapBn = 0;
+
+    private int mCallCount_setArgumentsBe = 0;
+
+    private int mCallCount_setEnterSharedElementCallbackSk = 0;
+
+    private int mCallCount_setEnterTransitionOt = 0;
+
+    private int mCallCount_setExitSharedElementCallbackSk = 0;
+
+    private int mCallCount_setExitTransitionOt = 0;
+
+    private int mCallCount_setHasOptionsMenuBn = 0;
+
+    private int mCallCount_setInitialSavedStateSe = 0;
+
+    private int mCallCount_setMenuVisibilityBn = 0;
+
+    private int mCallCount_setReenterTransitionOt = 0;
+
+    private int mCallCount_setRetainInstanceBn = 0;
+
+    private int mCallCount_setReturnTransitionOt = 0;
+
+    private int mCallCount_setSharedElementEnterTransitionOt = 0;
+
+    private int mCallCount_setSharedElementReturnTransitionOt = 0;
+
+    private int mCallCount_setTargetFragmentFtIr = 0;
+
+    private int mCallCount_setUserVisibleHintBn = 0;
+
+    private int mCallCount_shouldShowRequestPermissionRationaleSg = 0;
+
+    private int mCallCount_startActivityForResultItIr = 0;
+
+    private int mCallCount_startActivityForResultItIrBe = 0;
+
+    private int mCallCount_startActivityIt = 0;
+
+    private int mCallCount_startActivityItBe = 0;
+
+    private int mCallCount_toString = 0;
+
+    private int mCallCount_unregisterForContextMenuVw = 0;
+
+    private boolean mIsOverridden_dumpSgFrPrSg = false;
+
+    private boolean mIsOverridden_getAllowEnterTransitionOverlap = false;
+
+    private boolean mIsOverridden_getAllowReturnTransitionOverlap = false;
+
+    private boolean mIsOverridden_getContext = false;
+
+    private boolean mIsOverridden_getEnterTransition = false;
+
+    private boolean mIsOverridden_getExitTransition = false;
+
+    private boolean mIsOverridden_getLayoutInflaterBe = false;
+
+    private boolean mIsOverridden_getLoaderManager = false;
+
+    private boolean mIsOverridden_getReenterTransition = false;
+
+    private boolean mIsOverridden_getReturnTransition = false;
+
+    private boolean mIsOverridden_getSharedElementEnterTransition = false;
+
+    private boolean mIsOverridden_getSharedElementReturnTransition = false;
+
+    private boolean mIsOverridden_getUserVisibleHint = false;
+
+    private boolean mIsOverridden_getView = false;
+
+    private boolean mIsOverridden_onActivityCreatedBe = false;
+
+    private boolean mIsOverridden_onActivityResultIrIrIt = false;
+
+    private boolean mIsOverridden_onAttachAy = false;
+
+    private boolean mIsOverridden_onAttachCt = false;
+
+    private boolean mIsOverridden_onConfigurationChangedCn = false;
+
+    private boolean mIsOverridden_onContextItemSelectedMm = false;
+
+    private boolean mIsOverridden_onCreateAnimationIrBnIr = false;
+
+    private boolean mIsOverridden_onCreateBe = false;
+
+    private boolean mIsOverridden_onCreateContextMenuCuVwCo = false;
+
+    private boolean mIsOverridden_onCreateOptionsMenuMuMr = false;
+
+    private boolean mIsOverridden_onCreateViewLrVpBe = false;
+
+    private boolean mIsOverridden_onDestroy = false;
+
+    private boolean mIsOverridden_onDestroyOptionsMenu = false;
+
+    private boolean mIsOverridden_onDestroyView = false;
+
+    private boolean mIsOverridden_onDetach = false;
+
+    private boolean mIsOverridden_onHiddenChangedBn = false;
+
+    private boolean mIsOverridden_onInflateAyAtBe = false;
+
+    private boolean mIsOverridden_onInflateCtAtBe = false;
+
+    private boolean mIsOverridden_onLowMemory = false;
+
+    private boolean mIsOverridden_onOptionsItemSelectedMm = false;
+
+    private boolean mIsOverridden_onOptionsMenuClosedMu = false;
+
+    private boolean mIsOverridden_onPause = false;
+
+    private boolean mIsOverridden_onPrepareOptionsMenuMu = false;
+
+    private boolean mIsOverridden_onRequestPermissionsResultIrSgit = false;
+
+    private boolean mIsOverridden_onResume = false;
+
+    private boolean mIsOverridden_onSaveInstanceStateBe = false;
+
+    private boolean mIsOverridden_onStart = false;
+
+    private boolean mIsOverridden_onStop = false;
+
+    private boolean mIsOverridden_onViewCreatedVwBe = false;
+
+    private boolean mIsOverridden_onViewStateRestoredBe = false;
+
+    private boolean mIsOverridden_registerForContextMenuVw = false;
+
+    private boolean mIsOverridden_setAllowEnterTransitionOverlapBn = false;
+
+    private boolean mIsOverridden_setAllowReturnTransitionOverlapBn = false;
+
+    private boolean mIsOverridden_setArgumentsBe = false;
+
+    private boolean mIsOverridden_setEnterSharedElementCallbackSk = false;
+
+    private boolean mIsOverridden_setEnterTransitionOt = false;
+
+    private boolean mIsOverridden_setExitSharedElementCallbackSk = false;
+
+    private boolean mIsOverridden_setExitTransitionOt = false;
+
+    private boolean mIsOverridden_setHasOptionsMenuBn = false;
+
+    private boolean mIsOverridden_setInitialSavedStateSe = false;
+
+    private boolean mIsOverridden_setMenuVisibilityBn = false;
+
+    private boolean mIsOverridden_setReenterTransitionOt = false;
+
+    private boolean mIsOverridden_setRetainInstanceBn = false;
+
+    private boolean mIsOverridden_setReturnTransitionOt = false;
+
+    private boolean mIsOverridden_setSharedElementEnterTransitionOt = false;
+
+    private boolean mIsOverridden_setSharedElementReturnTransitionOt = false;
+
+    private boolean mIsOverridden_setTargetFragmentFtIr = false;
+
+    private boolean mIsOverridden_setUserVisibleHintBn = false;
+
+    private boolean mIsOverridden_shouldShowRequestPermissionRationaleSg = false;
+
+    private boolean mIsOverridden_startActivityForResultItIr = false;
+
+    private boolean mIsOverridden_startActivityForResultItIrBe = false;
+
+    private boolean mIsOverridden_startActivityIt = false;
+
+    private boolean mIsOverridden_startActivityItBe = false;
+
+    private boolean mIsOverridden_toString = false;
+
+    private boolean mIsOverridden_unregisterForContextMenuVw = false;
+
+    private final HashMap<String, List<FragmentPlugin>> mMethodImplementingPlugins
+            = new HashMap<>();
 
     public FragmentDelegate(final ICompositeFragment icompositefragment) {
         super(icompositefragment);
 
     }
 
+    @Override
+    public Removable addPlugin(final FragmentPlugin plugin) {
+        mMethodImplementingPlugins.clear();
+        mIsOverridden_dumpSgFrPrSg = true;
+        mIsOverridden_getAllowEnterTransitionOverlap = true;
+        mIsOverridden_getAllowReturnTransitionOverlap = true;
+        mIsOverridden_getContext = true;
+        mIsOverridden_getEnterTransition = true;
+        mIsOverridden_getExitTransition = true;
+        mIsOverridden_getLayoutInflaterBe = true;
+        mIsOverridden_getLoaderManager = true;
+        mIsOverridden_getReenterTransition = true;
+        mIsOverridden_getReturnTransition = true;
+        mIsOverridden_getSharedElementEnterTransition = true;
+        mIsOverridden_getSharedElementReturnTransition = true;
+        mIsOverridden_getUserVisibleHint = true;
+        mIsOverridden_getView = true;
+        mIsOverridden_onActivityCreatedBe = true;
+        mIsOverridden_onActivityResultIrIrIt = true;
+        mIsOverridden_onAttachCt = true;
+        mIsOverridden_onAttachAy = true;
+        mIsOverridden_onConfigurationChangedCn = true;
+        mIsOverridden_onContextItemSelectedMm = true;
+        mIsOverridden_onCreateBe = true;
+        mIsOverridden_onCreateAnimationIrBnIr = true;
+        mIsOverridden_onCreateContextMenuCuVwCo = true;
+        mIsOverridden_onCreateOptionsMenuMuMr = true;
+        mIsOverridden_onCreateViewLrVpBe = true;
+        mIsOverridden_onDestroy = true;
+        mIsOverridden_onDestroyOptionsMenu = true;
+        mIsOverridden_onDestroyView = true;
+        mIsOverridden_onDetach = true;
+        mIsOverridden_onHiddenChangedBn = true;
+        mIsOverridden_onInflateCtAtBe = true;
+        mIsOverridden_onInflateAyAtBe = true;
+        mIsOverridden_onLowMemory = true;
+        mIsOverridden_onOptionsItemSelectedMm = true;
+        mIsOverridden_onOptionsMenuClosedMu = true;
+        mIsOverridden_onPause = true;
+        mIsOverridden_onPrepareOptionsMenuMu = true;
+        mIsOverridden_onRequestPermissionsResultIrSgit = true;
+        mIsOverridden_onResume = true;
+        mIsOverridden_onSaveInstanceStateBe = true;
+        mIsOverridden_onStart = true;
+        mIsOverridden_onStop = true;
+        mIsOverridden_onViewCreatedVwBe = true;
+        mIsOverridden_onViewStateRestoredBe = true;
+        mIsOverridden_registerForContextMenuVw = true;
+        mIsOverridden_setAllowEnterTransitionOverlapBn = true;
+        mIsOverridden_setAllowReturnTransitionOverlapBn = true;
+        mIsOverridden_setArgumentsBe = true;
+        mIsOverridden_setEnterSharedElementCallbackSk = true;
+        mIsOverridden_setEnterTransitionOt = true;
+        mIsOverridden_setExitSharedElementCallbackSk = true;
+        mIsOverridden_setExitTransitionOt = true;
+        mIsOverridden_setHasOptionsMenuBn = true;
+        mIsOverridden_setInitialSavedStateSe = true;
+        mIsOverridden_setMenuVisibilityBn = true;
+        mIsOverridden_setReenterTransitionOt = true;
+        mIsOverridden_setRetainInstanceBn = true;
+        mIsOverridden_setReturnTransitionOt = true;
+        mIsOverridden_setSharedElementEnterTransitionOt = true;
+        mIsOverridden_setSharedElementReturnTransitionOt = true;
+        mIsOverridden_setTargetFragmentFtIr = true;
+        mIsOverridden_setUserVisibleHintBn = true;
+        mIsOverridden_shouldShowRequestPermissionRationaleSg = true;
+        mIsOverridden_startActivityIt = true;
+        mIsOverridden_startActivityItBe = true;
+        mIsOverridden_startActivityForResultItIr = true;
+        mIsOverridden_startActivityForResultItIrBe = true;
+        mIsOverridden_toString = true;
+        mIsOverridden_unregisterForContextMenuVw = true;
+
+        return super.addPlugin(plugin);
+    }
 
     public void dump(final String prefix, final FileDescriptor fd, final PrintWriter writer,
             final String[] args) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_dumpSgFrPrSg) {
             getOriginal().super_dump(prefix, fd, writer, args);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_dumpSgFrPrSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_dumpSgFrPrSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("dump(String, FileDescriptor, PrintWriter, String[])");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("dump", String.class,
+                        FileDescriptor.class, PrintWriter.class, String[].class);
+                mMethodImplementingPlugins
+                        .put("dump(String, FileDescriptor, PrintWriter, String[])",
+                                implementingPlugins);
+                mIsOverridden_dumpSgFrPrSg = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid4<String, FileDescriptor, PrintWriter, String[]> superCall
                 = new CallVoid4<String, FileDescriptor, PrintWriter, String[]>(
@@ -70,11 +448,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public boolean getAllowEnterTransitionOverlap() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getAllowEnterTransitionOverlap) {
             return getOriginal().super_getAllowEnterTransitionOverlap();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getAllowEnterTransitionOverlap < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getAllowEnterTransitionOverlap++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getAllowEnterTransitionOverlap()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getAllowEnterTransitionOverlap");
+                mMethodImplementingPlugins
+                        .put("getAllowEnterTransitionOverlap()", implementingPlugins);
+                mIsOverridden_getAllowEnterTransitionOverlap = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>(
                 "getAllowEnterTransitionOverlap()") {
@@ -92,11 +485,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public boolean getAllowReturnTransitionOverlap() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getAllowReturnTransitionOverlap) {
             return getOriginal().super_getAllowReturnTransitionOverlap();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getAllowReturnTransitionOverlap < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getAllowReturnTransitionOverlap++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getAllowReturnTransitionOverlap()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getAllowReturnTransitionOverlap");
+                mMethodImplementingPlugins
+                        .put("getAllowReturnTransitionOverlap()", implementingPlugins);
+                mIsOverridden_getAllowReturnTransitionOverlap = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>(
                 "getAllowReturnTransitionOverlap()") {
@@ -114,11 +522,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Context getContext() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getContext) {
             return getOriginal().super_getContext();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getContext < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getContext++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getContext()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getContext");
+                mMethodImplementingPlugins.put("getContext()", implementingPlugins);
+                mIsOverridden_getContext = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Context> superCall = new CallFun0<Context>("getContext()") {
 
@@ -135,11 +557,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Object getEnterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getEnterTransition) {
             return getOriginal().super_getEnterTransition();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getEnterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getEnterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getEnterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getEnterTransition");
+                mMethodImplementingPlugins.put("getEnterTransition()", implementingPlugins);
+                mIsOverridden_getEnterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Object> superCall = new CallFun0<Object>("getEnterTransition()") {
 
@@ -156,11 +592,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Object getExitTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getExitTransition) {
             return getOriginal().super_getExitTransition();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getExitTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getExitTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getExitTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getExitTransition");
+                mMethodImplementingPlugins.put("getExitTransition()", implementingPlugins);
+                mIsOverridden_getExitTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Object> superCall = new CallFun0<Object>("getExitTransition()") {
 
@@ -177,11 +627,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public LayoutInflater getLayoutInflater(final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getLayoutInflaterBe) {
             return getOriginal().super_getLayoutInflater(savedInstanceState);
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getLayoutInflaterBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getLayoutInflaterBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getLayoutInflater(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getLayoutInflater", Bundle.class);
+                mMethodImplementingPlugins.put("getLayoutInflater(Bundle)", implementingPlugins);
+                mIsOverridden_getLayoutInflaterBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<LayoutInflater, Bundle> superCall = new CallFun1<LayoutInflater, Bundle>(
                 "getLayoutInflater(Bundle)") {
@@ -199,11 +663,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public LoaderManager getLoaderManager() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getLoaderManager) {
             return getOriginal().super_getLoaderManager();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getLoaderManager < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getLoaderManager++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getLoaderManager()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getLoaderManager");
+                mMethodImplementingPlugins.put("getLoaderManager()", implementingPlugins);
+                mIsOverridden_getLoaderManager = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<LoaderManager> superCall = new CallFun0<LoaderManager>(
                 "getLoaderManager()") {
@@ -221,11 +699,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Object getReenterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getReenterTransition) {
             return getOriginal().super_getReenterTransition();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getReenterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getReenterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getReenterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getReenterTransition");
+                mMethodImplementingPlugins.put("getReenterTransition()", implementingPlugins);
+                mIsOverridden_getReenterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Object> superCall = new CallFun0<Object>("getReenterTransition()") {
 
@@ -242,11 +734,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Object getReturnTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getReturnTransition) {
             return getOriginal().super_getReturnTransition();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getReturnTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getReturnTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getReturnTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getReturnTransition");
+                mMethodImplementingPlugins.put("getReturnTransition()", implementingPlugins);
+                mIsOverridden_getReturnTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Object> superCall = new CallFun0<Object>("getReturnTransition()") {
 
@@ -263,11 +769,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Object getSharedElementEnterTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSharedElementEnterTransition) {
             return getOriginal().super_getSharedElementEnterTransition();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getSharedElementEnterTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSharedElementEnterTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSharedElementEnterTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSharedElementEnterTransition");
+                mMethodImplementingPlugins
+                        .put("getSharedElementEnterTransition()", implementingPlugins);
+                mIsOverridden_getSharedElementEnterTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Object> superCall = new CallFun0<Object>(
                 "getSharedElementEnterTransition()") {
@@ -285,11 +806,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Object getSharedElementReturnTransition() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getSharedElementReturnTransition) {
             return getOriginal().super_getSharedElementReturnTransition();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getSharedElementReturnTransition < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getSharedElementReturnTransition++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getSharedElementReturnTransition()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getSharedElementReturnTransition");
+                mMethodImplementingPlugins
+                        .put("getSharedElementReturnTransition()", implementingPlugins);
+                mIsOverridden_getSharedElementReturnTransition = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Object> superCall = new CallFun0<Object>(
                 "getSharedElementReturnTransition()") {
@@ -307,11 +843,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public boolean getUserVisibleHint() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getUserVisibleHint) {
             return getOriginal().super_getUserVisibleHint();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getUserVisibleHint < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getUserVisibleHint++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("getUserVisibleHint()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getUserVisibleHint");
+                mMethodImplementingPlugins.put("getUserVisibleHint()", implementingPlugins);
+                mIsOverridden_getUserVisibleHint = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<Boolean> superCall = new CallFun0<Boolean>("getUserVisibleHint()") {
 
@@ -328,11 +878,24 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public View getView() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_getView) {
             return getOriginal().super_getView();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_getView < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_getView++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins.get("getView()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("getView");
+                mMethodImplementingPlugins.put("getView()", implementingPlugins);
+                mIsOverridden_getView = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<View> superCall = new CallFun0<View>("getView()") {
 
@@ -349,12 +912,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onActivityCreated(@Nullable final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onActivityCreatedBe) {
             getOriginal().super_onActivityCreated(savedInstanceState);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onActivityCreatedBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onActivityCreatedBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onActivityCreated(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onActivityCreated", Bundle.class);
+                mMethodImplementingPlugins.put("onActivityCreated(Bundle)", implementingPlugins);
+                mIsOverridden_onActivityCreatedBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onActivityCreated(Bundle)") {
 
@@ -371,12 +948,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onActivityResultIrIrIt) {
             getOriginal().super_onActivityResult(requestCode, resultCode, data);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onActivityResultIrIrIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onActivityResultIrIrIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onActivityResult(Integer, Integer, Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onActivityResult", Integer.class,
+                        Integer.class, Intent.class);
+                mMethodImplementingPlugins
+                        .put("onActivityResult(Integer, Integer, Intent)", implementingPlugins);
+                mIsOverridden_onActivityResultIrIrIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Integer, Integer, Intent> superCall
                 = new CallVoid3<Integer, Integer, Intent>(
@@ -396,12 +989,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onAttach(final Context context) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onAttachCt) {
             getOriginal().super_onAttach(context);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onAttachCt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onAttachCt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onAttach(Context)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onAttach", Context.class);
+                mMethodImplementingPlugins.put("onAttach(Context)", implementingPlugins);
+                mIsOverridden_onAttachCt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Context> superCall = new CallVoid1<Context>("onAttach(Context)") {
 
@@ -418,12 +1025,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onAttach(final Activity activity) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onAttachAy) {
             getOriginal().super_onAttach(activity);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onAttachAy < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onAttachAy++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onAttach(Activity)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onAttach", Activity.class);
+                mMethodImplementingPlugins.put("onAttach(Activity)", implementingPlugins);
+                mIsOverridden_onAttachAy = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Activity> superCall = new CallVoid1<Activity>("onAttach(Activity)") {
 
@@ -440,12 +1061,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onConfigurationChanged(final Configuration newConfig) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onConfigurationChangedCn) {
             getOriginal().super_onConfigurationChanged(newConfig);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onConfigurationChangedCn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onConfigurationChangedCn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onConfigurationChanged(Configuration)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onConfigurationChanged",
+                        Configuration.class);
+                mMethodImplementingPlugins
+                        .put("onConfigurationChanged(Configuration)", implementingPlugins);
+                mIsOverridden_onConfigurationChangedCn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Configuration> superCall = new CallVoid1<Configuration>(
                 "onConfigurationChanged(Configuration)") {
@@ -463,11 +1100,27 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public boolean onContextItemSelected(final MenuItem item) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onContextItemSelectedMm) {
             return getOriginal().super_onContextItemSelected(item);
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onContextItemSelectedMm < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onContextItemSelectedMm++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onContextItemSelected(MenuItem)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onContextItemSelected",
+                        MenuItem.class);
+                mMethodImplementingPlugins
+                        .put("onContextItemSelected(MenuItem)", implementingPlugins);
+                mIsOverridden_onContextItemSelectedMm = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onContextItemSelected(MenuItem)") {
@@ -485,12 +1138,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onCreate(@Nullable final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateBe) {
             getOriginal().super_onCreate(savedInstanceState);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onCreateBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreate(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreate", Bundle.class);
+                mMethodImplementingPlugins.put("onCreate(Bundle)", implementingPlugins);
+                mIsOverridden_onCreateBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onCreate(Bundle)") {
 
@@ -507,11 +1174,27 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public Animation onCreateAnimation(final int transit, final boolean enter, final int nextAnim) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateAnimationIrBnIr) {
             return getOriginal().super_onCreateAnimation(transit, enter, nextAnim);
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onCreateAnimationIrBnIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateAnimationIrBnIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateAnimation(Integer, Boolean, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateAnimation", Integer.class,
+                        Boolean.class, Integer.class);
+                mMethodImplementingPlugins
+                        .put("onCreateAnimation(Integer, Boolean, Integer)", implementingPlugins);
+                mIsOverridden_onCreateAnimationIrBnIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<Animation, Integer, Boolean, Integer> superCall
                 = new CallFun3<Animation, Integer, Boolean, Integer>(
@@ -532,12 +1215,29 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
     public void onCreateContextMenu(final ContextMenu menu, final View v,
             final ContextMenu.ContextMenuInfo menuInfo) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateContextMenuCuVwCo) {
             getOriginal().super_onCreateContextMenu(menu, v, menuInfo);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onCreateContextMenuCuVwCo < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateContextMenuCuVwCo++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateContextMenu",
+                        ContextMenu.class, View.class, ContextMenu.ContextMenuInfo.class);
+                mMethodImplementingPlugins
+                        .put("onCreateContextMenu(ContextMenu, View, ContextMenu.ContextMenuInfo)",
+                                implementingPlugins);
+                mIsOverridden_onCreateContextMenuCuVwCo = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo> superCall
                 = new CallVoid3<ContextMenu, View, ContextMenu.ContextMenuInfo>(
@@ -557,12 +1257,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onCreateOptionsMenu(final Menu menu, final MenuInflater inflater) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateOptionsMenuMuMr) {
             getOriginal().super_onCreateOptionsMenu(menu, inflater);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onCreateOptionsMenuMuMr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateOptionsMenuMuMr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateOptionsMenu(Menu, MenuInflater)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateOptionsMenu", Menu.class,
+                        MenuInflater.class);
+                mMethodImplementingPlugins
+                        .put("onCreateOptionsMenu(Menu, MenuInflater)", implementingPlugins);
+                mIsOverridden_onCreateOptionsMenuMuMr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Menu, MenuInflater> superCall = new CallVoid2<Menu, MenuInflater>(
                 "onCreateOptionsMenu(Menu, MenuInflater)") {
@@ -581,11 +1297,27 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
     public View onCreateView(final LayoutInflater inflater, @Nullable final ViewGroup container,
             @Nullable final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onCreateViewLrVpBe) {
             return getOriginal().super_onCreateView(inflater, container, savedInstanceState);
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onCreateViewLrVpBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onCreateViewLrVpBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onCreateView(LayoutInflater, ViewGroup, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onCreateView", LayoutInflater.class,
+                        ViewGroup.class, Bundle.class);
+                mMethodImplementingPlugins.put("onCreateView(LayoutInflater, ViewGroup, Bundle)",
+                        implementingPlugins);
+                mIsOverridden_onCreateViewLrVpBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun3<View, LayoutInflater, ViewGroup, Bundle> superCall
                 = new CallFun3<View, LayoutInflater, ViewGroup, Bundle>(
@@ -607,12 +1339,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onDestroy() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onDestroy) {
             getOriginal().super_onDestroy();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onDestroy < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onDestroy++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onDestroy()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onDestroy");
+                mMethodImplementingPlugins.put("onDestroy()", implementingPlugins);
+                mIsOverridden_onDestroy = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onDestroy()") {
 
@@ -629,12 +1375,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onDestroyOptionsMenu() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onDestroyOptionsMenu) {
             getOriginal().super_onDestroyOptionsMenu();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onDestroyOptionsMenu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onDestroyOptionsMenu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onDestroyOptionsMenu()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onDestroyOptionsMenu");
+                mMethodImplementingPlugins.put("onDestroyOptionsMenu()", implementingPlugins);
+                mIsOverridden_onDestroyOptionsMenu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onDestroyOptionsMenu()") {
 
@@ -651,12 +1411,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onDestroyView() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onDestroyView) {
             getOriginal().super_onDestroyView();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onDestroyView < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onDestroyView++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onDestroyView()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onDestroyView");
+                mMethodImplementingPlugins.put("onDestroyView()", implementingPlugins);
+                mIsOverridden_onDestroyView = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onDestroyView()") {
 
@@ -673,12 +1447,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onDetach() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onDetach) {
             getOriginal().super_onDetach();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onDetach < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onDetach++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins.get("onDetach()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onDetach");
+                mMethodImplementingPlugins.put("onDetach()", implementingPlugins);
+                mIsOverridden_onDetach = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onDetach()") {
 
@@ -695,12 +1482,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onHiddenChanged(final boolean hidden) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onHiddenChangedBn) {
             getOriginal().super_onHiddenChanged(hidden);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onHiddenChangedBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onHiddenChangedBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onHiddenChanged(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onHiddenChanged", Boolean.class);
+                mMethodImplementingPlugins.put("onHiddenChanged(Boolean)", implementingPlugins);
+                mIsOverridden_onHiddenChangedBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("onHiddenChanged(Boolean)") {
 
@@ -718,12 +1519,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
     public void onInflate(final Context context, final AttributeSet attrs,
             final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onInflateCtAtBe) {
             getOriginal().super_onInflate(context, attrs, savedInstanceState);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onInflateCtAtBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onInflateCtAtBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onInflate(Context, AttributeSet, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onInflate", Context.class,
+                        AttributeSet.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("onInflate(Context, AttributeSet, Bundle)", implementingPlugins);
+                mIsOverridden_onInflateCtAtBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Context, AttributeSet, Bundle> superCall
                 = new CallVoid3<Context, AttributeSet, Bundle>(
@@ -744,12 +1561,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
     public void onInflate(final Activity activity, final AttributeSet attrs,
             final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onInflateAyAtBe) {
             getOriginal().super_onInflate(activity, attrs, savedInstanceState);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onInflateAyAtBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onInflateAyAtBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onInflate(Activity, AttributeSet, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onInflate", Activity.class,
+                        AttributeSet.class, Bundle.class);
+                mMethodImplementingPlugins
+                        .put("onInflate(Activity, AttributeSet, Bundle)", implementingPlugins);
+                mIsOverridden_onInflateAyAtBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Activity, AttributeSet, Bundle> superCall
                 = new CallVoid3<Activity, AttributeSet, Bundle>(
@@ -769,12 +1602,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onLowMemory() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onLowMemory) {
             getOriginal().super_onLowMemory();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onLowMemory < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onLowMemory++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onLowMemory()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onLowMemory");
+                mMethodImplementingPlugins.put("onLowMemory()", implementingPlugins);
+                mIsOverridden_onLowMemory = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onLowMemory()") {
 
@@ -791,11 +1638,27 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public boolean onOptionsItemSelected(final MenuItem item) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onOptionsItemSelectedMm) {
             return getOriginal().super_onOptionsItemSelected(item);
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onOptionsItemSelectedMm < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onOptionsItemSelectedMm++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onOptionsItemSelected(MenuItem)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onOptionsItemSelected",
+                        MenuItem.class);
+                mMethodImplementingPlugins
+                        .put("onOptionsItemSelected(MenuItem)", implementingPlugins);
+                mIsOverridden_onOptionsItemSelectedMm = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, MenuItem> superCall = new CallFun1<Boolean, MenuItem>(
                 "onOptionsItemSelected(MenuItem)") {
@@ -813,12 +1676,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onOptionsMenuClosed(final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onOptionsMenuClosedMu) {
             getOriginal().super_onOptionsMenuClosed(menu);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onOptionsMenuClosedMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onOptionsMenuClosedMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onOptionsMenuClosed(Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onOptionsMenuClosed", Menu.class);
+                mMethodImplementingPlugins.put("onOptionsMenuClosed(Menu)", implementingPlugins);
+                mIsOverridden_onOptionsMenuClosedMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onOptionsMenuClosed(Menu)") {
 
@@ -835,12 +1712,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onPause() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPause) {
             getOriginal().super_onPause();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onPause < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPause++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins.get("onPause()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPause");
+                mMethodImplementingPlugins.put("onPause()", implementingPlugins);
+                mIsOverridden_onPause = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onPause()") {
 
@@ -857,12 +1747,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onPrepareOptionsMenu(final Menu menu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onPrepareOptionsMenuMu) {
             getOriginal().super_onPrepareOptionsMenu(menu);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onPrepareOptionsMenuMu < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onPrepareOptionsMenuMu++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onPrepareOptionsMenu(Menu)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onPrepareOptionsMenu", Menu.class);
+                mMethodImplementingPlugins.put("onPrepareOptionsMenu(Menu)", implementingPlugins);
+                mIsOverridden_onPrepareOptionsMenuMu = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Menu> superCall = new CallVoid1<Menu>("onPrepareOptionsMenu(Menu)") {
 
@@ -880,12 +1784,29 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
     public void onRequestPermissionsResult(final int requestCode,
             @NonNull final String[] permissions, @NonNull final int[] grantResults) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onRequestPermissionsResultIrSgit) {
             getOriginal().super_onRequestPermissionsResult(requestCode, permissions, grantResults);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onRequestPermissionsResultIrSgit < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onRequestPermissionsResultIrSgit++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onRequestPermissionsResult(Integer, String[], int[])");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onRequestPermissionsResult",
+                        Integer.class, String[].class, int[].class);
+                mMethodImplementingPlugins
+                        .put("onRequestPermissionsResult(Integer, String[], int[])",
+                                implementingPlugins);
+                mIsOverridden_onRequestPermissionsResultIrSgit = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Integer, String[], int[]> superCall
                 = new CallVoid3<Integer, String[], int[]>(
@@ -907,12 +1828,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onResume() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onResume) {
             getOriginal().super_onResume();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onResume < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onResume++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins.get("onResume()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onResume");
+                mMethodImplementingPlugins.put("onResume()", implementingPlugins);
+                mIsOverridden_onResume = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onResume()") {
 
@@ -929,12 +1863,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onSaveInstanceState(final Bundle outState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onSaveInstanceStateBe) {
             getOriginal().super_onSaveInstanceState(outState);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onSaveInstanceStateBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onSaveInstanceStateBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onSaveInstanceState(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onSaveInstanceState", Bundle.class);
+                mMethodImplementingPlugins.put("onSaveInstanceState(Bundle)", implementingPlugins);
+                mIsOverridden_onSaveInstanceStateBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onSaveInstanceState(Bundle)") {
 
@@ -951,12 +1899,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onStart() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onStart) {
             getOriginal().super_onStart();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onStart < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onStart++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins.get("onStart()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onStart");
+                mMethodImplementingPlugins.put("onStart()", implementingPlugins);
+                mIsOverridden_onStart = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onStart()") {
 
@@ -973,12 +1934,25 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onStop() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onStop) {
             getOriginal().super_onStop();
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onStop < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onStop++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins.get("onStop()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onStop");
+                mMethodImplementingPlugins.put("onStop()", implementingPlugins);
+                mIsOverridden_onStop = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid0 superCall = new CallVoid0("onStop()") {
 
@@ -995,12 +1969,27 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onViewCreated(final View view, @Nullable final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onViewCreatedVwBe) {
             getOriginal().super_onViewCreated(view, savedInstanceState);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onViewCreatedVwBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onViewCreatedVwBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onViewCreated(View, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onViewCreated", View.class,
+                        Bundle.class);
+                mMethodImplementingPlugins.put("onViewCreated(View, Bundle)", implementingPlugins);
+                mIsOverridden_onViewCreatedVwBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<View, Bundle> superCall = new CallVoid2<View, Bundle>(
                 "onViewCreated(View, Bundle)") {
@@ -1018,12 +2007,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void onViewStateRestored(@Nullable final Bundle savedInstanceState) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_onViewStateRestoredBe) {
             getOriginal().super_onViewStateRestored(savedInstanceState);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_onViewStateRestoredBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_onViewStateRestoredBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("onViewStateRestored(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("onViewStateRestored", Bundle.class);
+                mMethodImplementingPlugins.put("onViewStateRestored(Bundle)", implementingPlugins);
+                mIsOverridden_onViewStateRestoredBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("onViewStateRestored(Bundle)") {
 
@@ -1040,12 +2043,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void registerForContextMenu(final View view) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_registerForContextMenuVw) {
             getOriginal().super_registerForContextMenu(view);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_registerForContextMenuVw < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_registerForContextMenuVw++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("registerForContextMenu(View)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("registerForContextMenu", View.class);
+                mMethodImplementingPlugins.put("registerForContextMenu(View)", implementingPlugins);
+                mIsOverridden_registerForContextMenuVw = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<View> superCall = new CallVoid1<View>("registerForContextMenu(View)") {
 
@@ -1062,12 +2079,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setAllowEnterTransitionOverlap(final boolean allow) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setAllowEnterTransitionOverlapBn) {
             getOriginal().super_setAllowEnterTransitionOverlap(allow);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setAllowEnterTransitionOverlapBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setAllowEnterTransitionOverlapBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setAllowEnterTransitionOverlap(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setAllowEnterTransitionOverlap",
+                        Boolean.class);
+                mMethodImplementingPlugins
+                        .put("setAllowEnterTransitionOverlap(Boolean)", implementingPlugins);
+                mIsOverridden_setAllowEnterTransitionOverlapBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
                 "setAllowEnterTransitionOverlap(Boolean)") {
@@ -1085,12 +2118,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setAllowReturnTransitionOverlap(final boolean allow) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setAllowReturnTransitionOverlapBn) {
             getOriginal().super_setAllowReturnTransitionOverlap(allow);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setAllowReturnTransitionOverlapBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setAllowReturnTransitionOverlapBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setAllowReturnTransitionOverlap(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setAllowReturnTransitionOverlap",
+                        Boolean.class);
+                mMethodImplementingPlugins
+                        .put("setAllowReturnTransitionOverlap(Boolean)", implementingPlugins);
+                mIsOverridden_setAllowReturnTransitionOverlapBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>(
                 "setAllowReturnTransitionOverlap(Boolean)") {
@@ -1108,12 +2157,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setArguments(final Bundle args) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setArgumentsBe) {
             getOriginal().super_setArguments(args);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setArgumentsBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setArgumentsBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setArguments(Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setArguments", Bundle.class);
+                mMethodImplementingPlugins.put("setArguments(Bundle)", implementingPlugins);
+                mIsOverridden_setArgumentsBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Bundle> superCall = new CallVoid1<Bundle>("setArguments(Bundle)") {
 
@@ -1130,12 +2193,29 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setEnterSharedElementCallback(final SharedElementCallback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setEnterSharedElementCallbackSk) {
             getOriginal().super_setEnterSharedElementCallback(callback);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setEnterSharedElementCallbackSk < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setEnterSharedElementCallbackSk++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setEnterSharedElementCallback(SharedElementCallback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setEnterSharedElementCallback",
+                        SharedElementCallback.class);
+                mMethodImplementingPlugins
+                        .put("setEnterSharedElementCallback(SharedElementCallback)",
+                                implementingPlugins);
+                mIsOverridden_setEnterSharedElementCallbackSk = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setEnterSharedElementCallback(SharedElementCallback)") {
@@ -1153,12 +2233,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setEnterTransition(final Object transition) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setEnterTransitionOt) {
             getOriginal().super_setEnterTransition(transition);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setEnterTransitionOt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setEnterTransitionOt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setEnterTransition(Object)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setEnterTransition", Object.class);
+                mMethodImplementingPlugins.put("setEnterTransition(Object)", implementingPlugins);
+                mIsOverridden_setEnterTransitionOt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Object> superCall = new CallVoid1<Object>("setEnterTransition(Object)") {
 
@@ -1175,12 +2269,29 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setExitSharedElementCallback(final SharedElementCallback callback) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setExitSharedElementCallbackSk) {
             getOriginal().super_setExitSharedElementCallback(callback);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setExitSharedElementCallbackSk < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setExitSharedElementCallbackSk++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setExitSharedElementCallback(SharedElementCallback)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setExitSharedElementCallback",
+                        SharedElementCallback.class);
+                mMethodImplementingPlugins
+                        .put("setExitSharedElementCallback(SharedElementCallback)",
+                                implementingPlugins);
+                mIsOverridden_setExitSharedElementCallbackSk = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<SharedElementCallback> superCall = new CallVoid1<SharedElementCallback>(
                 "setExitSharedElementCallback(SharedElementCallback)") {
@@ -1198,12 +2309,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setExitTransition(final Object transition) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setExitTransitionOt) {
             getOriginal().super_setExitTransition(transition);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setExitTransitionOt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setExitTransitionOt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setExitTransition(Object)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setExitTransition", Object.class);
+                mMethodImplementingPlugins.put("setExitTransition(Object)", implementingPlugins);
+                mIsOverridden_setExitTransitionOt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Object> superCall = new CallVoid1<Object>("setExitTransition(Object)") {
 
@@ -1220,12 +2345,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setHasOptionsMenu(final boolean hasMenu) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setHasOptionsMenuBn) {
             getOriginal().super_setHasOptionsMenu(hasMenu);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setHasOptionsMenuBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setHasOptionsMenuBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setHasOptionsMenu(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setHasOptionsMenu", Boolean.class);
+                mMethodImplementingPlugins.put("setHasOptionsMenu(Boolean)", implementingPlugins);
+                mIsOverridden_setHasOptionsMenuBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setHasOptionsMenu(Boolean)") {
 
@@ -1242,12 +2381,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setInitialSavedState(final Fragment.SavedState state) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setInitialSavedStateSe) {
             getOriginal().super_setInitialSavedState(state);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setInitialSavedStateSe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setInitialSavedStateSe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setInitialSavedState(Fragment.SavedState)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setInitialSavedState",
+                        Fragment.SavedState.class);
+                mMethodImplementingPlugins
+                        .put("setInitialSavedState(Fragment.SavedState)", implementingPlugins);
+                mIsOverridden_setInitialSavedStateSe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Fragment.SavedState> superCall = new CallVoid1<Fragment.SavedState>(
                 "setInitialSavedState(Fragment.SavedState)") {
@@ -1265,12 +2420,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setMenuVisibility(final boolean menuVisible) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setMenuVisibilityBn) {
             getOriginal().super_setMenuVisibility(menuVisible);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setMenuVisibilityBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setMenuVisibilityBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setMenuVisibility(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setMenuVisibility", Boolean.class);
+                mMethodImplementingPlugins.put("setMenuVisibility(Boolean)", implementingPlugins);
+                mIsOverridden_setMenuVisibilityBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setMenuVisibility(Boolean)") {
 
@@ -1287,12 +2456,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setReenterTransition(final Object transition) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setReenterTransitionOt) {
             getOriginal().super_setReenterTransition(transition);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setReenterTransitionOt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setReenterTransitionOt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setReenterTransition(Object)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setReenterTransition", Object.class);
+                mMethodImplementingPlugins.put("setReenterTransition(Object)", implementingPlugins);
+                mIsOverridden_setReenterTransitionOt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Object> superCall = new CallVoid1<Object>("setReenterTransition(Object)") {
 
@@ -1309,12 +2492,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setRetainInstance(final boolean retain) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setRetainInstanceBn) {
             getOriginal().super_setRetainInstance(retain);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setRetainInstanceBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setRetainInstanceBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setRetainInstance(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setRetainInstance", Boolean.class);
+                mMethodImplementingPlugins.put("setRetainInstance(Boolean)", implementingPlugins);
+                mIsOverridden_setRetainInstanceBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setRetainInstance(Boolean)") {
 
@@ -1331,12 +2528,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setReturnTransition(final Object transition) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setReturnTransitionOt) {
             getOriginal().super_setReturnTransition(transition);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setReturnTransitionOt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setReturnTransitionOt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setReturnTransition(Object)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setReturnTransition", Object.class);
+                mMethodImplementingPlugins.put("setReturnTransition(Object)", implementingPlugins);
+                mIsOverridden_setReturnTransitionOt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Object> superCall = new CallVoid1<Object>("setReturnTransition(Object)") {
 
@@ -1353,12 +2564,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setSharedElementEnterTransition(final Object transition) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setSharedElementEnterTransitionOt) {
             getOriginal().super_setSharedElementEnterTransition(transition);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setSharedElementEnterTransitionOt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setSharedElementEnterTransitionOt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setSharedElementEnterTransition(Object)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setSharedElementEnterTransition",
+                        Object.class);
+                mMethodImplementingPlugins
+                        .put("setSharedElementEnterTransition(Object)", implementingPlugins);
+                mIsOverridden_setSharedElementEnterTransitionOt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Object> superCall = new CallVoid1<Object>(
                 "setSharedElementEnterTransition(Object)") {
@@ -1376,12 +2603,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setSharedElementReturnTransition(final Object transition) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setSharedElementReturnTransitionOt) {
             getOriginal().super_setSharedElementReturnTransition(transition);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setSharedElementReturnTransitionOt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setSharedElementReturnTransitionOt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setSharedElementReturnTransition(Object)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setSharedElementReturnTransition",
+                        Object.class);
+                mMethodImplementingPlugins
+                        .put("setSharedElementReturnTransition(Object)", implementingPlugins);
+                mIsOverridden_setSharedElementReturnTransitionOt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Object> superCall = new CallVoid1<Object>(
                 "setSharedElementReturnTransition(Object)") {
@@ -1399,12 +2642,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setTargetFragment(final Fragment fragment, final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setTargetFragmentFtIr) {
             getOriginal().super_setTargetFragment(fragment, requestCode);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setTargetFragmentFtIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setTargetFragmentFtIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setTargetFragment(Fragment, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setTargetFragment", Fragment.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("setTargetFragment(Fragment, Integer)", implementingPlugins);
+                mIsOverridden_setTargetFragmentFtIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Fragment, Integer> superCall = new CallVoid2<Fragment, Integer>(
                 "setTargetFragment(Fragment, Integer)") {
@@ -1422,12 +2681,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void setUserVisibleHint(final boolean isVisibleToUser) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_setUserVisibleHintBn) {
             getOriginal().super_setUserVisibleHint(isVisibleToUser);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_setUserVisibleHintBn < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_setUserVisibleHintBn++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("setUserVisibleHint(Boolean)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("setUserVisibleHint", Boolean.class);
+                mMethodImplementingPlugins.put("setUserVisibleHint(Boolean)", implementingPlugins);
+                mIsOverridden_setUserVisibleHintBn = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Boolean> superCall = new CallVoid1<Boolean>("setUserVisibleHint(Boolean)") {
 
@@ -1444,11 +2717,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public boolean shouldShowRequestPermissionRationale(@NonNull final String permission) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_shouldShowRequestPermissionRationaleSg) {
             return getOriginal().super_shouldShowRequestPermissionRationale(permission);
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_shouldShowRequestPermissionRationaleSg < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_shouldShowRequestPermissionRationaleSg++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("shouldShowRequestPermissionRationale(String)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("shouldShowRequestPermissionRationale",
+                        String.class);
+                mMethodImplementingPlugins
+                        .put("shouldShowRequestPermissionRationale(String)", implementingPlugins);
+                mIsOverridden_shouldShowRequestPermissionRationaleSg = implementingPlugins.size()
+                        > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun1<Boolean, String> superCall = new CallFun1<Boolean, String>(
                 "shouldShowRequestPermissionRationale(String)") {
@@ -1467,12 +2757,26 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void startActivity(final Intent intent) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityIt) {
             getOriginal().super_startActivity(intent);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_startActivityIt < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityIt++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivity(Intent)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivity", Intent.class);
+                mMethodImplementingPlugins.put("startActivity(Intent)", implementingPlugins);
+                mIsOverridden_startActivityIt = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<Intent> superCall = new CallVoid1<Intent>("startActivity(Intent)") {
 
@@ -1489,12 +2793,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void startActivity(final Intent intent, @Nullable final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityItBe) {
             getOriginal().super_startActivity(intent, options);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_startActivityItBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityItBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivity(Intent, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivity", Intent.class,
+                        Bundle.class);
+                mMethodImplementingPlugins
+                        .put("startActivity(Intent, Bundle)", implementingPlugins);
+                mIsOverridden_startActivityItBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, Bundle> superCall = new CallVoid2<Intent, Bundle>(
                 "startActivity(Intent, Bundle)") {
@@ -1512,12 +2832,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void startActivityForResult(final Intent intent, final int requestCode) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityForResultItIr) {
             getOriginal().super_startActivityForResult(intent, requestCode);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_startActivityForResultItIr < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityForResultItIr++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityForResult(Intent, Integer)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityForResult", Intent.class,
+                        Integer.class);
+                mMethodImplementingPlugins
+                        .put("startActivityForResult(Intent, Integer)", implementingPlugins);
+                mIsOverridden_startActivityForResultItIr = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid2<Intent, Integer> superCall = new CallVoid2<Intent, Integer>(
                 "startActivityForResult(Intent, Integer)") {
@@ -1536,12 +2872,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
 
     public void startActivityForResult(final Intent intent, final int requestCode,
             @Nullable final Bundle options) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_startActivityForResultItIrBe) {
             getOriginal().super_startActivityForResult(intent, requestCode, options);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_startActivityForResultItIrBe < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_startActivityForResultItIrBe++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("startActivityForResult(Intent, Integer, Bundle)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("startActivityForResult", Intent.class,
+                        Integer.class, Bundle.class);
+                mMethodImplementingPlugins.put("startActivityForResult(Intent, Integer, Bundle)",
+                        implementingPlugins);
+                mIsOverridden_startActivityForResultItIrBe = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid3<Intent, Integer, Bundle> superCall = new CallVoid3<Intent, Integer, Bundle>(
                 "startActivityForResult(Intent, Integer, Bundle)") {
@@ -1559,11 +2911,24 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public String toString() {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_toString) {
             return getOriginal().super_toString();
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_toString < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_toString++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins.get("toString()");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("toString");
+                mMethodImplementingPlugins.put("toString()", implementingPlugins);
+                mIsOverridden_toString = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallFun0<String> superCall = new CallFun0<String>("toString()") {
 
@@ -1580,12 +2945,28 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
     }
 
     public void unregisterForContextMenu(final View view) {
-        if (mPlugins.isEmpty()) {
+        if (!mIsOverridden_unregisterForContextMenuVw) {
             getOriginal().super_unregisterForContextMenu(view);
             return;
         }
 
-        final ListIterator<FragmentPlugin> iterator = mPlugins.listIterator(mPlugins.size());
+        final ListIterator<FragmentPlugin> iterator;
+        if (mCallCount_unregisterForContextMenuVw < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+            mCallCount_unregisterForContextMenuVw++;
+            iterator = mPlugins.listIterator(mPlugins.size());
+        } else {
+            List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
+                    .get("unregisterForContextMenu(View)");
+            if (implementingPlugins == null) {
+                implementingPlugins = getImplementingPlugins("unregisterForContextMenu",
+                        View.class);
+                mMethodImplementingPlugins
+                        .put("unregisterForContextMenu(View)", implementingPlugins);
+                mIsOverridden_unregisterForContextMenuVw = implementingPlugins.size() > 0;
+            }
+
+            iterator = implementingPlugins.listIterator(implementingPlugins.size());
+        }
 
         final CallVoid1<View> superCall = new CallVoid1<View>("unregisterForContextMenu(View)") {
 
@@ -1599,6 +2980,21 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
             }
         };
         superCall.call(view);
+    }
+
+
+    private List<FragmentPlugin> getImplementingPlugins(final String methodName,
+            final Class<?>... parameterTypes) {
+        synchronized (mPlugins) {
+            final ArrayList<FragmentPlugin> implementingPlugins = new ArrayList<>();
+            for (int i = 0; i < mPlugins.size(); i++) {
+                final FragmentPlugin plugin = mPlugins.get(i);
+                if (plugin.isMethodOverridden(methodName, parameterTypes)) {
+                    implementingPlugins.add(plugin);
+                }
+            }
+            return implementingPlugins;
+        }
     }
 
 

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentDelegate.java
@@ -45,7 +45,7 @@ import java.util.ListIterator;
 public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, FragmentPlugin> {
 
     @VisibleForTesting
-    static final int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
+    int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
 
     private int mCallCount_dumpSgFrPrSg = 0;
 
@@ -1246,8 +1246,8 @@ public class FragmentDelegate extends AbstractDelegate<ICompositeFragment, Fragm
             List<FragmentPlugin> implementingPlugins = mMethodImplementingPlugins
                     .get("onCreateAnimation(Integer, Boolean, Integer)");
             if (implementingPlugins == null) {
-                implementingPlugins = getImplementingPlugins("onCreateAnimation", Integer.class,
-                        Boolean.class, Integer.class);
+                implementingPlugins = getImplementingPlugins("onCreateAnimation", Integer.TYPE,
+                        Boolean.TYPE, Integer.TYPE);
                 mMethodImplementingPlugins
                         .put("onCreateAnimation(Integer, Boolean, Integer)", implementingPlugins);
                 mIsOverridden_onCreateAnimationIrBnIr = implementingPlugins.size() > 0;

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentPlugin.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentPlugin.java
@@ -32,6 +32,7 @@ import android.view.animation.Animation;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
+import java.lang.reflect.Method;
 
 @SuppressWarnings("unused")
 public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
@@ -501,6 +502,18 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
             mSuperListeners.push(superCall);
             return getView();
         }
+    }
+
+    boolean isMethodOverridden(final String methodName, final Class<?>... parameterTypes) {
+        try {
+            final Class<? extends FragmentPlugin> myClass = this.getClass();
+            final Method method = myClass.getMethod(methodName, parameterTypes);
+            if (method.getDeclaringClass() == FragmentPlugin.class) {
+                return false;
+            }
+        } catch (NoSuchMethodException ignore) {
+        }
+        return true;
     }
 
     void onActivityCreated(final CallVoid1<Bundle> superCall,

--- a/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentPlugin.java
+++ b/fragment/src/main/java/com/pascalwelsch/compositeandroid/fragment/FragmentPlugin.java
@@ -535,12 +535,10 @@ public class FragmentPlugin extends AbstractPlugin<Fragment, FragmentDelegate> {
         try {
             final Class<? extends FragmentPlugin> myClass = this.getClass();
             final Method method = myClass.getMethod(methodName, parameterTypes);
-            if (method.getDeclaringClass() == FragmentPlugin.class) {
-                return false;
-            }
+            return method.getDeclaringClass() != FragmentPlugin.class;
         } catch (NoSuchMethodException ignore) {
+            return false;
         }
-        return true;
     }
 
     void onActivityCreated(final CallVoid1<Bundle> superCall,

--- a/generator/src/main/kotlin/parse/AnalyzedJavaFile.kt
+++ b/generator/src/main/kotlin/parse/AnalyzedJavaFile.kt
@@ -86,4 +86,8 @@ data class AnalyzedJavaMethod(
             emptyList()
         }
     }
+
+    val identifier = "$name(${parameterTypes.joinToString()})"
+    val uniqueName = "$name${parameterTypes.map { "${it.first()}${it.last{it.isLetter()}}" }.joinToString("")}"
+
 }

--- a/generator/src/main/kotlin/types/Activity.kt
+++ b/generator/src/main/kotlin/types/Activity.kt
@@ -39,7 +39,9 @@ fun generateActivity() {
             "ICompositeActivity",
             "ActivityPlugin",
             extends = "AbstractDelegate<ICompositeActivity, ActivityPlugin>",
-            additionalImports = "import java.util.ListIterator;",
+            additionalImports = """
+            |import android.support.v4.app.*;
+            """.replaceIndentByMargin(),
             addCodeToClass = delegate_custom_nonConfigurationInstance_handling)
 
     writePlugin(outPath,

--- a/generator/src/main/kotlin/writer/DelegateWriter.kt
+++ b/generator/src/main/kotlin/writer/DelegateWriter.kt
@@ -75,33 +75,58 @@ fun writeDelegate(outPath: String,
         """.replaceIndentByMargin()
     }
 
-    fun addPlugin(): String {
-        return if (superClassDelegateName.isEmpty()) "" else """
-        |@Override
-        |public Removable addPlugin(final $pluginName plugin) {
-        |    final Removable removable = super.addPlugin(plugin);
-        |    final Removable superRemovable = m$superClassDelegateName.addPlugin(plugin);
-        |    return new Removable() {
-        |        @Override
-        |        public void remove() {
-        |            removable.remove();
-        |            superRemovable.remove();
-        |        }
-        |    };
-        |}
-        """.replaceIndentByMargin()
+
+    fun resetOptimizations(): String {
+        val sb = StringBuilder()
+        sb.appendln("    mMethodImplementingPlugins.clear();")
+        for (method in distinctMethods) {
+            val isSameMethod: (AnalyzedJavaMethod) -> Boolean = { method.name == it.name && method.parameterTypes == it.parameterTypes }
+            val definedInSuperComposite = superClassInputFile?.methods
+                    ?.filter(isSameMethod)?.isNotEmpty() ?: false
+
+            if (!definedInSuperComposite)
+                sb.appendln("        mIsOverridden_${method.uniqueName} = true;")
+        }
+
+        return sb.toString()
     }
+
+    fun addPluginSuper(): String =
+            if (superClassDelegateName.isEmpty()) "return super.addPlugin(plugin);"
+            else """
+            |    final Removable removable = super.addPlugin(plugin);
+            |    final Removable superRemovable = m$superClassDelegateName.addPlugin(plugin);
+            |    return new Removable() {
+            |        @Override
+            |        public void remove() {
+            |            removable.remove();
+            |            superRemovable.remove();
+            |        }
+            |    };
+            """.replaceIndentByMargin()
+
 
     var activityDelegate = """
         |package com.pascalwelsch.compositeandroid.$javaPackage;
         |
         |import com.pascalwelsch.compositeandroid.core.*;
+        |import java.util.ArrayList;
+        |import java.util.List;
+        |import java.util.ListIterator;
+        |import java.util.HashMap;
+        |import android.support.annotation.VisibleForTesting;
         |
         |${javaFile.imports}
         |
         |${additionalImports ?: ""}
         |
         |public class $javaClassName extends $extends {
+        |
+        |    @VisibleForTesting
+        |    static final int CALL_COUNT_OPTIMIZATION_THRESHOLD = 100;
+        |
+        |    private final HashMap<String, List<$pluginName>> mMethodImplementingPlugins
+            = new HashMap<>();
         |
         |    ${superDelegateDeclaration()}
         |
@@ -111,9 +136,27 @@ fun writeDelegate(outPath: String,
         |    }
         |
         |${addSuperDelegatePlugin().prependIndent()}
-        |${addPlugin().prependIndent()}
+        |
+        |    @Override
+        |    public Removable addPlugin(final $pluginName plugin) {
+        |${resetOptimizations()}
+        |${addPluginSuper().prependIndent()}
+        |    }
         |
         |${methodsSb.toString()}
+        |
+        |    private List<$pluginName> getImplementingPlugins(final String methodName, final Class<?>... parameterTypes) {
+        |        synchronized (mPlugins) {
+        |            final ArrayList<$pluginName> implementingPlugins = new ArrayList<>();
+        |            for (int i = 0; i < mPlugins.size(); i++) {
+        |                final $pluginName plugin = mPlugins.get(i);
+        |                if (plugin.isMethodOverridden(methodName, parameterTypes)) {
+        |                    implementingPlugins.add(plugin);
+        |                }
+        |            }
+        |            return implementingPlugins;
+        |        }
+        |    }
         |
         |${addCodeToClass ?: ""}
         |
@@ -126,9 +169,12 @@ fun writeDelegate(outPath: String,
 
     val out = File("$outPath${javaPackage.replace('.', '/')}/$javaClassName.java")
     out.parentFile.mkdirs()
-    out.printWriter().use { it.write(activityDelegate) }
+    out.printWriter().use {
+        it.write(activityDelegate)
+    }
     System.out.println("wrote ${out.absolutePath}")
 }
+
 
 fun AnalyzedJavaMethod.forwardToDelegate(delegateName: String): String {
     return """
@@ -148,53 +194,6 @@ fun AnalyzedJavaMethod.forwardToDelegateWithReturn(delegateName: String): String
     """.replaceIndentByMargin("    ")
 }
 
-
-/*fun AnalyzedJavaMethod.hook(originalGetterName: String = "getOriginal()",
-                            pluginType: String = "Plugin"): String {
-
-
-    val typedArgs = parameterTypes.mapIndexed { i, type -> "($type) args[$i]" }
-
-    val varargs = if (parameterTypes.size == 1
-            && parameterTypes[0].contains("[]")) {
-        "new Object[]{${parameterNames[0]}}"
-    } else parameterNames.joinToString()
-
-
-    val sb = StringBuilder()
-    sb.appendln("    public void $name($rawParameters) $exceptions {")
-    sb.appendln(
-            "        callHook(\"$name(${parameterTypes.joinToString()})\", new PluginCallVoid<$pluginType>() {")
-    sb.appendln("            @Override")
-    sb.appendln(
-            "            public void call(final NamedSuperCall<Void> superCall, final $pluginType plugin, final Object... args) {")
-    if (throws) sb.appendln("                try {")
-    sb.appendln("                plugin.$name(${listOf("superCall").plus(
-            typedArgs).joinToString()});")
-    if (throws) {
-        sb.appendln("            } catch ($exceptionType e) {")
-        sb.appendln("                throw new SuppressedException(e);")
-        sb.appendln("            }")
-    }
-    sb.appendln("            }")
-    sb.appendln("        }, new SuperCallVoid() {")
-    sb.appendln("            @Override")
-    sb.appendln("            public void call(final Object... args) {")
-    if (throws) sb.appendln("                try {")
-    sb.appendln("                $originalGetterName.super_$name(${typedArgs.joinToString()});")
-    if (throws) {
-        sb.appendln("            } catch ($exceptionType e) {")
-        sb.appendln("                throw new SuppressedException(e);")
-        sb.appendln("            }")
-    }
-    sb.appendln("            }")
-    sb.appendln(
-            "        }${if (parameterNames.size > 0) ", " else ""}$varargs);")
-    sb.appendln("    }")
-
-    return sb.toString();
-}*/
-
 fun AnalyzedJavaMethod.hook(pluginType: String = "Plugin"): String {
 
     val varargs = if (parameterNames.size == 1 && parameterNames[0].contains("[]")) {
@@ -204,14 +203,33 @@ fun AnalyzedJavaMethod.hook(pluginType: String = "Plugin"): String {
     val genericTypeCallType = if (parameterTypes.size == 0) "" else "<${parameterTypes.joinToString()}>"
 
     return """
+    |
+    |private int mCallCount_$uniqueName = 0;
+    |
+    |private boolean mIsOverridden_$uniqueName = false;
+    |
     |public void $name($rawParameters) $exceptions {
-    |    if (mPlugins.isEmpty()) {
-    |${"getOriginal().super_$name($varargs);"
-            .wrapWithTryCatch(exceptionType).prependIndent("            ")}
+    |    if (!mIsOverridden_$uniqueName) {
+    |        getOriginal().super_$name($varargs);
     |        return;
     |    }
     |
-    |    final ListIterator<$pluginType> iterator = mPlugins.listIterator(mPlugins.size());
+    |    final ListIterator<$pluginType> iterator;
+    |    if (mCallCount_$uniqueName < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+    |        mCallCount_$uniqueName++;
+    |        iterator = mPlugins.listIterator(mPlugins.size());
+    |    } else {
+    |        List<$pluginType> implementingPlugins = mMethodImplementingPlugins.get("$identifier");
+    |        if (implementingPlugins == null) {
+    |            implementingPlugins = getImplementingPlugins("$name"${if (parameterTypes.isEmpty()) "" else ", "}${parameterTypes.map {
+        it.removeSuffix("<?>")
+    }.map { "$it.class" }.joinToString()});
+    |            mMethodImplementingPlugins.put("$identifier", implementingPlugins);
+    |            mIsOverridden_$uniqueName = implementingPlugins.size() > 0;
+    |        }
+    |
+    |        iterator = implementingPlugins.listIterator(implementingPlugins.size());
+    |    }
     |
     |    final CallVoid${parameterNames.size}$genericTypeCallType superCall = new CallVoid${parameterNames.size}$genericTypeCallType("$name(${parameterTypes.joinToString()})") {
     |
@@ -232,7 +250,6 @@ fun AnalyzedJavaMethod.hook(pluginType: String = "Plugin"): String {
 }
 
 fun AnalyzedJavaMethod.callFunction(pluginType: String = "Plugin"): String {
-    val typedArgs = parameterTypes.mapIndexed { i, type -> "($type) args[$i]" }
 
     val varargs = if (parameterNames.size == 1 && parameterNames[0].contains("[]")) {
         "new Object[]{${parameterNames[0]}}"
@@ -245,15 +262,34 @@ fun AnalyzedJavaMethod.callFunction(pluginType: String = "Plugin"): String {
     val genericTypeCallType = "<${genericTypes.joinToString()}>"
 
     return """
+    |
+    |private int mCallCount_$uniqueName = 0;
+    |
+    |private boolean mIsOverridden_$uniqueName = false;
+    |
     |public $returnType $name($rawParameters) $exceptions {
-    |    if (mPlugins.isEmpty()) {
-    |${"return getOriginal().super_$name($varargs);"
-            .wrapWithTryCatch(exceptionType).prependIndent("            ")}
+    |    if (!mIsOverridden_$uniqueName) {
+    |        return getOriginal().super_$name($varargs);
     |    }
     |
-    |    final ListIterator<$pluginType> iterator = mPlugins.listIterator(mPlugins.size());
+    |    final ListIterator<$pluginType> iterator;
+    |    if (mCallCount_$uniqueName < CALL_COUNT_OPTIMIZATION_THRESHOLD) {
+    |        mCallCount_$uniqueName++;
+    |        iterator = mPlugins.listIterator(mPlugins.size());
+    |    } else {
+    |        List<$pluginType> implementingPlugins = mMethodImplementingPlugins.get("$identifier");
+    |        if (implementingPlugins == null) {
+    |            implementingPlugins = getImplementingPlugins("$name"${if (parameterTypes.isEmpty()) "" else ", "}${parameterTypes.map {
+        it.removeSuffix("<?>")
+    }.map { "$it.class" }.joinToString()});
+    |            mMethodImplementingPlugins.put("$identifier", implementingPlugins);
+    |            mIsOverridden_$uniqueName = implementingPlugins.size() > 0;
+    |        }
     |
-    |    final CallFun${parameterNames.size}$genericTypeCallType superCall = new CallFun${parameterNames.size}$genericTypeCallType("$name(${parameterTypes.joinToString()})") {
+    |        iterator = implementingPlugins.listIterator(implementingPlugins.size());
+    |    }
+    |
+    |    final CallFun${parameterNames.size}$genericTypeCallType superCall = new CallFun${parameterNames.size}$genericTypeCallType("$identifier") {
     |
     |        @Override
     |        public $boxedReturnType call(${rawParametersBoxed.joinToString()}) {

--- a/generator/src/main/kotlin/writer/PluginWriter.kt
+++ b/generator/src/main/kotlin/writer/PluginWriter.kt
@@ -52,12 +52,10 @@ fun writePlugin(outPath: String,
         |            try {
         |                final Class<? extends $javaClassName> myClass = this.getClass();
         |                final Method method = myClass.getMethod(methodName, parameterTypes);
-        |                if (method.getDeclaringClass() == $javaClassName.class) {
-        |                    return false;
-        |                }
+        |                return method.getDeclaringClass() != $javaClassName.class;
         |            } catch (NoSuchMethodException ignore) {
+        |                return false;
         |            }
-        |            return true;
         |        }
         |
         |

--- a/generator/src/main/kotlin/writer/PluginWriter.kt
+++ b/generator/src/main/kotlin/writer/PluginWriter.kt
@@ -36,6 +36,7 @@ fun writePlugin(outPath: String,
         |package com.pascalwelsch.compositeandroid.$javaPackage;
         |
         |import com.pascalwelsch.compositeandroid.core.*;
+        |import java.lang.reflect.Method;
         |
         |${javaFile.imports}
         |
@@ -46,6 +47,19 @@ fun writePlugin(outPath: String,
         |$methods
         |
         |$niceGetter
+        |
+        |        boolean isMethodOverridden(final String methodName, final Class<?>... parameterTypes) {
+        |            try {
+        |                final Class<? extends $javaClassName> myClass = this.getClass();
+        |                final Method method = myClass.getMethod(methodName, parameterTypes);
+        |                if (method.getDeclaringClass() == $javaClassName.class) {
+        |                    return false;
+        |                }
+        |            } catch (NoSuchMethodException ignore) {
+        |            }
+        |            return true;
+        |        }
+        |
         |
         |${addCodeToClass ?: ""}
         |}


### PR DESCRIPTION
Part II of #23 

Use reflection to check for overridden methods. Don't call plugins which did not override a method.

Since reflection is very heavy it will be only used after a fixed amount of calls.

_Performance measurements will follow_

Increases the performance of `getApplicationInfo()` and `getResources()` drastically when not overridden which get called multiple thousand times per Activity Lifecycle.
